### PR TITLE
Add advance function to Parse method

### DIFF
--- a/internal/expr/expr_test.go
+++ b/internal/expr/expr_test.go
@@ -44,15 +44,11 @@ var tests = []struct {
 }, {
 	"multiple-quoted bypass expression",
 	`SELECT '''' AS &Person.*`,
-	`[Bypass[SELECT ] Bypass[''''] Bypass[ AS &Person.*]]`,
+	`[Bypass[SELECT ] Bypass[''''] Bypass[ AS ] Output[[] [Person.*]]]`,
 }, {
 	"single quote in double quotes",
 	`SELECT "'" AS &Person.*`,
-	`[Bypass[SELECT ] Bypass["'"] Bypass[ AS &Person.*]]`,
-}, {
-	"dollar without preceding space",
-	"SELECT p.* AS&Person.*",
-	"[Bypass[SELECT p.* AS&Person.*]]",
+	`[Bypass[SELECT ] Bypass["'"] Bypass[ AS ] Output[[] [Person.*]]]`,
 }, {
 	"quoted output expression",
 	"SELECT p.* AS &Person.*, '&notAnOutputExpresion.*' AS literal FROM t",
@@ -288,8 +284,7 @@ var tests = []struct {
 	"input with no space",
 	"SELECT p.*, a.district " +
 		"FROM person AS p WHERE p.name=$Person.name",
-	"[Bypass[SELECT p.*, a.district FROM person AS p WHERE p.name=] " +
-		"Input[Person.name]]",
+	"[Bypass[SELECT p.*, a.district FROM person AS p WHERE p.name=$Person.name]]",
 }, {
 	"escaped double quote",
 	`SELECT foo FROM t WHERE t.p = "Jimmy ""Quickfingers"" Jones"`,
@@ -304,7 +299,7 @@ var tests = []struct {
 	"complex escaped quotes",
 	`SELECT * AS &Person.* FROM person WHERE ` +
 		`name IN ('Lorn', 'Onos T''oolan', '', ''' ''');`,
-	`[Bypass[SELECT * AS &Person.* FROM person WHERE name IN (] ` +
+	`[Bypass[SELECT ] Output[[*] [Person.*]] Bypass[ FROM person WHERE name IN (] ` +
 		`Bypass['Lorn'] Bypass[, ] Bypass['Onos T''oolan'] ` +
 		`Bypass[, ] Bypass[''] Bypass[, ] Bypass[''' '''] ` +
 		`Bypass[);]]`,

--- a/internal/expr/parser.go
+++ b/internal/expr/parser.go
@@ -160,14 +160,14 @@ func (p *Parser) Parse(input string) (expr *ParsedExpr, err error) {
 func (p *Parser) advance() {
 
 	// These bytes might be the start of an expression.
-	initialBytes := map[byte]bool{
+	stopBytes := map[byte]bool{
 		'$':  true,
 		'"':  true,
 		'\'': true,
 		'(':  true,
 	}
 
-	// The byte following these bytes might the start of an expression.
+	// The byte following these bytes might be the start of an expression.
 	delimiterBytes := map[byte]bool{
 		' ':  true,
 		'\t': true,
@@ -178,7 +178,7 @@ func (p *Parser) advance() {
 	}
 
 	p.pos++
-	for p.pos < len(p.input) && !initialBytes[p.input[p.pos]] &&
+	for p.pos < len(p.input) && !stopBytes[p.input[p.pos]] &&
 		!delimiterBytes[p.input[p.pos]] {
 		p.pos++
 	}

--- a/internal/expr/parser.go
+++ b/internal/expr/parser.go
@@ -6,7 +6,6 @@ import (
 	"strings"
 )
 
-// Parser keeps track of the current parsing state.
 type Parser struct {
 	input string
 	pos   int
@@ -111,8 +110,7 @@ func (p *Parser) add(part queryPart) {
 }
 
 // Parse takes an input string and parses the input and output parts. It returns
-// a pointer to a ParsedExpr. If the parser encounters an error then ParsedExpr
-// is nil.
+// a pointer to a ParsedExpr.
 func (p *Parser) Parse(input string) (expr *ParsedExpr, err error) {
 	defer func() {
 		if err != nil {
@@ -157,9 +155,8 @@ func (p *Parser) Parse(input string) (expr *ParsedExpr, err error) {
 	return &ParsedExpr{p.parts}, nil
 }
 
-// advance increments p.pos until we reach a space, a $, a " or a '. If we find
-// a space we advance to the rightmost adjacent space so the p.pos points to the
-// last space before the next non-space character.
+// advance increments p.pos until we reach content that may be the start of a
+// token we want to parse.
 func (p *Parser) advance() {
 	noteableBytes := map[byte]bool{
 		'$':  true,
@@ -167,19 +164,18 @@ func (p *Parser) advance() {
 		'\'': true,
 		' ':  true,
 	}
-	// Advance the parser to the next char.
+
 	p.pos++
-	// Keep incrementing pos until we find a character of interest.
 	for p.pos < len(p.input) && !noteableBytes[p.input[p.pos]] {
 		p.pos++
 	}
+
 	// If we are on a space, advance to the rightmost in the sequence.
 	if p.peekByte(' ') {
 		for p.pos+1 < len(p.input) && p.input[p.pos+1] == ' ' {
 			p.pos++
 		}
 	}
-	return
 }
 
 // peekByte returns true if the current byte equals the one passed as parameter.

--- a/internal/expr/parser.go
+++ b/internal/expr/parser.go
@@ -159,12 +159,9 @@ func (p *Parser) Parse(input string) (expr *ParsedExpr, err error) {
 // token we want to parse.
 func (p *Parser) advance() {
 
-	// These bytes might be the start of an expression.
-	stopBytes := map[byte]bool{
-		'$':  true,
+	quoteBytes := map[byte]bool{
 		'"':  true,
 		'\'': true,
-		'(':  true,
 	}
 
 	// The byte following these bytes might be the start of an expression.
@@ -173,12 +170,10 @@ func (p *Parser) advance() {
 		'\t': true,
 		'\n': true,
 		'\r': true,
-		')':  true,
-		';':  true,
 	}
 
 	p.pos++
-	for p.pos < len(p.input) && !stopBytes[p.input[p.pos]] &&
+	for p.pos < len(p.input) && !quoteBytes[p.input[p.pos]] &&
 		!delimiterBytes[p.input[p.pos]] {
 		p.pos++
 	}

--- a/internal/expr/parser.go
+++ b/internal/expr/parser.go
@@ -158,24 +158,36 @@ func (p *Parser) Parse(input string) (expr *ParsedExpr, err error) {
 // advance increments p.pos until we reach content that may be the start of a
 // token we want to parse.
 func (p *Parser) advance() {
-	noteableBytes := map[byte]bool{
+
+	// These bytes might be the start of an expression.
+	initialBytes := map[byte]bool{
 		'$':  true,
 		'"':  true,
 		'\'': true,
+		'(':  true,
+	}
+
+	// The byte following these bytes might the start of an expression.
+	delimiterBytes := map[byte]bool{
 		' ':  true,
+		'\t': true,
+		'\n': true,
+		'\r': true,
+		')':  true,
+		';':  true,
 	}
 
 	p.pos++
-	for p.pos < len(p.input) && !noteableBytes[p.input[p.pos]] {
+	for p.pos < len(p.input) && !initialBytes[p.input[p.pos]] &&
+		!delimiterBytes[p.input[p.pos]] {
 		p.pos++
 	}
 
-	// If we are on a space, advance to the rightmost in the sequence.
-	if p.peekByte(' ') {
-		for p.pos+1 < len(p.input) && p.input[p.pos+1] == ' ' {
-			p.pos++
-		}
+	if p.pos < len(p.input) && delimiterBytes[p.input[p.pos]] {
+		p.pos++
 	}
+
+	p.skipSpaces()
 }
 
 // peekByte returns true if the current byte equals the one passed as parameter.

--- a/internal/expr/parser.go
+++ b/internal/expr/parser.go
@@ -119,6 +119,7 @@ func (p *Parser) Parse(input string) (expr *ParsedExpr, err error) {
 			err = fmt.Errorf("cannot parse expression: %s", err)
 		}
 	}()
+
 	p.init(input)
 	for {
 		p.partStart = p.pos

--- a/internal/expr/typeinfo_test.go
+++ b/internal/expr/typeinfo_test.go
@@ -3,13 +3,9 @@ package expr
 import (
 	"reflect"
 	"sync"
-	"testing"
 
 	. "gopkg.in/check.v1"
 )
-
-// Hook up gocheck into the "go test" runner.
-func TestInternal(t *testing.T) { TestingT(t) }
 
 type ExprInternalSuite struct{}
 


### PR DESCRIPTION
This PR removed the p.pos++ from the Parse function and replaces it with a function advance that skips input until it finds the next character of interest. These are the characters that appear at the start of IO expressions and quoted string literals. 