### PR TITLE
Add parts types.

### DIFF
--- a/internal/parse/parser.go
+++ b/internal/parse/parser.go
@@ -2,16 +2,6 @@ package parse
 
 import "strings"
 
-// QueryPart defines a simple interface for all the different parts that
-// compose a ParsedExpr.
-type QueryPart interface {
-	// String returns the original string comprising this query part.
-	String() string
-
-	// ToSQL returns the executable SQL resulting from this query part.
-	ToSQL() (string, error)
-}
-
 // Parser is used to parse the SQLAir DSL.
 type Parser struct {
 	// input is the DSL statement to be parted.
@@ -51,7 +41,7 @@ func (p *Parser) Parse(input string) (*ParsedExpr, error) {
 //
 // [stringPart outputPart stringPart inputPart]
 type ParsedExpr struct {
-	queryParts []QueryPart
+	queryParts []queryPart
 }
 
 // peekByte returns true if the current byte

--- a/internal/parse/parts.go
+++ b/internal/parse/parts.go
@@ -16,7 +16,7 @@ type FullName struct {
 	Prefix, Name string
 }
 
-// InputPart represents a named parameter that will be send to the database
+// InputPart represents a named parameter that will be sent to the database
 // while performing the query.
 type InputPart struct {
 	FullName

--- a/internal/parse/parts.go
+++ b/internal/parse/parts.go
@@ -30,7 +30,8 @@ func (p *InputPart) ToSQL() string {
 	return ""
 }
 
-// OutputPart represents an expression to be used as output in our SDL.
+// OutputPart represents a named target output variable in the SQL expression,
+// as well as the source table and column where it will be read from.
 type OutputPart struct {
 	Source FullName
 	Target FullName
@@ -44,7 +45,7 @@ func (p *OutputPart) ToSQL() string {
 	return ""
 }
 
-// BypassPart represents a part of the SDL that we want to pass to the
+// BypassPart represents a part of the expression that we want to pass to the
 // backend database verbatim.
 type BypassPart struct {
 	Chunk string

--- a/internal/parse/parts.go
+++ b/internal/parse/parts.go
@@ -19,7 +19,7 @@ type FullName struct {
 // InputPart represents a named parameter that will be sent to the database
 // while performing the query.
 type InputPart struct {
-	FullName
+	Source FullName
 }
 
 // String returns a textual representation of the InputPart meant for debugging

--- a/internal/parse/parts.go
+++ b/internal/parse/parts.go
@@ -21,16 +21,6 @@ type InputPart struct {
 	FullName
 }
 
-// NewInputPart is a constructor that returns a pointer to an InputPart.
-func NewInputPart(typeName string, tagName string) (*InputPart, error) {
-	return &InputPart{
-		FullName{
-			Prefix: typeName,
-			Name:   tagName,
-		},
-	}, nil
-}
-
 func (p *InputPart) String() string {
 	return ""
 }
@@ -43,19 +33,6 @@ func (p *InputPart) ToSQL() string {
 type OutputPart struct {
 	Source FullName
 	Target FullName
-}
-
-// NewOutputPart is a constructor that returns a pointer to an OutputPart.
-func NewOutputPart(tableName string, colName string,
-	typeName string, tagName string) (*OutputPart, error) {
-	return &OutputPart{
-		FullName{Prefix: tableName,
-			Name: colName,
-		},
-		FullName{Prefix: typeName,
-			Name: tagName,
-		},
-	}, nil
 }
 
 func (p *OutputPart) String() string {

--- a/internal/parse/parts.go
+++ b/internal/parse/parts.go
@@ -26,7 +26,6 @@ func (p *InputPart) String() string {
 	return ""
 }
 
-// ToSQL returns a string with the SQL translation for the InputPart.
 func (p *InputPart) ToSQL() string {
 	return ""
 }
@@ -41,7 +40,6 @@ func (p *OutputPart) String() string {
 	return ""
 }
 
-// ToSQL returns a string with the SQL translation for the OutputPart.
 func (p *OutputPart) ToSQL() string {
 	return ""
 }
@@ -56,7 +54,6 @@ func (p *BypassPart) String() string {
 	return ""
 }
 
-// ToSQL returns a string with the SQL translation for the BypassPart.
 func (p *BypassPart) ToSQL() string {
 	return ""
 }

--- a/internal/parse/parts.go
+++ b/internal/parse/parts.go
@@ -1,155 +1,81 @@
 package parse
 
-import "fmt"
-
-// queryPart is an interface to be implemented by all parts.
+// A queryPart represents a section of a parsed SQL statement, which forms
+// a complete query when processed together with its surrounding parts, in
+// their correct order.
 type queryPart interface {
-	// String-like output for debugging purposes
+	// String returns the part's representation for debugging purposes.
 	String() string
 
-	// Translate part to its Sql equivalent
-	ToSql() string
+	// ToSQL returns the SQL representation of the part.
+	ToSQL() string
 }
 
-// qualifiedExpression represents a qualified expression
-// qualified. Examples are:
-//	... column as &Person ... 	<--- "column" is unqualified
-//	... t.column as &Person.name	<--- "name" and "column" and qualified
-type qualifiedExpression struct {
-	qualifier string
-	name      string
+type FullName struct {
+	Prefix, Name string
 }
 
-// InputPart represents an expression used as input in the SDL query.
-// Examples:
-//	$Address
-//	$Address.postal_code
+// InputPart represents a named parameter that will be send to the database
+// while performing the query.
 type InputPart struct {
-	goType
+	FullName
 }
 
 // NewInputPart is a constructor that returns a pointer to an InputPart.
 func NewInputPart(typeName string, tagName string) (*InputPart, error) {
-	if typeName == "" && tagName != "" {
-		return nil, fmt.Errorf("malformed InputPart")
-	}
 	return &InputPart{
-		goType{
-			qualifiedExpression{qualifier: typeName,
-				name: tagName,
-			},
+		FullName{
+			Prefix: typeName,
+			Name:   tagName,
 		},
 	}, nil
 }
 
-func (ip *InputPart) String() string {
+func (p *InputPart) String() string {
 	return ""
 }
 
-func (ip *InputPart) ToSql() string {
+func (p *InputPart) ToSQL() string {
 	return ""
-}
-
-// TypeName returns the name of the type in the input part or empty string if
-// none is present.
-func (ip *InputPart) TypeName() string {
-	return ip.qualifier
-}
-
-// TagName returns the name of the tag in the input part or empty string if
-// none is present.
-func (ip *InputPart) TagName() string {
-	return ip.name
-}
-
-// A column is an internal type that represents the columns selected in the
-// query.
-type column struct {
-	qualifiedExpression
-}
-
-// TableName returns the name of the table that qualifies a column or empty
-// string if there is none. Examples:
-//
-// select t.column	<--- TableName() returns "t"
-// select column	<--- TableName() returns ""
-func (c *column) TableName() string {
-	return c.qualifier
-}
-
-// ColumnName returns the name of the column that is selected in a query or an
-// empty string if there is none. Examples:
-//
-// select t.column	<--- TableName() returns "column"
-func (c *column) ColumnName() string {
-	return c.name
-}
-
-// A goType is an internal type that represents the type part of an output
-// expression in our SDL
-type goType struct {
-	qualifiedExpression
-}
-
-// TypeName returns the name of the type in the output part or empty string if
-// none is present.
-func (gt *goType) TypeName() string {
-	return gt.qualifier
-}
-
-// TagName returns the name of the type in the output part or empty string if
-// none is present.
-func (gt *goType) TagName() string {
-	return gt.name
 }
 
 // OutputPart represents an expression to be used as output in our SDL.
-// Examples:
-// 	&Person
-//	&Person.name
 type OutputPart struct {
-	Column column
-	GoType goType
+	Source FullName
+	Target FullName
 }
 
 // NewOutputPart is a constructor that returns a pointer to an OutputPart.
 func NewOutputPart(tableName string, colName string,
 	typeName string, tagName string) (*OutputPart, error) {
-	if (tableName != "" && colName == "") || (typeName == "" && tagName != "") {
-		return nil, fmt.Errorf("malformed OutputPart")
-	}
 	return &OutputPart{
-		column{
-			qualifiedExpression{qualifier: tableName,
-				name: colName,
-			},
+		FullName{Prefix: tableName,
+			Name: colName,
 		},
-		goType{
-			qualifiedExpression{qualifier: typeName,
-				name: tagName,
-			},
+		FullName{Prefix: typeName,
+			Name: tagName,
 		},
 	}, nil
 }
 
-func (op *OutputPart) String() string {
+func (p *OutputPart) String() string {
 	return ""
 }
 
-func (op *OutputPart) ToSql() string {
+func (p *OutputPart) ToSQL() string {
 	return ""
 }
 
-// passthroughPart represents a part of the SDL that we want to pass to the
+// BypassPart represents a part of the SDL that we want to pass to the
 // backend database verbatim.
-type PassthroughPart struct {
+type BypassPart struct {
 	Chunk string
 }
 
-func (pt *PassthroughPart) String() string {
+func (p *BypassPart) String() string {
 	return ""
 }
 
-func (pt *PassthroughPart) ToSql() string {
+func (p *BypassPart) ToSQL() string {
 	return ""
 }

--- a/internal/parse/parts.go
+++ b/internal/parse/parts.go
@@ -22,8 +22,6 @@ type InputPart struct {
 	Source FullName
 }
 
-// String returns a textual representation of the InputPart meant for debugging
-// purposes.
 func (p *InputPart) String() string {
 	return ""
 }
@@ -39,8 +37,6 @@ type OutputPart struct {
 	Target FullName
 }
 
-// String returns a textual representation of the OutputPart meant for debugging
-// purposes.
 func (p *OutputPart) String() string {
 	return ""
 }
@@ -56,8 +52,6 @@ type BypassPart struct {
 	Chunk string
 }
 
-// String returns a textual representation of the BypassPart meant for debugging
-// purposes.
 func (p *BypassPart) String() string {
 	return ""
 }

--- a/internal/parse/parts.go
+++ b/internal/parse/parts.go
@@ -11,6 +11,7 @@ type queryPart interface {
 	ToSQL() string
 }
 
+// FullName represents a table column or a Go type identifier.
 type FullName struct {
 	Prefix, Name string
 }
@@ -21,10 +22,13 @@ type InputPart struct {
 	FullName
 }
 
+// String returns a textual representation of the InputPart meant for debugging
+// purposes.
 func (p *InputPart) String() string {
 	return ""
 }
 
+// ToSQL returns a string with the SQL translation for the InputPart.
 func (p *InputPart) ToSQL() string {
 	return ""
 }
@@ -35,10 +39,13 @@ type OutputPart struct {
 	Target FullName
 }
 
+// String returns a textual representation of the OutputPart meant for debugging
+// purposes.
 func (p *OutputPart) String() string {
 	return ""
 }
 
+// ToSQL returns a string with the SQL translation for the OutputPart.
 func (p *OutputPart) ToSQL() string {
 	return ""
 }
@@ -49,10 +56,13 @@ type BypassPart struct {
 	Chunk string
 }
 
+// String returns a textual representation of the BypassPart meant for debugging
+// purposes.
 func (p *BypassPart) String() string {
 	return ""
 }
 
+// ToSQL returns a string with the SQL translation for the BypassPart.
 func (p *BypassPart) ToSQL() string {
 	return ""
 }

--- a/internal/parse/parts.go
+++ b/internal/parse/parts.go
@@ -1,0 +1,155 @@
+package parse
+
+import "fmt"
+
+// queryPart is an interface to be implemented by all parts.
+type queryPart interface {
+	// String-like output for debugging purposes
+	String() string
+
+	// Translate part to its Sql equivalent
+	ToSql() string
+}
+
+// qualifiedExpression represents a qualified expression
+// qualified. Examples are:
+//	... column as &Person ... 	<--- "column" is unqualified
+//	... t.column as &Person.name	<--- "name" and "column" and qualified
+type qualifiedExpression struct {
+	qualifier string
+	name      string
+}
+
+// InputPart represents an expression used as input in the SDL query.
+// Examples:
+//	$Address
+//	$Address.postal_code
+type InputPart struct {
+	goType
+}
+
+// NewInputPart is a constructor that returns a pointer to an InputPart.
+func NewInputPart(typeName string, tagName string) (*InputPart, error) {
+	if typeName == "" && tagName != "" {
+		return nil, fmt.Errorf("malformed InputPart")
+	}
+	return &InputPart{
+		goType{
+			qualifiedExpression{qualifier: typeName,
+				name: tagName,
+			},
+		},
+	}, nil
+}
+
+func (ip *InputPart) String() string {
+	return ""
+}
+
+func (ip *InputPart) ToSql() string {
+	return ""
+}
+
+// TypeName returns the name of the type in the input part or empty string if
+// none is present.
+func (ip *InputPart) TypeName() string {
+	return ip.qualifier
+}
+
+// TagName returns the name of the tag in the input part or empty string if
+// none is present.
+func (ip *InputPart) TagName() string {
+	return ip.name
+}
+
+// A column is an internal type that represents the columns selected in the
+// query.
+type column struct {
+	qualifiedExpression
+}
+
+// TableName returns the name of the table that qualifies a column or empty
+// string if there is none. Examples:
+//
+// select t.column	<--- TableName() returns "t"
+// select column	<--- TableName() returns ""
+func (c *column) TableName() string {
+	return c.qualifier
+}
+
+// ColumnName returns the name of the column that is selected in a query or an
+// empty string if there is none. Examples:
+//
+// select t.column	<--- TableName() returns "column"
+func (c *column) ColumnName() string {
+	return c.name
+}
+
+// A goType is an internal type that represents the type part of an output
+// expression in our SDL
+type goType struct {
+	qualifiedExpression
+}
+
+// TypeName returns the name of the type in the output part or empty string if
+// none is present.
+func (gt *goType) TypeName() string {
+	return gt.qualifier
+}
+
+// TagName returns the name of the type in the output part or empty string if
+// none is present.
+func (gt *goType) TagName() string {
+	return gt.name
+}
+
+// OutputPart represents an expression to be used as output in our SDL.
+// Examples:
+// 	&Person
+//	&Person.name
+type OutputPart struct {
+	Column column
+	GoType goType
+}
+
+// NewOutputPart is a constructor that returns a pointer to an OutputPart.
+func NewOutputPart(tableName string, colName string,
+	typeName string, tagName string) (*OutputPart, error) {
+	if (tableName != "" && colName == "") || (typeName == "" && tagName != "") {
+		return nil, fmt.Errorf("malformed OutputPart")
+	}
+	return &OutputPart{
+		column{
+			qualifiedExpression{qualifier: tableName,
+				name: colName,
+			},
+		},
+		goType{
+			qualifiedExpression{qualifier: typeName,
+				name: tagName,
+			},
+		},
+	}, nil
+}
+
+func (op *OutputPart) String() string {
+	return ""
+}
+
+func (op *OutputPart) ToSql() string {
+	return ""
+}
+
+// passthroughPart represents a part of the SDL that we want to pass to the
+// backend database verbatim.
+type PassthroughPart struct {
+	Chunk string
+}
+
+func (pt *PassthroughPart) String() string {
+	return ""
+}
+
+func (pt *PassthroughPart) ToSql() string {
+	return ""
+}

--- a/internal/parse/parts_test.go
+++ b/internal/parse/parts_test.go
@@ -7,8 +7,12 @@ import (
 )
 
 func TestInputPart(t *testing.T) {
-	i, err := NewInputPart("mytype", "mytag")
-	assert.Equal(t, nil, err)
+	i := InputPart{
+		FullName{
+			Prefix: "mytype",
+			Name:   "mytag",
+		},
+	}
 	assert.NotEqual(t, nil, i)
 	assert.Equal(t, "mytype", i.Prefix)
 	assert.Equal(t, "mytag", i.Name)
@@ -16,27 +20,18 @@ func TestInputPart(t *testing.T) {
 
 func TestOutputPart(t *testing.T) {
 	// Fully specified part
-	p, err := NewOutputPart("mytable", "mycolumn", "mytype", "mytag")
-	assert.Equal(t, nil, err)
+	p := OutputPart{FullName{
+		Prefix: "mytable",
+		Name:   "mycolumn",
+	},
+		FullName{
+			Prefix: "mytype",
+			Name:   "mytag",
+		},
+	}
 	assert.NotEqual(t, nil, p)
 	assert.Equal(t, "mytable", p.Source.Prefix)
 	assert.Equal(t, "mycolumn", p.Source.Name)
 	assert.Equal(t, "mytype", p.Target.Prefix)
 	assert.Equal(t, "mytag", p.Target.Name)
-	// Having column name without table is OK
-	p, err = NewOutputPart("", "mycolumn", "mytype", "mytag")
-	assert.Equal(t, nil, err)
-	assert.NotEqual(t, nil, p)
-	assert.Equal(t, "", p.Source.Prefix)
-	assert.Equal(t, "mycolumn", p.Source.Name)
-	assert.Equal(t, "mytype", p.Target.Prefix)
-	assert.Equal(t, "mytag", p.Target.Name)
-	// Having type name without tag name is OK
-	p, err = NewOutputPart("mytable", "mycolumn", "mytype", "")
-	assert.Equal(t, nil, err)
-	assert.NotEqual(t, nil, p)
-	assert.Equal(t, "mytable", p.Source.Prefix)
-	assert.Equal(t, "mycolumn", p.Source.Name)
-	assert.Equal(t, "mytype", p.Target.Prefix)
-	assert.Equal(t, "", p.Target.Name)
 }

--- a/internal/parse/parts_test.go
+++ b/internal/parse/parts_test.go
@@ -14,8 +14,8 @@ func TestInputPart(t *testing.T) {
 		},
 	}
 	assert.NotEqual(t, nil, i)
-	assert.Equal(t, "mytype", i.Prefix)
-	assert.Equal(t, "mytag", i.Name)
+	assert.Equal(t, "mytype", i.Source.Prefix)
+	assert.Equal(t, "mytag", i.Source.Name)
 }
 
 func TestOutputPart(t *testing.T) {

--- a/internal/parse/parts_test.go
+++ b/internal/parse/parts_test.go
@@ -1,7 +1,6 @@
 package parse
 
 import (
-	"fmt"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
@@ -11,44 +10,33 @@ func TestInputPart(t *testing.T) {
 	i, err := NewInputPart("mytype", "mytag")
 	assert.Equal(t, nil, err)
 	assert.NotEqual(t, nil, i)
-	assert.Equal(t, "mytype", i.TypeName())
-	assert.Equal(t, "mytag", i.TagName())
-	i, err = NewInputPart("", "mytag")
-	assert.Equal(t, (*InputPart)(nil), i)
-	assert.Equal(t, fmt.Errorf("malformed InputPart"), err)
+	assert.Equal(t, "mytype", i.Prefix)
+	assert.Equal(t, "mytag", i.Name)
 }
 
 func TestOutputPart(t *testing.T) {
 	// Fully specified part
-	i, err := NewOutputPart("mytable", "mycolumn", "mytype", "mytag")
+	p, err := NewOutputPart("mytable", "mycolumn", "mytype", "mytag")
 	assert.Equal(t, nil, err)
-	assert.NotEqual(t, nil, i)
-	assert.Equal(t, "mytable", i.Column.TableName())
-	assert.Equal(t, "mycolumn", i.Column.ColumnName())
-	assert.Equal(t, "mytype", i.GoType.TypeName())
-	assert.Equal(t, "mytag", i.GoType.TagName())
-	// Having table name but not column name is an error
-	i, err = NewOutputPart("mytable", "", "mytype", "mytag")
-	assert.Equal(t, (*OutputPart)(nil), i)
-	assert.Equal(t, fmt.Errorf("malformed OutputPart"), err)
+	assert.NotEqual(t, nil, p)
+	assert.Equal(t, "mytable", p.Source.Prefix)
+	assert.Equal(t, "mycolumn", p.Source.Name)
+	assert.Equal(t, "mytype", p.Target.Prefix)
+	assert.Equal(t, "mytag", p.Target.Name)
 	// Having column name without table is OK
-	i, err = NewOutputPart("", "mycolumn", "mytype", "mytag")
+	p, err = NewOutputPart("", "mycolumn", "mytype", "mytag")
 	assert.Equal(t, nil, err)
-	assert.NotEqual(t, nil, i)
-	assert.Equal(t, "", i.Column.TableName())
-	assert.Equal(t, "mycolumn", i.Column.ColumnName())
-	assert.Equal(t, "mytype", i.GoType.TypeName())
-	assert.Equal(t, "mytag", i.GoType.TagName())
-	// Having tag name but no type name is an error
-	i, err = NewOutputPart("mytag", "mycolumn", "", "mytag")
-	assert.Equal(t, (*OutputPart)(nil), i)
-	assert.Equal(t, fmt.Errorf("malformed OutputPart"), err)
+	assert.NotEqual(t, nil, p)
+	assert.Equal(t, "", p.Source.Prefix)
+	assert.Equal(t, "mycolumn", p.Source.Name)
+	assert.Equal(t, "mytype", p.Target.Prefix)
+	assert.Equal(t, "mytag", p.Target.Name)
 	// Having type name without tag name is OK
-	i, err = NewOutputPart("mytable", "mycolumn", "mytype", "")
+	p, err = NewOutputPart("mytable", "mycolumn", "mytype", "")
 	assert.Equal(t, nil, err)
-	assert.NotEqual(t, nil, i)
-	assert.Equal(t, "mytable", i.Column.TableName())
-	assert.Equal(t, "mycolumn", i.Column.ColumnName())
-	assert.Equal(t, "mytype", i.GoType.TypeName())
-	assert.Equal(t, "", i.GoType.TagName())
+	assert.NotEqual(t, nil, p)
+	assert.Equal(t, "mytable", p.Source.Prefix)
+	assert.Equal(t, "mycolumn", p.Source.Name)
+	assert.Equal(t, "mytype", p.Target.Prefix)
+	assert.Equal(t, "", p.Target.Name)
 }

--- a/internal/parse/parts_test.go
+++ b/internal/parse/parts_test.go
@@ -1,0 +1,54 @@
+package parse
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestInputPart(t *testing.T) {
+	i, err := NewInputPart("mytype", "mytag")
+	assert.Equal(t, nil, err)
+	assert.NotEqual(t, nil, i)
+	assert.Equal(t, "mytype", i.TypeName())
+	assert.Equal(t, "mytag", i.TagName())
+	i, err = NewInputPart("", "mytag")
+	assert.Equal(t, (*InputPart)(nil), i)
+	assert.Equal(t, fmt.Errorf("malformed InputPart"), err)
+}
+
+func TestOutputPart(t *testing.T) {
+	// Fully specified part
+	i, err := NewOutputPart("mytable", "mycolumn", "mytype", "mytag")
+	assert.Equal(t, nil, err)
+	assert.NotEqual(t, nil, i)
+	assert.Equal(t, "mytable", i.Column.TableName())
+	assert.Equal(t, "mycolumn", i.Column.ColumnName())
+	assert.Equal(t, "mytype", i.GoType.TypeName())
+	assert.Equal(t, "mytag", i.GoType.TagName())
+	// Having table name but not column name is an error
+	i, err = NewOutputPart("mytable", "", "mytype", "mytag")
+	assert.Equal(t, (*OutputPart)(nil), i)
+	assert.Equal(t, fmt.Errorf("malformed OutputPart"), err)
+	// Having column name without table is OK
+	i, err = NewOutputPart("", "mycolumn", "mytype", "mytag")
+	assert.Equal(t, nil, err)
+	assert.NotEqual(t, nil, i)
+	assert.Equal(t, "", i.Column.TableName())
+	assert.Equal(t, "mycolumn", i.Column.ColumnName())
+	assert.Equal(t, "mytype", i.GoType.TypeName())
+	assert.Equal(t, "mytag", i.GoType.TagName())
+	// Having tag name but no type name is an error
+	i, err = NewOutputPart("mytag", "mycolumn", "", "mytag")
+	assert.Equal(t, (*OutputPart)(nil), i)
+	assert.Equal(t, fmt.Errorf("malformed OutputPart"), err)
+	// Having type name without tag name is OK
+	i, err = NewOutputPart("mytable", "mycolumn", "mytype", "")
+	assert.Equal(t, nil, err)
+	assert.NotEqual(t, nil, i)
+	assert.Equal(t, "mytable", i.Column.TableName())
+	assert.Equal(t, "mycolumn", i.Column.ColumnName())
+	assert.Equal(t, "mytype", i.GoType.TypeName())
+	assert.Equal(t, "", i.GoType.TagName())
+}


### PR DESCRIPTION
The input SDL statement will be splitted in different `queryParts`. We support three classes:

 * PassthroughPart
 * InputPart
 * OutputPart

Input and Output parts provide constructors and accessors for convenience. The constructors check for the correctness of the parameters and returns an error if the expressions are malformed.

The definition of the `QueryPart` interface has been moved to the `parts.go` file and has been made private.