### PR TITLE
Expand skip spaces

### DIFF
--- a/internal/expr/expr_test.go
+++ b/internal/expr/expr_test.go
@@ -42,6 +42,28 @@ var tests = []struct {
 	"SELECT p.* AS &Person.*",
 	"[Bypass[SELECT p.* AS &Person.*]]",
 }, {
+	"spaces and tabs",
+	"SELECT p.* 	AS 		   &Person.*",
+	"ParsedExpr[BypassPart[SELECT p.* 	AS 		   &Person.*]]",
+}, {
+	"new lines",
+	`SELECT
+		p.* AS &Person.*,
+		foo
+	 FROM t
+	 WHERE
+		foo = bar
+		and
+		x = y`,
+	`ParsedExpr[BypassPart[SELECT
+		p.* AS &Person.*,
+		foo
+	 FROM t
+	 WHERE
+		foo = bar
+		and
+		x = y]]`,
+}, {
 	"quoted output expression",
 	"SELECT p.* AS &Person.*, '&notAnOutputExpresion.*' AS literal FROM t",
 	"[Bypass[SELECT p.* AS &Person.*, ] " +

--- a/internal/expr/parser.go
+++ b/internal/expr/parser.go
@@ -177,9 +177,8 @@ func (p *Parser) skipByteFind(b byte) bool {
 	return false
 }
 
-// skipBlanks advances the parser jumping over consecutive spaces, tabs or new
-// lines. It stops when finding a non-blank character. Returns true if the
-// parser position was actually changed, false otherwise.
+// skipBlanks advances the parser past spaces, tabs and newlines. Returns
+// whether the parser position was changed.
 func (p *Parser) skipBlanks() bool {
 	mark := p.pos
 	blanks := map[byte]bool{

--- a/internal/expr/parser.go
+++ b/internal/expr/parser.go
@@ -177,13 +177,14 @@ func (p *Parser) skipByteFind(b byte) bool {
 	return false
 }
 
-// skipSpaces advances the parser jumping over consecutive spaces. It stops when
-// finding a non-space character. Returns true if the parser position was
-// actually changed, false otherwise.
-func (p *Parser) skipSpaces() bool {
+// skipBlanks advances the parser jumping over consecutive spaces, tabs or new
+// lines. It stops when finding a non-blank character. Returns true if the
+// parser position was actually changed, false otherwise.
+func (p *Parser) skipBlanks() bool {
 	mark := p.pos
 	for p.pos < len(p.input) {
-		if p.input[p.pos] != ' ' {
+		if p.input[p.pos] != ' ' && p.input[p.pos] != '\t' &&
+			p.input[p.pos] != '\n' {
 			break
 		}
 		p.pos++

--- a/internal/expr/parser.go
+++ b/internal/expr/parser.go
@@ -182,11 +182,13 @@ func (p *Parser) skipByteFind(b byte) bool {
 // parser position was actually changed, false otherwise.
 func (p *Parser) skipBlanks() bool {
 	mark := p.pos
-	for p.pos < len(p.input) {
-		if p.input[p.pos] != ' ' && p.input[p.pos] != '\t' &&
-			p.input[p.pos] != '\n' {
-			break
-		}
+	blanks := map[byte]bool{
+		' ':  true,
+		'\t': true,
+		'\r': true,
+		'\n': true,
+	}
+	for p.pos < len(p.input) && blanks[p.input[p.pos]] {
 		p.pos++
 	}
 	return p.pos != mark

--- a/internal/expr/parser.go
+++ b/internal/expr/parser.go
@@ -181,14 +181,13 @@ func (p *Parser) skipByteFind(b byte) bool {
 // whether the parser position was changed.
 func (p *Parser) skipBlanks() bool {
 	mark := p.pos
-	blanks := map[byte]bool{
-		' ':  true,
-		'\t': true,
-		'\r': true,
-		'\n': true,
-	}
-	for p.pos < len(p.input) && blanks[p.input[p.pos]] {
-		p.pos++
+	for p.pos < len(p.input) {
+		switch p.input[p.pos] {
+		case ' ', '\t', '\r', '\n':
+			p.pos++
+		default:
+			return p.pos != mark
+		}
 	}
 	return p.pos != mark
 }

--- a/internal/expr/parser_helper_test.go
+++ b/internal/expr/parser_helper_test.go
@@ -29,11 +29,12 @@ func (s *ExprInternalSuite) TestRunTable(c *C) {
 		{bytef: p.skipByteFind, result: []bool{false, true, true}, input: "abcde", data: []string{"x", "b", "c"}},
 		{bytef: p.skipByteFind, result: []bool{true, false}, input: "abcde ", data: []string{" ", " "}},
 
-		{stringf0: p.skipSpaces, result: []bool{false}, input: "", data: []string{}},
-		{stringf0: p.skipSpaces, result: []bool{false}, input: "abc    d", data: []string{}},
-		{stringf0: p.skipSpaces, result: []bool{true}, input: "     abcd", data: []string{}},
-		{stringf0: p.skipSpaces, result: []bool{true}, input: "  \t  abcd", data: []string{}},
-		{stringf0: p.skipSpaces, result: []bool{false}, input: "\t  abcd", data: []string{}},
+		{stringf0: p.skipBlanks, result: []bool{false}, input: "", data: []string{}},
+		{stringf0: p.skipBlanks, result: []bool{false}, input: "abc    d", data: []string{}},
+		{stringf0: p.skipBlanks, result: []bool{true}, input: "     abcd", data: []string{}},
+		{stringf0: p.skipBlanks, result: []bool{true}, input: "  \t  abcd", data: []string{}},
+		{stringf0: p.skipBlanks, result: []bool{true}, input: "\t  abcd", data: []string{}},
+		{stringf0: p.skipBlanks, result: []bool{true}, input: "\n\t  abcd", data: []string{}},
 
 		{stringf: p.skipString, result: []bool{false}, input: "", data: []string{"a"}},
 		{stringf: p.skipString, result: []bool{true, true}, input: "helloworld", data: []string{"hElLo", "w"}},

--- a/internal/expr/parser_helper_test.go
+++ b/internal/expr/parser_helper_test.go
@@ -34,7 +34,11 @@ func (s *ExprInternalSuite) TestRunTable(c *C) {
 		{stringf0: p.skipBlanks, result: []bool{true}, input: "     abcd", data: []string{}},
 		{stringf0: p.skipBlanks, result: []bool{true}, input: "  \t  abcd", data: []string{}},
 		{stringf0: p.skipBlanks, result: []bool{true}, input: "\t  abcd", data: []string{}},
-		{stringf0: p.skipBlanks, result: []bool{true}, input: "\n\t  abcd", data: []string{}},
+		{stringf0: p.skipBlanks, result: []bool{true}, input: "\n  abcd", data: []string{}},
+		{stringf0: p.skipBlanks, result: []bool{true}, input: "\r  abcd", data: []string{}},
+		{stringf0: p.skipBlanks, result: []bool{true}, input: "\n\r  abcd", data: []string{}},
+		{stringf0: p.skipBlanks, result: []bool{true}, input: "\n\r\t  abcd", data: []string{}},
+		{stringf0: p.skipBlanks, result: []bool{true}, input: "   \n\r\t  abcd", data: []string{}},
 
 		{stringf: p.skipString, result: []bool{false}, input: "", data: []string{"a"}},
 		{stringf: p.skipString, result: []bool{true, true}, input: "helloworld", data: []string{"hElLo", "w"}},


### PR DESCRIPTION
Expand `skipSpaces` so it handles new lines and tabs. This will be useful since queries in code tend to be indented for clarity. Since it now handles more than spaces, rename the function to `skipBlanks`