### PR TITLE
Add bypass parser

### DIFF
--- a/internal/parse/parser.go
+++ b/internal/parse/parser.go
@@ -44,7 +44,6 @@ func (cp *checkpoint) restore() {
 
 // advance moves the parser's index forward by one element.
 func (p *Parser) advance() bool {
-	p.skipSpaces()
 	if p.pos == len(p.input) {
 		return false
 	}
@@ -117,7 +116,6 @@ func (p *Parser) Parse(input string) (*ParsedExpr, error) {
 	p.init(input)
 	var peb parsedExprBuilder
 	for {
-		p.skipSpaces()
 		peb.partStart = p.pos
 		if !p.advance() {
 			break

--- a/internal/parse/parser.go
+++ b/internal/parse/parser.go
@@ -1,57 +1,140 @@
 package parse
 
-import "strings"
+import (
+	"strings"
+)
 
-// Parser is used to parse the SQLAir DSL.
 type Parser struct {
-	// input is the DSL statement to be parted.
 	input string
-
-	// lastParsedPos is the character position of the last parsed part.
-	lastParsedPos int
-
-	// pos is the current character position of the parser.
-	pos int
+	pos   int
 }
 
-// NewParser returns a reference to a new parser.
 func NewParser() *Parser {
 	return &Parser{}
 }
 
-// init initializes the parser.
+// init resets the state of the parser and sets the input string.
 func (p *Parser) init(input string) {
 	p.input = input
-	p.lastParsedPos = 0
 	p.pos = 0
 }
 
-func (p *Parser) Parse(input string) (*ParsedExpr, error) {
-	p.init(input)
-	return nil, nil
+// A checkpoint struct for saving parser state to restore later. We only use
+// a checkpoint within an attempted parsing of an part, not at a higher level
+// since we don't keep track of the parts in the checkpoint.
+type checkpoint struct {
+	parser *Parser
+	pos    int
 }
 
-// ParsedExpr represents a parsed expression.
-// It has a representation of the original SQL statement in terms of QueryParts
+// save takes a snapshot of the state of the parser and returns a pointer to a
+// checkpoint that represents it.
+func (p *Parser) save() *checkpoint {
+	return &checkpoint{
+		parser: p,
+		pos:    p.pos,
+	}
+}
+
+// restore sets the internal state of the parser to the values stored in the
+// checkpoint.
+func (cp *checkpoint) restore() {
+	cp.parser.pos = cp.pos
+}
+
+// advance moves the parser's index forward by one element.
+func (p *Parser) advance() bool {
+	p.skipSpaces()
+	if p.pos == len(p.input) {
+		return false
+	}
+	p.pos++
+	return true
+}
+
+// ParsedExpr is the AST representation of an SQL expression.
+// It has a representation of the original SQL statement in terms of queryParts
 // A SQL statement like this:
 //
 // Select p.* as &Person.* from person where p.name = $Boss.Name
 //
 // would be represented as:
 //
-// [stringPart outputPart stringPart inputPart]
+// [BypassPart OutputPart BypassPart InputPart]
 type ParsedExpr struct {
 	queryParts []queryPart
 }
 
-// peekByte returns true if the current byte
-// equals the one passed as parameter.
+// String returns a textual representation of the AST contained in the
+// ParsedExpr for debugging purposes.
+func (pe *ParsedExpr) String() string {
+	out := "ParsedExpr["
+	for i, p := range pe.queryParts {
+		if i > 0 {
+			out = out + " "
+		}
+		out = out + p.String()
+	}
+	out = out + "]"
+	return out
+}
+
+// parsedExprBuilder keeps track of the parts parsed so far, along with
+// information for parsing the BypassPart between input/output parts.
+type parsedExprBuilder struct {
+	// prevPart is the position of Parser.pos when we last finished parsing a
+	// part.
+	prevPart int
+	// partStart is the position of Parser.pos just before we started parsing
+	// the current part. We maintain partStart >= prevPart.
+	partStart int
+	parts     []queryPart
+}
+
+// add pushes the parsed part to the parsedExprBuilder along with the BypassPart
+// that stretches from the end of the previous part to the beginning of this
+// part.
+func (peb *parsedExprBuilder) add(p *Parser, part queryPart) {
+	// Add the string between the previous I/O part and the current part.
+	if peb.prevPart != peb.partStart {
+		peb.parts = append(peb.parts,
+			&BypassPart{p.input[peb.prevPart:peb.partStart]})
+	}
+
+	if part != nil {
+		peb.parts = append(peb.parts, part)
+	}
+
+	// Save this position at the end of the part.
+	peb.prevPart = p.pos
+	// Ensure that partStart >= prevPart.
+	peb.partStart = p.pos
+}
+
+// Parse takes an input string and parses the input and output parts. It returns
+// a pointer to a ParsedExpr.
+func (p *Parser) Parse(input string) (*ParsedExpr, error) {
+	p.init(input)
+	var peb parsedExprBuilder
+	for {
+		p.skipSpaces()
+		peb.partStart = p.pos
+		if !p.advance() {
+			break
+		}
+	}
+	// Add any remaining unparsed string input to the parser.
+	peb.add(p, nil)
+	return &ParsedExpr{peb.parts}, nil
+}
+
+// peekByte returns true if the current byte equals the one passed as parameter.
 func (p *Parser) peekByte(b byte) bool {
 	return p.pos < len(p.input) && p.input[p.pos] == b
 }
 
-// skipByte jumps over the current byte if it matches
-// the byte passed as a parameter. Returns true in that case, false otherwise.
+// skipByte jumps over the current byte if it matches the byte passed as a
+// parameter. Returns true in that case, false otherwise.
 func (p *Parser) skipByte(b byte) bool {
 	if p.pos < len(p.input) && p.input[p.pos] == b {
 		p.pos++
@@ -98,4 +181,11 @@ func (p *Parser) skipString(s string) bool {
 		return true
 	}
 	return false
+}
+
+// isNameByte returns true if the byte passed as parameter is considered to be
+// one that can be part of a name. It returns false otherwise
+func isNameByte(c byte) bool {
+	return 'A' <= c && c <= 'Z' || 'a' <= c && c <= 'z' ||
+		'0' <= c && c <= '9' || c == '_'
 }

--- a/internal/parse/parser.go
+++ b/internal/parse/parser.go
@@ -1,7 +1,9 @@
 package parse
 
 import (
+	"log"
 	"strings"
+	"testing"
 )
 
 type Parser struct {
@@ -40,15 +42,6 @@ func (p *Parser) save() *checkpoint {
 // checkpoint.
 func (cp *checkpoint) restore() {
 	cp.parser.pos = cp.pos
-}
-
-// advance moves the parser's index forward by one element.
-func (p *Parser) advance() bool {
-	if p.pos == len(p.input) {
-		return false
-	}
-	p.pos++
-	return true
 }
 
 // ParsedExpr is the AST representation of an SQL expression.
@@ -117,9 +110,10 @@ func (p *Parser) Parse(input string) (*ParsedExpr, error) {
 	var peb parsedExprBuilder
 	for {
 		peb.partStart = p.pos
-		if !p.advance() {
+		if p.pos == len(p.input) {
 			break
 		}
+		p.pos++
 	}
 	// Add any remaining unparsed string input to the parser.
 	peb.add(p, nil)
@@ -186,4 +180,59 @@ func (p *Parser) skipString(s string) bool {
 func isNameByte(c byte) bool {
 	return 'A' <= c && c <= 'Z' || 'a' <= c && c <= 'z' ||
 		'0' <= c && c <= '9' || c == '_'
+}
+
+type parseHelperTest struct {
+	bytef    func(byte) bool
+	stringf  func(string) bool
+	stringf0 func() bool
+	result   []bool
+	input    string
+	data     []string
+}
+
+func TestRunTable(t *testing.T) {
+	var p = NewParser()
+	var parseTests = []parseHelperTest{
+
+		{bytef: p.peekByte, result: []bool{false}, input: "", data: []string{"a"}},
+		{bytef: p.peekByte, result: []bool{false}, input: "b", data: []string{"a"}},
+		{bytef: p.peekByte, result: []bool{true}, input: "a", data: []string{"a"}},
+
+		{bytef: p.skipByte, result: []bool{false}, input: "", data: []string{"a"}},
+		{bytef: p.skipByte, result: []bool{false}, input: "abc", data: []string{"b"}},
+		{bytef: p.skipByte, result: []bool{true, true}, input: "abc", data: []string{"a", "b"}},
+
+		{bytef: p.skipByteFind, result: []bool{false}, input: "", data: []string{"a"}},
+		{bytef: p.skipByteFind, result: []bool{false, true, true}, input: "abcde", data: []string{"x", "b", "c"}},
+		{bytef: p.skipByteFind, result: []bool{true, false}, input: "abcde ", data: []string{" ", " "}},
+
+		{stringf0: p.skipSpaces, result: []bool{false}, input: "", data: []string{}},
+		{stringf0: p.skipSpaces, result: []bool{false}, input: "abc    d", data: []string{}},
+		{stringf0: p.skipSpaces, result: []bool{true}, input: "     abcd", data: []string{}},
+		{stringf0: p.skipSpaces, result: []bool{true}, input: "  \t  abcd", data: []string{}},
+		{stringf0: p.skipSpaces, result: []bool{false}, input: "\t  abcd", data: []string{}},
+
+		{stringf: p.skipString, result: []bool{false}, input: "", data: []string{"a"}},
+		{stringf: p.skipString, result: []bool{true, true}, input: "helloworld", data: []string{"hElLo", "w"}},
+		{stringf: p.skipString, result: []bool{true, true}, input: "hello world", data: []string{"hello", " "}},
+	}
+	for _, v := range parseTests {
+		p.Parse(v.input)
+		for i, _ := range v.result {
+			var result bool
+			if v.bytef != nil {
+				result = v.bytef(v.data[i][0])
+			}
+			if v.stringf != nil {
+				result = v.stringf(v.data[i])
+			}
+			if v.stringf0 != nil {
+				result = v.stringf0()
+			}
+			if v.result[i] != result {
+				log.Printf("Test %#v failed. Expected: '%t', got '%t'\n", v, result, v.result[i])
+			}
+		}
+	}
 }

--- a/internal/parse/parser_test.go
+++ b/internal/parse/parser_test.go
@@ -6,17 +6,6 @@ import (
 	"github.com/canonical/sqlair/internal/parse"
 )
 
-type parseHelperTest struct {
-	bytef    func(byte) bool
-	stringf  func(string) bool
-	stringf0 func() bool
-	result   []bool
-	input    string
-	data     []string
-}
-
-var p = parse.NewParser()
-
 type Address struct {
 	ID int `db:"id"`
 }

--- a/internal/parse/parser_test.go
+++ b/internal/parse/parser_test.go
@@ -42,7 +42,7 @@ var parseTests = []parseHelperTest{
 
 func TestRunTable(t *testing.T) {
 	for _, v := range parseTests {
-		p.init(v.input)
+		p.Parse(v.input)
 		for i := range v.result {
 			var result bool
 			if v.bytef != nil {

--- a/internal/parse/parser_test.go
+++ b/internal/parse/parser_test.go
@@ -1,8 +1,9 @@
-package parse
+package parse_test
 
 import (
-	"log"
 	"testing"
+
+	"github.com/canonical/sqlair/internal/parse"
 )
 
 type parseHelperTest struct {
@@ -14,52 +15,7 @@ type parseHelperTest struct {
 	data     []string
 }
 
-var p = NewParser()
-
-var parseTests = []parseHelperTest{
-	{bytef: p.peekByte, result: []bool{false}, input: "", data: []string{"a"}},
-	{bytef: p.peekByte, result: []bool{false}, input: "b", data: []string{"a"}},
-	{bytef: p.peekByte, result: []bool{true}, input: "a", data: []string{"a"}},
-
-	{bytef: p.skipByte, result: []bool{false}, input: "", data: []string{"a"}},
-	{bytef: p.skipByte, result: []bool{false}, input: "abc", data: []string{"b"}},
-	{bytef: p.skipByte, result: []bool{true, true}, input: "abc", data: []string{"a", "b"}},
-
-	{bytef: p.skipByteFind, result: []bool{false}, input: "", data: []string{"a"}},
-	{bytef: p.skipByteFind, result: []bool{false, true, true}, input: "abcde", data: []string{"x", "b", "c"}},
-	{bytef: p.skipByteFind, result: []bool{true, false}, input: "abcde ", data: []string{" ", " "}},
-
-	{stringf0: p.skipSpaces, result: []bool{false}, input: "", data: []string{}},
-	{stringf0: p.skipSpaces, result: []bool{false}, input: "abc    d", data: []string{}},
-	{stringf0: p.skipSpaces, result: []bool{true}, input: "     abcd", data: []string{}},
-	{stringf0: p.skipSpaces, result: []bool{true}, input: "  \t  abcd", data: []string{}},
-	{stringf0: p.skipSpaces, result: []bool{false}, input: "\t  abcd", data: []string{}},
-
-	{stringf: p.skipString, result: []bool{false}, input: "", data: []string{"a"}},
-	{stringf: p.skipString, result: []bool{true, true}, input: "helloworld", data: []string{"hElLo", "w"}},
-	{stringf: p.skipString, result: []bool{true, true}, input: "hello world", data: []string{"hello", " "}},
-}
-
-func TestRunTable(t *testing.T) {
-	for _, v := range parseTests {
-		p.Parse(v.input)
-		for i := range v.result {
-			var result bool
-			if v.bytef != nil {
-				result = v.bytef(v.data[i][0])
-			}
-			if v.stringf != nil {
-				result = v.stringf(v.data[i])
-			}
-			if v.stringf0 != nil {
-				result = v.stringf0()
-			}
-			if v.result[i] != result {
-				log.Printf("Test %#v failed. Expected: '%t', got '%t'\n", v, result, v.result[i])
-			}
-		}
-	}
-}
+var p = parse.NewParser()
 
 type Address struct {
 	ID int `db:"id"`
@@ -320,9 +276,9 @@ func TestRound(t *testing.T) {
 		},
 	}
 
-	parser := NewParser()
+	parser := parse.NewParser()
 	for i, test := range tests {
-		var parsedExpr *ParsedExpr
+		var parsedExpr *parse.ParsedExpr
 		if parsedExpr, _ = parser.Parse(test.input); parsedExpr.String() !=
 			test.expectedParsed {
 			t.Errorf("Test %d Failed (Parse): input: %s\nexpected: %s\nactual:   %s\n", i, test.input, test.expectedParsed, parsedExpr.String())

--- a/internal/parse/parser_test.go
+++ b/internal/parse/parser_test.go
@@ -3,8 +3,6 @@ package parse
 import (
 	"log"
 	"testing"
-
-	"github.com/stretchr/testify/assert"
 )
 
 type parseHelperTest struct {
@@ -44,8 +42,8 @@ var parseTests = []parseHelperTest{
 
 func TestRunTable(t *testing.T) {
 	for _, v := range parseTests {
-		p.Parse(v.input)
-		for i, _ := range v.result {
+		p.init(v.input)
+		for i := range v.result {
 			var result bool
 			if v.bytef != nil {
 				result = v.bytef(v.data[i][0])
@@ -63,9 +61,271 @@ func TestRunTable(t *testing.T) {
 	}
 }
 
-func TestInit(t *testing.T) {
-	p := NewParser()
-	expr, err := p.Parse("select foo from bar")
-	assert.Equal(t, nil, err)
-	assert.Equal(t, (*ParsedExpr)(nil), expr)
+type Address struct {
+	ID int `db:"id"`
+}
+
+type Person struct {
+	ID         int    `db:"id"`
+	Fullname   string `db:"name"`
+	PostalCode int    `db:"address_id"`
+}
+
+type Manager struct {
+	Name string `db:"manager_name"`
+}
+
+type District struct {
+}
+
+type M map[string]any
+
+func TestRound(t *testing.T) {
+	var tests = []struct {
+		input             string
+		expectedParsed    string
+		prepArgs          []any
+		completeArgs      []any
+		expectedCompleted string
+	}{
+		{
+			"select p.* as &Person.*",
+			"ParsedExpr[BypassPart[select p.* as &Person.*]]",
+			[]any{&Person{}},
+			[]any{&Person{}},
+			"select p.*",
+		},
+		{
+			"select p.* AS&Person.*",
+			"ParsedExpr[BypassPart[select p.* AS&Person.*]]",
+			[]any{&Person{}},
+			[]any{&Person{}},
+			"select p.*",
+		},
+		{
+			"select p.* as &Person.*, '&notAnOutputExpresion.*' as literal from t",
+			"ParsedExpr[BypassPart[select p.* as &Person.*, '&notAnOutputExpresion.*' as literal from t]]",
+			[]any{&Person{}},
+			[]any{&Person{}},
+			"select p.* ,  '&notAnOutputExpresion.*'  as literal from t",
+		},
+		{
+			"select * as &Person.* from t",
+			"ParsedExpr[BypassPart[select * as &Person.* from t]]",
+			[]any{&Person{}},
+			[]any{&Person{}},
+			"select *  from t",
+		},
+		{
+			"select foo, bar from table where foo = $Person.ID",
+			"ParsedExpr[BypassPart[select foo, bar from table where foo = $Person.ID]]",
+			[]any{&Person{}},
+			[]any{&Person{}},
+			"select foo, bar from table where foo = ?",
+		},
+		{
+			"select &Person from table where foo = $Address.ID",
+			"ParsedExpr[BypassPart[select &Person from table where foo = $Address.ID]]",
+			[]any{&Person{}, &Address{}},
+			[]any{&Person{}, &Address{}},
+			"select address_id, id, name  from table where foo = ?",
+		},
+		{
+			"select &Person.* from table where foo = $Address.ID",
+			"ParsedExpr[BypassPart[select &Person.* from table where foo = $Address.ID]]",
+			[]any{&Person{}, &Address{}},
+			[]any{&Person{}, &Address{}},
+			"select address_id, id, name  from table where foo = ?",
+		},
+		{
+			"select foo, bar, &Person.ID from table where foo = 'xx'",
+			"ParsedExpr[BypassPart[select foo, bar, &Person.ID from table where foo = 'xx']]",
+			[]any{&Person{}},
+			[]any{&Person{}},
+			"select foo, bar, id  from table where foo =  'xx'",
+		},
+		{
+			"select foo, &Person.ID, bar, baz, &Manager.Name from table where foo = 'xx'",
+			"ParsedExpr[BypassPart[select foo, &Person.ID, bar, baz, &Manager.Name from table where foo = 'xx']]",
+			[]any{&Person{}, &Manager{}},
+			[]any{&Person{}, &Manager{}},
+			"select foo, id , bar, baz, manager_name  from table where foo =  'xx'",
+		},
+		{
+			"SELECT * AS &Person.* FROM person WHERE name = 'Fred'",
+			"ParsedExpr[BypassPart[SELECT * AS &Person.* FROM person WHERE name = 'Fred']]",
+			[]any{&Person{}},
+			[]any{&Person{}},
+			"SELECT *  FROM person WHERE name =  'Fred'",
+		},
+		{
+			"SELECT &Person.* FROM person WHERE name = 'Fred'",
+			"ParsedExpr[BypassPart[SELECT &Person.* FROM person WHERE name = 'Fred']]",
+			[]any{&Person{}},
+			[]any{&Person{}},
+			"SELECT address_id, id, name  FROM person WHERE name =  'Fred'",
+		},
+		{
+			"SELECT * AS &Person.*, a.* as &Address.* FROM person, address a WHERE name = 'Fred'",
+			"ParsedExpr[BypassPart[SELECT * AS &Person.*, a.* as &Address.* FROM person, address a WHERE name = 'Fred']]",
+			[]any{&Person{}, &Address{}},
+			[]any{&Person{}, &Address{}},
+			"SELECT * , a.*  FROM person, address a WHERE name =  'Fred'",
+		},
+		{
+			"SELECT (a.district, a.street) AS &Address.* FROM address AS a WHERE p.name = 'Fred'",
+			"ParsedExpr[BypassPart[SELECT (a.district, a.street) AS &Address.* FROM address AS a WHERE p.name = 'Fred']]",
+			[]any{&Address{}},
+			[]any{&Address{}},
+			"SELECT a.district, a.street  FROM address AS a WHERE p.name =  'Fred'",
+		},
+		{
+			"SELECT 1 FROM person WHERE p.name = 'Fred'",
+			"ParsedExpr[BypassPart[SELECT 1 FROM person WHERE p.name = 'Fred']]",
+			[]any{},
+			[]any{},
+			"SELECT 1 FROM person WHERE p.name =  'Fred'",
+		},
+		{
+			"SELECT p.* AS &Person.*, (a.district, a.street) AS &Address.*, " +
+				"(5+7), (col1 * col2) as calculated_value FROM person AS p " +
+				"JOIN address AS a ON p.address_id = a.id WHERE p.name = 'Fred'",
+			"ParsedExpr[BypassPart[SELECT p.* AS &Person.*, (a.district, a.street) AS &Address.*, " +
+				"(5+7), (col1 * col2) as calculated_value FROM person AS p " +
+				"JOIN address AS a ON p.address_id = a.id WHERE p.name = 'Fred']]",
+			[]any{&Person{}, &Address{}},
+			[]any{&Person{}, &Address{}},
+			"SELECT p.* , a.district, a.street , (5+7), (col1 * col2) as calculated_value FROM person AS p JOIN address AS a ON p.address_id = a.id WHERE p.name =  'Fred'",
+		},
+		{
+			"SELECT p.* AS &Person.*, (a.district, a.street) AS &Address.* " +
+				"FROM person AS p JOIN address AS a ON p .address_id = a.id " +
+				"WHERE p.name = 'Fred'",
+			"ParsedExpr[BypassPart[SELECT p.* AS &Person.*, (a.district, a.street) AS &Address.* " +
+				"FROM person AS p JOIN address AS a ON p .address_id = a.id " +
+				"WHERE p.name = 'Fred']]",
+			[]any{&Person{}, &Address{}},
+			[]any{&Person{}, &Address{}},
+			"SELECT p.* , a.district, a.street  FROM person AS p JOIN address AS a ON p .address_id = a.id WHERE p.name =  'Fred'",
+		},
+		{
+			"SELECT p.* AS &Person.*, (a.district, a.street) AS &Address.* " +
+				"FROM person AS p JOIN address AS a ON p.address_id = a.id " +
+				"WHERE p.name in (select name from table where table.n = $Person.name)",
+			"ParsedExpr[BypassPart[SELECT p.* AS &Person.*, (a.district, a.street) AS &Address.* " +
+				"FROM person AS p JOIN address AS a ON p.address_id = a.id " +
+				"WHERE p.name in (select name from table where table.n = $Person.name)]]",
+			[]any{&Person{}, &Address{}},
+			[]any{&Person{}, &Address{}, &Person{}},
+			"SELECT p.* , a.district, a.street  FROM person AS p JOIN address AS a ON p.address_id = a.id WHERE p.name in (select name from table where table.n = ? )",
+		},
+		{
+			"SELECT p.* AS &Person.*, (a.district, a.street) AS &Address.* " +
+				"FROM person WHERE p.name in (select name from table " +
+				"where table.n = $Person.name) UNION " +
+				"SELECT p.* AS &Person.*, (a.district, a.street) AS &Address.* " +
+				"FROM person WHERE p.name in " +
+				"(select name from table where table.n = $Person.name)",
+			"ParsedExpr[BypassPart[SELECT p.* AS &Person.*, (a.district, a.street) AS &Address.* " +
+				"FROM person WHERE p.name in (select name from table " +
+				"where table.n = $Person.name) UNION " +
+				"SELECT p.* AS &Person.*, (a.district, a.street) AS &Address.* " +
+				"FROM person WHERE p.name in " +
+				"(select name from table where table.n = $Person.name)]]",
+			[]any{&Person{}, &Address{}},
+			[]any{&Person{}, &Address{}, &Person{}, &Person{}, &Address{}, &Person{}},
+			"SELECT p.* , a.district, a.street  FROM person WHERE p.name in (select name from table where table.n = ? ) UNION SELECT p.* , a.district, a.street  FROM person WHERE p.name in (select name from table where table.n = ? )",
+		},
+		{
+			"SELECT p.* AS &Person.*, m.* AS &Manager.* " +
+				"FROM person AS p JOIN person AS m " +
+				"ON p.manager_id = m.id WHERE p.name = 'Fred'",
+			"ParsedExpr[BypassPart[SELECT p.* AS &Person.*, m.* AS &Manager.* " +
+				"FROM person AS p JOIN person AS m " +
+				"ON p.manager_id = m.id WHERE p.name = 'Fred']]",
+			[]any{&Person{}, &Manager{}},
+			[]any{&Person{}, &Manager{}},
+			"SELECT p.* , m.*  FROM person AS p JOIN person AS m ON p.manager_id = m.id WHERE p.name =  'Fred'",
+		},
+		{
+			"SELECT person.*, address.district FROM person JOIN address " +
+				"ON person.address_id = address.id WHERE person.name = 'Fred'",
+			"ParsedExpr[BypassPart[SELECT person.*, address.district FROM person JOIN address ON person.address_id = address.id WHERE person.name = 'Fred']]",
+			[]any{},
+			[]any{},
+			"SELECT person.*, address.district FROM person JOIN address ON person.address_id = address.id WHERE person.name =  'Fred'",
+		},
+		{
+			"SELECT p FROM person WHERE p.name = $Person.name",
+			"ParsedExpr[BypassPart[SELECT p FROM person WHERE p.name = $Person.name]]",
+			[]any{&Person{}},
+			[]any{&Person{}},
+			"SELECT p FROM person WHERE p.name = ?",
+		},
+		{
+			"SELECT p.* AS &Person, a.District AS &District " +
+				"FROM person AS p JOIN address AS a ON p.address_id = a.id " +
+				"WHERE p.name = $Person.name AND p.address_id = $Person.address_id",
+			"ParsedExpr[BypassPart[SELECT p.* AS &Person, a.District AS &District " +
+				"FROM person AS p JOIN address AS a ON p.address_id = a.id " +
+				"WHERE p.name = $Person.name AND p.address_id = $Person.address_id]]",
+			[]any{&Person{}, &District{}},
+			[]any{&Person{}, &District{}, &Person{}, &Person{}},
+			"SELECT p.* , a.District  FROM person AS p JOIN address AS a ON p.address_id = a.id WHERE p.name = ?  AND p.address_id = ?",
+		},
+		{
+			"SELECT p.* AS &Person, a.District AS &District " +
+				"FROM person AS p INNER JOIN address AS a " +
+				"ON p.address_id = $Address.ID " +
+				"WHERE p.name = $Person.name AND p.address_id = $Person.address_id",
+			"ParsedExpr[BypassPart[SELECT p.* AS &Person, a.District AS &District " +
+				"FROM person AS p INNER JOIN address AS a " +
+				"ON p.address_id = $Address.ID " +
+				"WHERE p.name = $Person.name AND p.address_id = $Person.address_id]]",
+			[]any{&Address{}, &Person{}, &District{}},
+			[]any{&Person{}, &District{}, &Address{}, &Person{}, &Person{}},
+			"SELECT p.* , a.District  FROM person AS p INNER JOIN address AS a ON p.address_id = ?  WHERE p.name = ?  AND p.address_id = ?",
+		},
+		{
+			"SELECT p.*, a.district " +
+				"FROM person AS p JOIN address AS a ON p.address_id = a.id " +
+				"WHERE p.name = $Person.*",
+			"ParsedExpr[BypassPart[SELECT p.*, a.district FROM person AS p JOIN address AS a ON p.address_id = a.id WHERE p.name = $Person.*]]",
+			[]any{&Person{}},
+			[]any{&Person{}},
+			"SELECT p.*, a.district FROM person AS p JOIN address AS a ON p.address_id = a.id WHERE p.name = ?",
+		},
+		{
+			"INSERT INTO person (name) VALUES $Person.name",
+			"ParsedExpr[BypassPart[INSERT INTO person (name) VALUES $Person.name]]",
+			[]any{&Person{}},
+			[]any{&Person{}},
+			"INSERT INTO person (name) VALUES ?",
+		},
+		{
+			"INSERT INTO person VALUES $Person.*",
+			"ParsedExpr[BypassPart[INSERT INTO person VALUES $Person.*]]",
+			[]any{&Person{}},
+			[]any{&Person{}},
+			"INSERT INTO person VALUES ?",
+		},
+		{
+			"UPDATE person SET person.address_id = $Address.ID " +
+				"WHERE person.id = $Person.ID",
+			"ParsedExpr[BypassPart[UPDATE person SET person.address_id = $Address.ID " +
+				"WHERE person.id = $Person.ID]]",
+			[]any{&Address{}, &Person{}},
+			[]any{&Address{}, &Person{}},
+			"UPDATE person SET person.address_id = ?  WHERE person.id = ?",
+		},
+	}
+
+	parser := NewParser()
+	for i, test := range tests {
+		var parsedExpr *ParsedExpr
+		if parsedExpr, _ = parser.Parse(test.input); parsedExpr.String() !=
+			test.expectedParsed {
+			t.Errorf("Test %d Failed (Parse): input: %s\nexpected: %s\nactual:   %s\n", i, test.input, test.expectedParsed, parsedExpr.String())
+		}
+	}
 }

--- a/internal/parse/parts.go
+++ b/internal/parse/parts.go
@@ -52,9 +52,9 @@ type BypassPart struct {
 }
 
 func (p *BypassPart) String() string {
-	return ""
+	return "BypassPart[" + p.Chunk + "]"
 }
 
 func (p *BypassPart) ToSQL() string {
-	return ""
+	return p.Chunk
 }

--- a/internal/parse/parts_test.go
+++ b/internal/parse/parts_test.go
@@ -1,14 +1,15 @@
-package parse
+package parse_test
 
 import (
 	"testing"
 
+	"github.com/canonical/sqlair/internal/parse"
 	"github.com/stretchr/testify/assert"
 )
 
 func TestInputPart(t *testing.T) {
-	i := InputPart{
-		FullName{
+	i := parse.InputPart{
+		parse.FullName{
 			Prefix: "mytype",
 			Name:   "mytag",
 		},
@@ -20,11 +21,11 @@ func TestInputPart(t *testing.T) {
 
 func TestOutputPart(t *testing.T) {
 	// Fully specified part
-	p := OutputPart{FullName{
+	p := parse.OutputPart{parse.FullName{
 		Prefix: "mytable",
 		Name:   "mycolumn",
 	},
-		FullName{
+		parse.FullName{
 			Prefix: "mytype",
 			Name:   "mytag",
 		},


### PR DESCRIPTION
This branch adds in a complete parser that parses any statement as only BypassParts. There are some changes from the initial skeleton of the parser that existed in main already. There is a new struct, ParsedExprBuilder, that factors out the slice of parsed parts from the Parser itself. This means the checkpoint does not have to make copies of this slice when save() is called.

The behaviour of the add function is retained from the experiment. When add(p) is called the BypassPart preceding p is also added to the slice of parts. The ParsedExprBuilder keeps track of the relevant markers to make this possible.