### PR TITLE
Add output parser

### DIFF
--- a/internal/expr/expr_test.go
+++ b/internal/expr/expr_test.go
@@ -40,17 +40,21 @@ var tests = []struct {
 }{{
 	"star table as output",
 	"SELECT p.* AS &Person.*",
-	"[Bypass[SELECT p.* AS &Person.*]]",
+	"[Bypass[SELECT ] Output[[p.*] [Person.*]]]",
 }, {
 	"quoted output expression",
 	"SELECT p.* AS &Person.*, '&notAnOutputExpresion.*' AS literal FROM t",
-	"[Bypass[SELECT p.* AS &Person.*, ] " +
+	"[Bypass[SELECT ] " +
+		"Output[[p.*] [Person.*]] " +
+		"Bypass[, ] " +
 		"Bypass['&notAnOutputExpresion.*'] " +
 		"Bypass[ AS literal FROM t]]",
 }, {
 	"star as output",
 	"SELECT * AS &Person.* FROM t",
-	"[Bypass[SELECT * AS &Person.* FROM t]]",
+	"[Bypass[SELECT ] " +
+		"Output[[*] [Person.*]] " +
+		"Bypass[ FROM t]]",
 }, {
 	"input v1",
 	"SELECT foo, bar FROM table WHERE foo = $Person.id",
@@ -69,43 +73,84 @@ var tests = []struct {
 		"Input[Person.name]]",
 }, {
 	"output and input",
-	"SELECT &Person FROM table WHERE foo = $Address.id",
-	"[Bypass[SELECT &Person FROM table WHERE foo = ] " +
+	"SELECT &Person.* FROM table WHERE foo = $Address.id",
+	"[Bypass[SELECT ] Output[[] [Person.*]] " +
+		"Bypass[ FROM table WHERE foo = ] " +
 		"Input[Address.id]]",
 }, {
 	"star output and input",
 	"SELECT &Person.* FROM table WHERE foo = $Address.id",
-	"[Bypass[SELECT &Person.* FROM table WHERE foo = ] " +
+	"[Bypass[SELECT ] " +
+		"Output[[] [Person.*]] " +
+		"Bypass[ FROM table WHERE foo = ] " +
 		"Input[Address.id]]",
 }, {
 	"output and quote",
 	"SELECT foo, bar, &Person.id FROM table WHERE foo = 'xx'",
-	"[Bypass[SELECT foo, bar, &Person.id FROM table WHERE foo = ] " +
+	"[Bypass[SELECT foo, bar, ] " +
+		"Output[[] [Person.id]] " +
+		"Bypass[ FROM table WHERE foo = ] " +
 		"Bypass['xx']]",
 }, {
 	"two outputs and quote",
 	"SELECT foo, &Person.id, bar, baz, &Manager.name FROM table WHERE foo = 'xx'",
-	"[Bypass[SELECT foo, &Person.id, bar, baz, &Manager.name FROM table WHERE foo = ] " +
+	"[Bypass[SELECT foo, ] " +
+		"Output[[] [Person.id]] " +
+		"Bypass[, bar, baz, ] " +
+		"Output[[] [Manager.name]] " +
+		"Bypass[ FROM table WHERE foo = ] " +
 		"Bypass['xx']]",
 }, {
 	"star as output and quote",
 	"SELECT * AS &Person.* FROM person WHERE name = 'Fred'",
-	"[Bypass[SELECT * AS &Person.* FROM person WHERE name = ] " +
+	"[Bypass[SELECT ] " +
+		"Output[[*] [Person.*]] " +
+		"Bypass[ FROM person WHERE name = ] " +
 		"Bypass['Fred']]",
 }, {
 	"star output and quote",
 	"SELECT &Person.* FROM person WHERE name = 'Fred'",
-	"[Bypass[SELECT &Person.* FROM person WHERE name = ] " +
+	"[Bypass[SELECT ] " +
+		"Output[[] [Person.*]] " +
+		"Bypass[ FROM person WHERE name = ] " +
 		"Bypass['Fred']]",
 }, {
 	"two star as outputs and quote",
 	"SELECT * AS &Person.*, a.* AS &Address.* FROM person, address a WHERE name = 'Fred'",
-	"[Bypass[SELECT * AS &Person.*, a.* AS &Address.* FROM person, address a WHERE name = ] " +
+	"[Bypass[SELECT ] " +
+		"Output[[*] [Person.*]] " +
+		"Bypass[, ] " +
+		"Output[[a.*] [Address.*]] " +
+		"Bypass[ FROM person, address a WHERE name = ] " +
 		"Bypass['Fred']]",
+}, {
+	"multicolumn output",
+	"SELECT (a.district, a.street) AS (&Address.district, &Address.street) FROM address AS a",
+	"[Bypass[SELECT ] " +
+		"Output[[a.district a.street] [Address.district Address.street]] " +
+		"Bypass[ FROM address AS a]]",
+}, {
+	"multicolumn output and output",
+	"SELECT (a.district, a.street) AS (&Address.district, &Address.street), " +
+		"a.id AS &Person.id FROM address AS a",
+	"[Bypass[SELECT ] " +
+		"Output[[a.district a.street] [Address.district Address.street]] " +
+		"Bypass[, ] Output[[a.id] [Person.id]] " +
+		"Bypass[ FROM address AS a]]",
+}, {
+	"multicolumn output and star",
+	"SELECT (a.district, a.street) AS (&Address.district, &Address.street), " +
+		"&Person.* FROM address AS a",
+	"[Bypass[SELECT ] " +
+		"Output[[a.district a.street] [Address.district Address.street]] " +
+		"Bypass[, ] Output[[] [Person.*]] " +
+		"Bypass[ FROM address AS a]]",
 }, {
 	"multicolumn output and quote",
 	"SELECT (a.district, a.street) AS &Address.* FROM address AS a WHERE p.name = 'Fred'",
-	"[Bypass[SELECT (a.district, a.street) AS &Address.* FROM address AS a WHERE p.name = ] Bypass['Fred']]",
+	"[Bypass[SELECT ] " +
+		"Output[[a.district a.street] [Address.*]] " +
+		"Bypass[ FROM address AS a WHERE p.name = ] Bypass['Fred']]",
 }, {
 	"quote",
 	"SELECT 1 FROM person WHERE p.name = 'Fred'",
@@ -116,23 +161,33 @@ var tests = []struct {
 	"SELECT p.* AS &Person.*, (a.district, a.street) AS &Address.*, " +
 		"(5+7), (col1 * col2) AS calculated_value FROM person AS p " +
 		"JOIN address AS a ON p.address_id = a.id WHERE p.name = 'Fred'",
-	"[Bypass[SELECT p.* AS &Person.*, (a.district, a.street) AS &Address.*, (5+7), (col1 * col2) AS calculated_value FROM person AS p JOIN address AS a ON p.address_id = a.id WHERE p.name = ] " +
+	"[Bypass[SELECT ] " +
+		"Output[[p.*] [Person.*]] " +
+		"Bypass[, ] " +
+		"Output[[a.district a.street] [Address.*]] " +
+		"Bypass[, (5+7), (col1 * col2) AS calculated_value FROM person AS p JOIN address AS a ON p.address_id = a.id WHERE p.name = ] " +
 		"Bypass['Fred']]",
 }, {
 	"complex query v2",
 	"SELECT p.* AS &Person.*, (a.district, a.street) AS &Address.* " +
 		"FROM person AS p JOIN address AS a ON p .address_id = a.id " +
 		"WHERE p.name = 'Fred'",
-	"[Bypass[SELECT p.* AS &Person.*, (a.district, a.street) AS &Address.*" +
-		" FROM person AS p JOIN address AS a ON p .address_id = a.id WHERE p.name = ] " +
+	"[Bypass[SELECT ] " +
+		"Output[[p.*] [Person.*]] " +
+		"Bypass[, ] " +
+		"Output[[a.district a.street] [Address.*]] " +
+		"Bypass[ FROM person AS p JOIN address AS a ON p .address_id = a.id WHERE p.name = ] " +
 		"Bypass['Fred']]",
 }, {
 	"complex query v3",
 	"SELECT p.* AS &Person.*, (a.district, a.street) AS &Address.* " +
 		"FROM person AS p JOIN address AS a ON p.address_id = a.id " +
 		"WHERE p.name IN (SELECT name FROM table WHERE table.n = $Person.name)",
-	"[Bypass[SELECT p.* AS &Person.*, (a.district, a.street) AS &Address.* " +
-		"FROM person AS p JOIN address AS a ON p.address_id = a.id WHERE p.name IN (SELECT name FROM table WHERE table.n = ] " +
+	"[Bypass[SELECT ] " +
+		"Output[[p.*] [Person.*]] " +
+		"Bypass[, ] " +
+		"Output[[a.district a.street] [Address.*]] " +
+		"Bypass[ FROM person AS p JOIN address AS a ON p.address_id = a.id WHERE p.name IN (SELECT name FROM table WHERE table.n = ] " +
 		"Input[Person.name] " +
 		"Bypass[)]]",
 }, {
@@ -143,32 +198,41 @@ var tests = []struct {
 		"SELECT p.* AS &Person.*, (a.district, a.street) AS &Address.* " +
 		"FROM person WHERE p.name IN " +
 		"(SELECT name FROM table WHERE table.n = $Person.name)",
-	"[Bypass[SELECT p.* AS &Person.*, " +
-		"(a.district, a.street) AS &Address.* " +
-		"FROM person WHERE p.name IN (SELECT name FROM table WHERE table.n = ] " +
+	"[Bypass[SELECT ] Output[[p.*] [Person.*]] " +
+		"Bypass[, ] Output[[a.district a.street] [Address.*]] " +
+		"Bypass[ FROM person WHERE p.name IN (SELECT name FROM table WHERE table.n = ] " +
 		"Input[Person.name] " +
-		"Bypass[) UNION SELECT p.* AS &Person.*, (a.district, a.street) AS &Address.* " +
-		"FROM person WHERE p.name IN (SELECT name FROM table WHERE table.n = ] " +
+		"Bypass[) UNION SELECT ] " +
+		"Output[[p.*] [Person.*]] " +
+		"Bypass[, ] " +
+		"Output[[a.district a.street] [Address.*]] " +
+		"Bypass[ FROM person WHERE p.name IN (SELECT name FROM table WHERE table.n = ] " +
 		"Input[Person.name] " +
 		"Bypass[)]]",
 }, {
 	"complex query v5",
-	"SELECT p.* AS &Person, a.District AS &District " +
+	"SELECT p.* AS &Person.*, a.district AS &District.* " +
 		"FROM person AS p JOIN address AS a ON p.address_id = a.id " +
 		"WHERE p.name = $Person.name AND p.address_id = $Person.address_id",
-	"[Bypass[SELECT p.* AS &Person, a.District AS &District " +
-		"FROM person AS p JOIN address AS a ON p.address_id = a.id WHERE p.name = ] " +
+	"[Bypass[SELECT ] " +
+		"Output[[p.*] [Person.*]] " +
+		"Bypass[, ] " +
+		"Output[[a.district] [District.*]] " +
+		"Bypass[ FROM person AS p JOIN address AS a ON p.address_id = a.id WHERE p.name = ] " +
 		"Input[Person.name] " +
 		"Bypass[ AND p.address_id = ] " +
 		"Input[Person.address_id]]",
 }, {
 	"complex query v6",
-	"SELECT p.* AS &Person, a.District AS &District " +
+	"SELECT p.* AS &Person.*, a.district AS &District.* " +
 		"FROM person AS p INNER JOIN address AS a " +
 		"ON p.address_id = $Address.id " +
 		"WHERE p.name = $Person.name AND p.address_id = $Person.address_id",
-	"[Bypass[SELECT p.* AS &Person, a.District AS &District " +
-		"FROM person AS p INNER JOIN address AS a ON p.address_id = ] " +
+	"[Bypass[SELECT ] " +
+		"Output[[p.*] [Person.*]] " +
+		"Bypass[, ] " +
+		"Output[[a.district] [District.*]] " +
+		"Bypass[ FROM person AS p INNER JOIN address AS a ON p.address_id = ] " +
 		"Input[Address.id] " +
 		"Bypass[ WHERE p.name = ] " +
 		"Input[Person.name] " +
@@ -179,8 +243,11 @@ var tests = []struct {
 	"SELECT p.* AS &Person.*, m.* AS &Manager.* " +
 		"FROM person AS p JOIN person AS m " +
 		"ON p.manager_id = m.id WHERE p.name = 'Fred'",
-	"[Bypass[SELECT p.* AS &Person.*, m.* AS &Manager.* " +
-		"FROM person AS p JOIN person AS m ON p.manager_id = m.id WHERE p.name = ] " +
+	"[Bypass[SELECT ] " +
+		"Output[[p.*] [Person.*]] " +
+		"Bypass[, ] " +
+		"Output[[m.*] [Manager.*]] " +
+		"Bypass[ FROM person AS p JOIN person AS m ON p.manager_id = m.id WHERE p.name = ] " +
 		"Bypass['Fred']]",
 }, {
 	"join v2",

--- a/internal/expr/expr_test.go
+++ b/internal/expr/expr_test.go
@@ -343,14 +343,14 @@ func (s *ExprSuite) TestParseBadFormatInput(c *C) {
 	for _, sql := range testListInvalidId {
 		parser := expr.NewParser()
 		expr, err := parser.Parse(sql)
-		c.Assert(err, ErrorMatches, "cannot parse expression: invalid identifier near char 37")
+		c.Assert(err, ErrorMatches, "cannot parse expression: column 37: invalid identifier")
 		c.Assert(expr, IsNil)
 	}
 
 	sql := "SELECT foo FROM t WHERE x = $Address"
 	parser := expr.NewParser()
 	_, err := parser.Parse(sql)
-	c.Assert(err, ErrorMatches, "cannot parse expression: go object near char 36 not qualified")
+	c.Assert(err, ErrorMatches, "cannot parse expression: column 36: type not qualified")
 }
 
 func FuzzParser(f *testing.F) {

--- a/internal/expr/parser.go
+++ b/internal/expr/parser.go
@@ -327,11 +327,10 @@ func (p *Parser) parseGoFullName() (fullName, bool, error) {
 // parseList takes a parsing function that returns a fullName and parses a
 // bracketed, comma seperated, list.
 func (p *Parser) parseList(parseFn func(p *Parser) (fullName, bool, error)) ([]fullName, bool, error) {
+	cp := p.save()
 	if !p.skipByte('(') {
 		return nil, false, nil
 	}
-
-	cp := p.save()
 
 	parenPos := p.pos
 	p.skipSpaces()
@@ -366,7 +365,6 @@ func (p *Parser) parseList(parseFn func(p *Parser) (fullName, bool, error)) ([]f
 // parseColumns parses a list of columns. For lists of more than one column the
 // columns must be enclosed in brackets e.g. "(col1, col2) AS &Person.*".
 func (p *Parser) parseColumns() ([]fullName, bool) {
-	cp := p.save()
 
 	// Case 1: A single column e.g. "p.name".
 	if col, ok, _ := p.parseColumn(); ok {
@@ -378,7 +376,6 @@ func (p *Parser) parseColumns() ([]fullName, bool) {
 		return cols, true
 	}
 
-	cp.restore()
 	return nil, false
 }
 
@@ -387,8 +384,6 @@ func (p *Parser) parseColumns() ([]fullName, bool) {
 // If the ampersand is not preceded by a space and succeeded by a name or
 // opening bracket the targets are not parsed.
 func (p *Parser) parseTargets() ([]fullName, bool, error) {
-	cp := p.save()
-
 	// Case 1: A single target e.g. "&Person.name".
 	if target, ok, err := p.parseTarget(); err != nil {
 		return nil, false, err
@@ -403,7 +398,6 @@ func (p *Parser) parseTargets() ([]fullName, bool, error) {
 		return targets, true, nil
 	}
 
-	cp.restore()
 	return nil, false, nil
 }
 

--- a/internal/expr/parser.go
+++ b/internal/expr/parser.go
@@ -378,7 +378,7 @@ func (p *Parser) parseColumns() ([]fullName, bool) {
 }
 
 // parseTargets parses the part of the output expression following the
-// ampersand. This can be one or more references Go objects.
+// ampersand. This can be one or more references to Go types.
 // If the ampersand is not preceded by a space and succeeded by a name or
 // opening bracket the targets are not parsed.
 func (p *Parser) parseTargets() ([]fullName, bool, error) {

--- a/internal/expr/parser.go
+++ b/internal/expr/parser.go
@@ -294,18 +294,15 @@ func (p *Parser) parseColumn() (fullName, bool, error) {
 }
 
 func (p *Parser) parseTarget() (fullName, bool, error) {
-	cp := p.save()
-
 	if p.skipByte('&') {
 		return p.parseGoFullName()
 	}
 
-	cp.restore()
 	return fullName{}, false, nil
 }
 
 // parseGoFullName parses a Go type name qualified by a tag name (or asterisk)
-// of the form "&TypeName.col_name". On success it returns the parsed FullName,
+// of the form "&TypeName.col_name". On success it returns the parsed fullName,
 // true and nil. If a Go full name is found, but not formatted correctly, false
 // and an error are returned. Otherwise the error is nil.
 func (p *Parser) parseGoFullName() (fullName, bool, error) {

--- a/internal/expr/parser.go
+++ b/internal/expr/parser.go
@@ -327,11 +327,11 @@ func (p *Parser) parseGoFullName() (fullName, bool, error) {
 // parseList takes a parsing function that returns a fullName and parses a
 // bracketed, comma seperated, list.
 func (p *Parser) parseList(parseFn func(p *Parser) (fullName, bool, error)) ([]fullName, bool, error) {
-	cp := p.save()
-
 	if !p.skipByte('(') {
 		return nil, false, nil
 	}
+
+	cp := p.save()
 
 	parenPos := p.pos
 	p.skipSpaces()

--- a/internal/expr/parser.go
+++ b/internal/expr/parser.go
@@ -379,8 +379,8 @@ func (p *Parser) parseColumns() ([]fullName, bool) {
 
 // parseTargets parses the part of the output expression following the
 // ampersand. This can be one or more references to Go types.
-// If the ampersand is not preceded by a space and succeeded by a name or
-// opening bracket the targets are not parsed.
+// If the ampersand is not preceded by a space or opening bracket and succeeded
+// by a name the targets are not parsed.
 func (p *Parser) parseTargets() ([]fullName, bool, error) {
 	// Case 1: A single target e.g. "&Person.name".
 	if target, ok, err := p.parseTarget(); err != nil {

--- a/internal/expr/parser.go
+++ b/internal/expr/parser.go
@@ -399,7 +399,6 @@ func (p *Parser) parseTargets() ([]fullName, bool, error) {
 // parseOutputExpression requires that the ampersand before the identifiers must
 // be preceded by a space and followed by a name byte.
 func (p *Parser) parseOutputExpression() (*outputPart, bool, error) {
-	cp := p.save()
 
 	// Case 1: There are no columns e.g. "&Person.*".
 	if targets, ok, err := p.parseTargets(); err != nil {
@@ -407,6 +406,8 @@ func (p *Parser) parseOutputExpression() (*outputPart, bool, error) {
 	} else if ok {
 		return &outputPart{[]fullName{}, targets}, true, nil
 	}
+
+	cp := p.save()
 
 	// Case 2: There are columns e.g. "p.col1 AS &Person.*".
 	if cols, ok := p.parseColumns(); ok {

--- a/internal/expr/parser.go
+++ b/internal/expr/parser.go
@@ -313,11 +313,11 @@ func (p *Parser) parseGoFullName() (fullName, bool, error) {
 
 	if id, ok := p.parseIdentifier(); ok {
 		if p.skipByte('.') {
-			if idField, ok := p.parseIdentifierAsterisk(); ok {
-				return fullName{id, idField}, true, nil
+			idField, ok := p.parseIdentifierAsterisk()
+			if !ok {
+				return fullName{}, false, fmt.Errorf("invalid identifier near char %d", p.pos)
 			}
-			return fullName{}, false,
-				fmt.Errorf("invalid identifier near char %d", p.pos)
+			return fullName{id, idField}, true, nil
 		}
 		return fullName{}, false,
 			fmt.Errorf("go object near char %d not qualified", p.pos)
@@ -347,7 +347,7 @@ func (p *Parser) parseList(parseFn func(p *Parser) (fullName, bool, error)) ([]f
 		} else if err != nil {
 			return nil, false, err
 		} else if i == 0 {
-			// If the first item is not what we are looking for we exit.
+			// If the first item is not what we are looking for, we exit.
 			cp.restore()
 			return nil, false, nil
 		} else {

--- a/internal/expr/parser.go
+++ b/internal/expr/parser.go
@@ -273,8 +273,8 @@ func (p *Parser) parseIdentifier() (string, bool) {
 }
 
 // parseColumn parses a column made up of name bytes, optionally dot-prefixed by
-// its table name. parseColumn returns an error so that it can be used with
-// parseList.
+// its table name.
+// parseColumn returns an error so that it can be used with parseList.
 func (p *Parser) parseColumn() (fullName, bool, error) {
 	cp := p.save()
 
@@ -302,9 +302,7 @@ func (p *Parser) parseTarget() (fullName, bool, error) {
 }
 
 // parseGoFullName parses a Go type name qualified by a tag name (or asterisk)
-// of the form "&TypeName.col_name". On success it returns the parsed fullName,
-// true and nil. If a Go full name is found, but not formatted correctly, false
-// and an error are returned. Otherwise the error is nil.
+// of the form "&TypeName.col_name".
 func (p *Parser) parseGoFullName() (fullName, bool, error) {
 	cp := p.save()
 

--- a/internal/expr/parser.go
+++ b/internal/expr/parser.go
@@ -310,12 +310,12 @@ func (p *Parser) parseGoFullName() (fullName, bool, error) {
 
 	if id, ok := p.parseIdentifier(); ok {
 		if !p.skipByte('.') {
-			return fullName{}, false, fmt.Errorf("go object near char %d not qualified", p.pos)
+			return fullName{}, false, fmt.Errorf("column %d: type not qualified", p.pos)
 		}
 
 		idField, ok := p.parseIdentifierAsterisk()
 		if !ok {
-			return fullName{}, false, fmt.Errorf("invalid identifier near char %d", p.pos)
+			return fullName{}, false, fmt.Errorf("column %d: invalid identifier", p.pos)
 		}
 		return fullName{id, idField}, true, nil
 	}


### PR DESCRIPTION
Add the functions for parsing outputs and updated the tests.
Some of the functions are somewhat similar to each other and could possibly be merged into one however we have elected to keep them separate with the view that with future updates their definitions will diverge.