### PR TITLE
Add back internal tests for the skip functions

### DIFF
--- a/internal/parse/parser_internal_test.go
+++ b/internal/parse/parser_internal_test.go
@@ -1,0 +1,66 @@
+package parse
+
+import (
+	"testing"
+)
+
+type parseHelperTest struct {
+	bytef    func(byte) bool
+	stringf  func(string) bool
+	stringf0 func() bool
+	result   []bool
+	input    string
+	data     []string
+}
+
+func TestRunTable(t *testing.T) {
+	var p = NewParser()
+	var parseTests = []parseHelperTest{
+
+		{bytef: p.peekByte, result: []bool{false}, input: "", data: []string{"a"}},
+		{bytef: p.peekByte, result: []bool{false}, input: "b", data: []string{"a"}},
+		{bytef: p.peekByte, result: []bool{true}, input: "a", data: []string{"a"}},
+
+		{bytef: p.skipByte, result: []bool{false}, input: "", data: []string{"a"}},
+		{bytef: p.skipByte, result: []bool{false}, input: "abc", data: []string{"b"}},
+		{bytef: p.skipByte, result: []bool{true, true}, input: "abc", data: []string{"a", "b"}},
+
+		{bytef: p.skipByteFind, result: []bool{false}, input: "", data: []string{"a"}},
+		{bytef: p.skipByteFind, result: []bool{false, true, true}, input: "abcde", data: []string{"x", "b", "c"}},
+		{bytef: p.skipByteFind, result: []bool{true, false}, input: "abcde ", data: []string{" ", " "}},
+
+		{stringf0: p.skipSpaces, result: []bool{false}, input: "", data: []string{}},
+		{stringf0: p.skipSpaces, result: []bool{false}, input: "abc    d", data: []string{}},
+		{stringf0: p.skipSpaces, result: []bool{true}, input: "     abcd", data: []string{}},
+		{stringf0: p.skipSpaces, result: []bool{true}, input: "  \t  abcd", data: []string{}},
+		{stringf0: p.skipSpaces, result: []bool{false}, input: "\t  abcd", data: []string{}},
+
+		{stringf: p.skipString, result: []bool{false}, input: "", data: []string{"a"}},
+		{stringf: p.skipString, result: []bool{true, true}, input: "helloworld", data: []string{"hElLo", "w"}},
+		{stringf: p.skipString, result: []bool{true, true}, input: "hello world", data: []string{"hello", " "}},
+
+		{stringf0: p.skipName, result: []bool{false}, input: " hi", data: []string{}},
+		{stringf0: p.skipName, result: []bool{false}, input: "*", data: []string{}},
+		{stringf0: p.skipName, result: []bool{true}, input: "hello", data: []string{}},
+		{stringf0: p.skipName, result: []bool{true}, input: "2d3d", data: []string{}},
+	}
+	for _, v := range parseTests {
+		// Reset the input.
+		p.init(v.input)
+		for i, _ := range v.result {
+			var result bool
+			if v.bytef != nil {
+				result = v.bytef(v.data[i][0])
+			}
+			if v.stringf != nil {
+				result = v.stringf(v.data[i])
+			}
+			if v.stringf0 != nil {
+				result = v.stringf0()
+			}
+			if v.result[i] != result {
+				t.Errorf("Test %#v failed. Expected: '%t', got '%t'\n", v, result, v.result[i])
+			}
+		}
+	}
+}


### PR DESCRIPTION
These were previously removed by accident. They have been updated for adding back in.