### PR TITLE
Add internal reflect package

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -11,5 +11,8 @@
 # Output of the go coverage tool, specifically when used with LiteIDE
 *.out
 
+# GoLand
+.idea/
+
 # Dependency directories (remove the comment below to include it)
 # vendor/

--- a/go.mod
+++ b/go.mod
@@ -1,0 +1,14 @@
+module github.com/canonical/sqlair
+
+go 1.19
+
+require (
+	github.com/pkg/errors v0.9.1
+	github.com/stretchr/testify v1.8.0
+)
+
+require (
+	github.com/davecgh/go-spew v1.1.1 // indirect
+	github.com/pmezard/go-difflib v1.0.0 // indirect
+	gopkg.in/yaml.v3 v3.0.1 // indirect
+)

--- a/go.sum
+++ b/go.sum
@@ -1,0 +1,17 @@
+github.com/davecgh/go-spew v1.1.0/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
+github.com/davecgh/go-spew v1.1.1 h1:vj9j/u1bqnvCEfJOwUhtlOARqs3+rkHYY13jYWTU97c=
+github.com/davecgh/go-spew v1.1.1/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
+github.com/pkg/errors v0.9.1 h1:FEBLx1zS214owpjy7qsBeixbURkuhQAwrK5UwLGTwt4=
+github.com/pkg/errors v0.9.1/go.mod h1:bwawxfHBFNV+L2hUp1rHADufV3IMtnDRdf1r5NINEl0=
+github.com/pmezard/go-difflib v1.0.0 h1:4DBwDE0NGyQoBHbLQYPwSUPoCMWR5BEzIk/f1lZbAQM=
+github.com/pmezard/go-difflib v1.0.0/go.mod h1:iKH77koFhYxTK1pcRnkKkqfTogsbg7gZNVY4sRDYZ/4=
+github.com/stretchr/objx v0.1.0/go.mod h1:HFkY916IF+rwdDfMAkV7OtwuqBVzrE8GR6GFx+wExME=
+github.com/stretchr/objx v0.4.0/go.mod h1:YvHI0jy2hoMjB+UWwv71VJQ9isScKT/TqJzVSSt89Yw=
+github.com/stretchr/testify v1.7.1/go.mod h1:6Fq8oRcR53rry900zMqJjRRixrwX3KX962/h/Wwjteg=
+github.com/stretchr/testify v1.8.0 h1:pSgiaMZlXftHpm5L7V1+rVB+AZJydKsMxsQBIJw4PKk=
+github.com/stretchr/testify v1.8.0/go.mod h1:yNjHg4UonilssWZ8iaSj1OCr/vHnekPRkoO+kdMU+MU=
+gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405 h1:yhCVgyC4o1eVCa2tZl7eS0r+SDo693bJlVdllGtEeKM=
+gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405/go.mod h1:Co6ibVJAznAaIkqp8huTwlJQCZ016jof/cbN4VW5Yz0=
+gopkg.in/yaml.v3 v3.0.0-20200313102051-9f266ea9e77c/go.mod h1:K4uyk7z7BCEPqu6E+C64Yfv1cQ7kz7rIZviUmN+EgEM=
+gopkg.in/yaml.v3 v3.0.1 h1:fxVm/GzAzEWqLHuvctI91KS9hhNmmWOoWu0XTYJS7CA=
+gopkg.in/yaml.v3 v3.0.1/go.mod h1:K4uyk7z7BCEPqu6E+C64Yfv1cQ7kz7rIZviUmN+EgEM=

--- a/internal/reflect/cache.go
+++ b/internal/reflect/cache.go
@@ -1,0 +1,95 @@
+package reflect
+
+import (
+	"reflect"
+	"strings"
+	"sync"
+
+	"github.com/pkg/errors"
+)
+
+// Cache is responsible for generating, caching and retrieving reflection
+// information for use in parsing and executing Sqlair DSL statements.
+type cache struct {
+	mutex sync.RWMutex
+	cache map[reflect.Type]Info
+}
+
+// Reflect will return the Info of a given type,
+// generating and caching as required.
+func (r *cache) Reflect(value any) (Info, error) {
+	v := reflect.ValueOf(value)
+	v = reflect.Indirect(v)
+
+	r.mutex.Lock()
+	defer r.mutex.Unlock()
+
+	if rs, ok := r.cache[v.Type()]; ok {
+		return rs, nil
+	}
+
+	ri, err := generate(v)
+	if err != nil {
+		return Struct{}, err
+	}
+	r.cache[v.Type()] = ri
+	return ri, nil
+}
+
+// generate produces and returns reflection information for the input
+// reflect.Value that is specifically required for Sqlair operation.
+func generate(value reflect.Value) (Info, error) {
+	// Dereference the pointer if it is one.
+	value = reflect.Indirect(value)
+
+	// If this is a not a struct, we can not provide
+	// any further reflection information.
+	if value.Kind() != reflect.Struct {
+		return Value{value: value}, nil
+	}
+
+	info := Struct{
+		Fields: make(map[string]Field),
+		value:  value,
+	}
+
+	typ := value.Type()
+	for i := 0; i < typ.NumField(); i++ {
+		field := typ.Field(i)
+
+		// Fields without a "db" tag are outside of Sqlair's remit.
+		tag := field.Tag.Get("db")
+		if tag == "" {
+			continue
+		}
+
+		tag, omitEmpty, err := parseTag(tag)
+		if err != nil {
+			return Value{}, err
+		}
+
+		info.Fields[tag] = Field{
+			Name:      field.Name,
+			OmitEmpty: omitEmpty,
+			value:     value.Field(i),
+		}
+	}
+
+	return info, nil
+}
+
+// parseTag parses the input tag string and returns its
+// name and whether it contains the "omitempty" option.
+func parseTag(tag string) (string, bool, error) {
+	options := strings.Split(tag, ",")
+
+	var omitEmpty bool
+	if len(options) > 1 {
+		if strings.ToLower(options[1]) != "omitempty" {
+			return "", false, errors.Errorf("unexpected tag value %q", options[1])
+		}
+		omitEmpty = true
+	}
+
+	return options[0], omitEmpty, nil
+}

--- a/internal/reflect/cache_test.go
+++ b/internal/reflect/cache_test.go
@@ -1,0 +1,82 @@
+package reflect
+
+import (
+	"reflect"
+	"sync"
+	"testing"
+
+	"github.com/pkg/errors"
+	"github.com/stretchr/testify/assert"
+)
+
+func TestReflectSimpleConcurrent(t *testing.T) {
+	var num int64
+
+	wg := sync.WaitGroup{}
+
+	// Set up some concurrent access.
+	for i := 0; i < 5; i++ {
+		wg.Add(1)
+		go func() {
+			_, _ = Cache().Reflect(num)
+			wg.Done()
+		}()
+	}
+
+	info, err := Cache().Reflect(num)
+	assert.Nil(t, err)
+
+	assert.Equal(t, reflect.Int64, info.Kind())
+	assert.Equal(t, "int64", info.Name())
+
+	_, ok := info.(Value)
+	assert.True(t, ok)
+
+	wg.Wait()
+}
+
+func TestReflectStruct(t *testing.T) {
+	type something struct {
+		ID      int64  `db:"id"`
+		Name    string `db:"name,omitempty"`
+		NotInDB string
+	}
+
+	s := something{
+		ID:      99,
+		Name:    "Chainheart Machine",
+		NotInDB: "doesn't matter",
+	}
+
+	info, err := Cache().Reflect(s)
+	assert.Nil(t, err)
+
+	assert.Equal(t, reflect.Struct, info.Kind())
+	assert.Equal(t, "something", info.Name())
+
+	st, ok := info.(Struct)
+	assert.True(t, ok)
+
+	assert.Len(t, st.Fields, 2)
+
+	id, ok := st.Fields["id"]
+	assert.True(t, ok)
+	assert.Equal(t, "ID", id.Name)
+	assert.False(t, id.OmitEmpty)
+
+	name, ok := st.Fields["name"]
+	assert.True(t, ok)
+	assert.Equal(t, "Name", name.Name)
+	assert.True(t, name.OmitEmpty)
+}
+
+func TestReflectBadTagError(t *testing.T) {
+	type something struct {
+		ID int64 `db:"id,bad-juju"`
+	}
+
+	s := something{ID: 99}
+
+	_, err := Cache().Reflect(s)
+	assert.Error(t, errors.New(`unexpected tag value "bad-juju"`), err)
+}

--- a/internal/reflect/info.go
+++ b/internal/reflect/info.go
@@ -1,0 +1,58 @@
+package reflect
+
+import (
+	"reflect"
+)
+
+// Info describes the ability to return reflection information.
+type Info interface {
+	Name() string
+	Kind() reflect.Kind
+}
+
+// Value represents reflection information for a simple type.
+// It wraps a reflect.Value in order to implement Info.
+type Value struct {
+	value reflect.Value
+}
+
+// Kind returns the Value's reflect.Kind.
+func (r Value) Kind() reflect.Kind {
+	return r.value.Kind()
+}
+
+// Name returns the name of the Value's type.
+func (r Value) Name() string {
+	return r.value.Type().Name()
+}
+
+// Field represents a single field from a struct type.
+type Field struct {
+	value reflect.Value
+
+	// Name is the name of the struct field.
+	Name string
+
+	// OmitEmpty is true when "omitempty" is
+	// a property of the field's "db" tag.
+	OmitEmpty bool
+}
+
+// Struct represents reflected information about a struct type.
+type Struct struct {
+	value reflect.Value
+
+	// Fields maps "db" tags to struct fields.
+	// Sqlair does not care about fields without a "db" tag.
+	Fields map[string]Field
+}
+
+// Kind returns the Struct's reflect.Kind.
+func (r Struct) Kind() reflect.Kind {
+	return r.value.Kind()
+}
+
+// Name returns the name of the Struct's type.
+func (r Struct) Name() string {
+	return r.value.Type().Name()
+}

--- a/internal/reflect/singleton.go
+++ b/internal/reflect/singleton.go
@@ -1,0 +1,23 @@
+package reflect
+
+import (
+	"reflect"
+	"sync"
+)
+
+var (
+	singleCache *cache
+	once        sync.Once
+)
+
+// Cache enforces the singleton pattern,
+// ensuring access to a single instance of cache.
+func Cache() *cache {
+	once.Do(func() {
+		singleCache = &cache{
+			cache: make(map[reflect.Type]Info),
+		}
+	})
+
+	return singleCache
+}


### PR DESCRIPTION
This adds the `internal/reflect` package from the [prototype repository](https://github.com/canonical/sqlair-prototype).

It is the mechanism by which we generate and cache reflection information for statement output targets and input parameters.