### PR TITLE
Replace parseFullName with parseGoObject

### DIFF
--- a/internal/parse/parser.go
+++ b/internal/parse/parser.go
@@ -244,7 +244,8 @@ const (
 )
 
 // parseIdentifier parses either a name made up only of nameBytes (or an
-// asterisk if asteriskF=allowAsterisk)
+// asterisk if asteriskF=allowAsterisk). On success it returns the parsed string
+// and true. Otherwise, it returns the empty string and false.
 func (p *Parser) parseIdentifier(asteriskF asteriskFlag) (string, bool) {
 	if asteriskF == allowAsterisk {
 		if p.skipByte('*') {
@@ -260,14 +261,16 @@ func (p *Parser) parseIdentifier(asteriskF asteriskFlag) (string, bool) {
 
 // parseGoObject parses a source or target go object of the form Prefix.Name
 // where the type is the Prefix and the field is the Name (this applies to maps
-// and structs).
+// and structs). On sccuess it returns the parsed FullName, true and nil.
+// If it cannot parse the Go object it returns false. If the construct was
+// recognised as a Go object there will be an error. Otherwise err=nil.
 func (p *Parser) parseGoObject() (FullName, bool, error) {
 	cp := p.save()
 	var fn FullName
 	if id, ok := p.parseIdentifier(disallowAsterisk); ok {
 		if p.skipByte('.') {
 			if idField, ok := p.parseIdentifier(allowAsterisk); ok {
-				return FullName{Prefix: id, Name: idField}, true, nil
+				return FullName{id, idField}, true, nil
 			}
 			return fn, false, fmt.Errorf("invalid identifier near char %d", p.pos)
 		}

--- a/internal/parse/parser.go
+++ b/internal/parse/parser.go
@@ -243,9 +243,9 @@ const (
 	disallowAsterisk
 )
 
-// parseIdentifier parses either a name made up only of nameBytes (or an
-// asterisk if asteriskF=allowAsterisk). On success it returns the parsed string
-// and true. Otherwise, it returns the empty string and false.
+// parseIdentifier parses a name made up of only nameBytes, or alternatively a
+// single asterisk if `allowAsterisk` is passed. On success it returns the
+// parsed string and true. Otherwise, it returns the empty string and false.
 func (p *Parser) parseIdentifier(asteriskF asteriskFlag) (string, bool) {
 	if asteriskF == allowAsterisk {
 		if p.skipByte('*') {
@@ -261,9 +261,9 @@ func (p *Parser) parseIdentifier(asteriskF asteriskFlag) (string, bool) {
 
 // parseGoObject parses a source or target go object of the form Prefix.Name
 // where the type is the Prefix and the field is the Name (this applies to maps
-// and structs). On sccuess it returns the parsed FullName, true and nil.
-// If it cannot parse the Go object it returns false. If the construct was
-// recognised as a Go object there will be an error. Otherwise err=nil.
+// and structs). On success it returns the parsed FullName, true and nil. If a
+// Go object is found, but not formatted correctly, false and an error are
+// returned. Otherwise the error is nil.
 func (p *Parser) parseGoObject() (FullName, bool, error) {
 	cp := p.save()
 	var fn FullName

--- a/internal/parse/parser.go
+++ b/internal/parse/parser.go
@@ -236,12 +236,12 @@ func (p *Parser) skipName() bool {
 //  - bool == false, err == nil
 //		The construct was not the one we are looking for
 
-// parseIdentifier parses either a name made up only of nameBytes or an
-// asterisk.
-func (p *Parser) parseIdentifier() (string, bool) {
-	if p.skipByte('*') {
-		return "*", true
-	}
+type asteriskFlag int
+
+const (
+	allowAsterisk asteriskFlag = iota
+	disallowAsterisk
+)
 
 // parseIdentifier parses either a name made up only of nameBytes (or an
 // asterisk if asteriskF=allowAsterisk)
@@ -275,18 +275,6 @@ func (p *Parser) parseGoObject() (FullName, bool, error) {
 	}
 	cp.restore()
 	return fn, false, nil
-}
-
-// asteriskCount returns the number of FullNames in the argument with a asterisk in
-// the Name field.
-func asteriskCount(fns []FullName) int {
-	s := 0
-	for _, fn := range fns {
-		if fn.Name == "*" {
-			s++
-		}
-	}
-	return s
 }
 
 // parseInputExpression parses an input expression of the form $Type.name.

--- a/internal/parse/parser.go
+++ b/internal/parse/parser.go
@@ -281,12 +281,11 @@ func (p *Parser) parseGoObject() (FullName, bool, error) {
 }
 
 // parseInputExpression parses an input expression of the form $Type.name.
-func (p *Parser) parseInputExpression() (ip *InputPart, ok bool, err error) {
+func (p *Parser) parseInputExpression() (*InputPart, bool, error) {
 	cp := p.save()
 
 	if p.skipByte('$') {
-		var fn FullName
-		if fn, ok, err = p.parseGoObject(); ok {
+		if fn, ok, err := p.parseGoObject(); ok {
 			if fn.Name == "*" {
 				return nil, false, fmt.Errorf("asterisk not allowed "+
 					"in expression near %d", p.pos)

--- a/internal/parse/parser.go
+++ b/internal/parse/parser.go
@@ -257,11 +257,11 @@ func (p *Parser) parseIdentifier() (string, bool) {
 	return "", false
 }
 
-// parseGoTarget parses a go type name qualified by a tag name (or asterisk) of
-// the form "TypeName.col_name". On success it returns the parsed FullName, true
-// and nil. If a target is found, but not formatted correctly, false and an
-// error are returned. Otherwise the error is nil.
-func (p *Parser) parseGoTarget() (FullName, bool, error) {
+// parseGoFullName parses a Go type name qualified by a tag name (or asterisk)
+// of the form "TypeName.col_name". On success it returns the parsed FullName,
+// true and nil. If a Go full name is found, but not formatted correctly, false
+// and an error are returned. Otherwise the error is nil.
+func (p *Parser) parseGoFullName() (FullName, bool, error) {
 	cp := p.save()
 	if id, ok := p.parseIdentifier(); ok {
 		if p.skipByte('.') {
@@ -283,7 +283,7 @@ func (p *Parser) parseInputExpression() (*InputPart, bool, error) {
 	cp := p.save()
 
 	if p.skipByte('$') {
-		if fn, ok, err := p.parseGoTarget(); ok {
+		if fn, ok, err := p.parseGoFullName(); ok {
 			if fn.Name == "*" {
 				return nil, false, fmt.Errorf("asterisk not allowed "+
 					"in expression near %d", p.pos)

--- a/internal/parse/parser.go
+++ b/internal/parse/parser.go
@@ -239,11 +239,9 @@ func (p *Parser) skipName() bool {
 // parseIdentifierAsterisk parses a name made up of only nameBytes or of a
 // single asterisk. On success it returns the parsed string and true. Otherwise,
 // it returns the empty string and false.
-func (p *Parser) parseIdentifierAsterisk(string, bool) {
-	if asteriskF == allowAsterisk {
-		if p.skipByte('*') {
-			return "*", true
-		}
+func (p *Parser) parseIdentifierAsterisk() (string, bool) {
+	if p.skipByte('*') {
+		return "*", true
 	}
 	return p.parseIdentifier()
 }

--- a/internal/parse/parser.go
+++ b/internal/parse/parser.go
@@ -266,18 +266,19 @@ func (p *Parser) parseIdentifier(asteriskF asteriskFlag) (string, bool) {
 // returned. Otherwise the error is nil.
 func (p *Parser) parseGoObject() (FullName, bool, error) {
 	cp := p.save()
-	var fn FullName
 	if id, ok := p.parseIdentifier(disallowAsterisk); ok {
 		if p.skipByte('.') {
 			if idField, ok := p.parseIdentifier(allowAsterisk); ok {
 				return FullName{id, idField}, true, nil
 			}
-			return fn, false, fmt.Errorf("invalid identifier near char %d", p.pos)
+			return FullName{}, false,
+				fmt.Errorf("invalid identifier near char %d", p.pos)
 		}
-		return fn, false, fmt.Errorf("go object near char %d not qualified", p.pos)
+		return FullName{}, false,
+			fmt.Errorf("go object near char %d not qualified", p.pos)
 	}
 	cp.restore()
-	return fn, false, nil
+	return FullName{}, false, nil
 }
 
 // parseInputExpression parses an input expression of the form $Type.name.

--- a/internal/parse/parser_test.go
+++ b/internal/parse/parser_test.go
@@ -157,19 +157,23 @@ func TestRound(t *testing.T) {
 			"BypassPart[ AND p.address_id = ] " +
 			"InputPart[Person.address_id]]",
 	}, {
-		"SELECT p.*, a.district " +
-			"FROM person AS p JOIN address AS a ON p.address_id = a.id " +
-			"WHERE p.name = $Person.*",
-		"ParsedExpr[BypassPart[SELECT p.*, a.district FROM person AS p JOIN address AS a ON p.address_id = a.id WHERE p.name = ] " +
-			"InputPart[Person.*]]",
-	}, {
 		"INSERT INTO person (name) VALUES $Person.name",
 		"ParsedExpr[BypassPart[INSERT INTO person (name) VALUES ] " +
 			"InputPart[Person.name]]",
 	}, {
-		"INSERT INTO person VALUES $Person.*",
-		"ParsedExpr[BypassPart[INSERT INTO person VALUES ] " +
-			"InputPart[Person.*]]",
+		"SELECT $ FROM moneytable",
+		"ParsedExpr[BypassPart[SELECT $ FROM moneytable]]",
+	}, {
+		"SELECT foo FROM data$",
+		"ParsedExpr[BypassPart[SELECT foo FROM data$]]",
+	}, {
+		"SELECT dollerrow$ FROM moneytable",
+		"ParsedExpr[BypassPart[SELECT dollerrow$ FROM moneytable]]",
+	}, {
+		"SELECT p.*, a.district " +
+			"FROM person AS p WHERE p.name=$Person.name",
+		"ParsedExpr[BypassPart[SELECT p.*, a.district FROM person AS p WHERE p.name=] " +
+			"InputPart[Person.name]]",
 	}, {
 		"UPDATE person SET person.address_id = $Address.ID " +
 			"WHERE person.id = $Person.ID",
@@ -232,57 +236,17 @@ func TestBadEscaped(t *testing.T) {
 }
 
 // Detect bad input DSL pieces
-func TestBadFormatInput(t *testing.T) {
-	sql := "SELECT foo FROM t WHERE x = $.id"
-	parser := parse.NewParser()
-	_, err := parser.Parse(sql)
-	assert.Equal(t, fmt.Errorf("cannot parse expression: malformed input type"), err)
-}
-
-// Detect bad input DSL pieces
-func TestBadFormatInputV2(t *testing.T) {
+func TestBadFormatInputV1(t *testing.T) {
 	sql := "SELECT foo FROM t WHERE x = $Address."
 	parser := parse.NewParser()
 	_, err := parser.Parse(sql)
-	assert.Equal(t, fmt.Errorf("cannot parse expression: malformed input type"), err)
+	assert.Equal(t, fmt.Errorf("cannot parse expression: invalid identifier near char 37"), err)
 }
 
-// Detect bad input DSL pieces
-func TestBadFormatInputV3(t *testing.T) {
-	sql := "SELECT foo FROM t WHERE x = $"
+// Detect bad input expressions
+func TestBadFormatInputV2(t *testing.T) {
+	sql := "SELECT foo FROM t WHERE x = $Address"
 	parser := parse.NewParser()
 	_, err := parser.Parse(sql)
-	assert.Equal(t, fmt.Errorf("cannot parse expression: malformed input type"), err)
-}
-
-// Detect bad input DSL pieces
-func TestBadFormatInputV4(t *testing.T) {
-	sql := "SELECT foo FROM t WHERE x = $$Address"
-	parser := parse.NewParser()
-	_, err := parser.Parse(sql)
-	assert.Equal(t, fmt.Errorf("cannot parse expression: malformed input type"), err)
-}
-
-// Detect bad input DSL pieces
-func TestBadFormatInputV5(t *testing.T) {
-	sql := "SELECT foo FROM t WHERE x = $```"
-	parser := parse.NewParser()
-	_, err := parser.Parse(sql)
-	assert.Equal(t, fmt.Errorf("cannot parse expression: malformed input type"), err)
-}
-
-// Detect bad input DSL pieces
-func TestBadFormatInputV6(t *testing.T) {
-	sql := "SELECT foo FROM t WHERE x = $.."
-	parser := parse.NewParser()
-	_, err := parser.Parse(sql)
-	assert.Equal(t, fmt.Errorf("cannot parse expression: malformed input type"), err)
-}
-
-// Detect bad input DSL pieces
-func TestBadFormatInputV7(t *testing.T) {
-	sql := "SELECT foo FROM t WHERE x = $."
-	parser := parse.NewParser()
-	_, err := parser.Parse(sql)
-	assert.Equal(t, fmt.Errorf("cannot parse expression: malformed input type"), err)
+	assert.Equal(t, fmt.Errorf("cannot parse expression: go object near char 36 not qualified"), err)
 }

--- a/internal/parse/parser_test.go
+++ b/internal/parse/parser_test.go
@@ -200,21 +200,19 @@ func TestUnfinishedStringLiteral(t *testing.T) {
 		name string
 		sql  string
 		err  string
-	}{
-		{
-			"missing right single quote",
-			"SELECT foo FROM t WHERE x = 'dddd",
-			"cannot parse expression: missing right quote in string literal",
-		}, {
-			"missing right double quote",
-			"SELECT foo FROM t WHERE x = \"dddd",
-			"cannot parse expression: missing right quote in string literal",
-		}, {
-			"quote missmatch",
-			"SELECT foo FROM t WHERE x = \"dddd'",
-			"cannot parse expression: missing right quote in string literal",
-		},
-	}
+	}{{
+		"missing right single quote",
+		"SELECT foo FROM t WHERE x = 'dddd",
+		"cannot parse expression: missing right quote in string literal",
+	}, {
+		"missing right double quote",
+		"SELECT foo FROM t WHERE x = \"dddd",
+		"cannot parse expression: missing right quote in string literal",
+	}, {
+		"quote missmatch",
+		"SELECT foo FROM t WHERE x = \"dddd'",
+		"cannot parse expression: missing right quote in string literal",
+	}}
 
 	for _, test := range testTable {
 		parser := parse.NewParser()
@@ -246,25 +244,23 @@ func TestBadFormatInput(t *testing.T) {
 		name string
 		sql  string
 		err  string
-	}{
-		{
-			"missing field name",
-			"SELECT foo FROM t WHERE x = $Address.",
-			"cannot parse expression: invalid identifier near char 37",
-		}, {
-			"object not qualified",
-			"SELECT foo FROM t WHERE x = $Address",
-			"cannot parse expression: go object near char 36 not qualified",
-		}, {
-			"field name bad syntax",
-			"SELECT foo FROM t WHERE x = $Address.&d",
-			"cannot parse expression: invalid identifier near char 37",
-		}, {
-			"bad field name",
-			"SELECT foo FROM t WHERE x = $Address.-",
-			"cannot parse expression: invalid identifier near char 37",
-		},
-	}
+	}{{
+		"missing field name",
+		"SELECT foo FROM t WHERE x = $Address.",
+		"cannot parse expression: invalid identifier near char 37",
+	}, {
+		"object not qualified",
+		"SELECT foo FROM t WHERE x = $Address",
+		"cannot parse expression: go object near char 36 not qualified",
+	}, {
+		"field name bad syntax",
+		"SELECT foo FROM t WHERE x = $Address.&d",
+		"cannot parse expression: invalid identifier near char 37",
+	}, {
+		"bad field name",
+		"SELECT foo FROM t WHERE x = $Address.-",
+		"cannot parse expression: invalid identifier near char 37",
+	}}
 
 	for _, test := range testTable {
 		parser := parse.NewParser()

--- a/internal/parse/parser_test.go
+++ b/internal/parse/parser_test.go
@@ -250,3 +250,19 @@ func TestBadFormatInputV2(t *testing.T) {
 	_, err := parser.Parse(sql)
 	assert.Equal(t, fmt.Errorf("cannot parse expression: go object near char 36 not qualified"), err)
 }
+
+// Detect bad input expressions
+func TestBadFormatInputV3(t *testing.T) {
+	sql := "SELECT foo FROM t WHERE x = $Address.&d"
+	parser := parse.NewParser()
+	_, err := parser.Parse(sql)
+	assert.Equal(t, fmt.Errorf("cannot parse expression: invalid identifier near char 37"), err)
+}
+
+// Detect bad input expressions
+func TestBadFormatInputV4(t *testing.T) {
+	sql := "SELECT foo FROM t WHERE x = $Address.-"
+	parser := parse.NewParser()
+	_, err := parser.Parse(sql)
+	assert.Equal(t, fmt.Errorf("cannot parse expression: invalid identifier near char 37"), err)
+}


### PR DESCRIPTION
This PR replaces parseFullName with the more specific parseGoObject. Previously, parseFullName was intended for use parsing columns and go objects but we decided it made more sense to have two separate functions.

By using parseGoObject we can also be more specific with how we parse input expressions. We will parse an input expression as long as the character after the $ is a name byte. We ignore the character before the $.

The errors returned by parseInputExpression also now include an approximate position of the error. We intend to provide an approximate position for all errors in future PRs.