### PR TITLE
Add Prepare stage for inputs

### DIFF
--- a/internal/expr/expr_test.go
+++ b/internal/expr/expr_test.go
@@ -357,7 +357,7 @@ func (s *ExprSuite) TestMismatchedInputStructName(c *C) {
 	parser := expr.NewParser()
 	parsedExpr, err := parser.Parse(sql)
 	_, err = parsedExpr.Prepare(Person{ID: 1}, Manager{})
-	c.Assert(err, ErrorMatches, `cannot prepare expression: type Address unknown, have: Person, Manager`)
+	c.Assert(err, ErrorMatches, `cannot prepare expression: type Address unknown, have: Manager, Person`)
 }
 
 func (s *ExprSuite) TestMissingTagInput(c *C) {

--- a/internal/expr/expr_test.go
+++ b/internal/expr/expr_test.go
@@ -356,8 +356,8 @@ func (s *ExprSuite) TestMismatchedInputStructName(c *C) {
 	sql := "SELECT street FROM t WHERE x = $Address.street"
 	parser := expr.NewParser()
 	parsedExpr, err := parser.Parse(sql)
-	_, err = parsedExpr.Prepare(Person{ID: 1})
-	c.Assert(err, ErrorMatches, `cannot prepare expression: unknown type: "Address"`)
+	_, err = parsedExpr.Prepare(Person{ID: 1}, Manager{})
+	c.Assert(err, ErrorMatches, `cannot prepare expression: type Address unknown, have: Person, Manager`)
 }
 
 func (s *ExprSuite) TestMissingTagInput(c *C) {
@@ -365,5 +365,5 @@ func (s *ExprSuite) TestMissingTagInput(c *C) {
 	parser := expr.NewParser()
 	parsedExpr, err := parser.Parse(sql)
 	_, err = parsedExpr.Prepare(Address{ID: 1})
-	c.Assert(err, ErrorMatches, `cannot prepare expression: no tag with name "number" in "Address"`)
+	c.Assert(err, ErrorMatches, `cannot prepare expression: type Address has no "number" db tag`)
 }

--- a/internal/expr/expr_test.go
+++ b/internal/expr/expr_test.go
@@ -15,7 +15,9 @@ type ExprSuite struct{}
 var _ = Suite(&ExprSuite{})
 
 type Address struct {
-	ID int `db:"id"`
+	ID       int    `db:"id"`
+	District string `db:"district"`
+	Street   string `db:"street"`
 }
 
 type Person struct {
@@ -322,4 +324,46 @@ func FuzzParser(f *testing.F) {
 		parser := expr.NewParser()
 		parser.Parse(s)
 	})
+}
+
+func (s *ExprSuite) TestValidPrepare(c *C) {
+	testList := []struct {
+		input            string
+		prepareArgs      []any
+		expectedPrepared string
+	}{{
+		"SELECT street FROM t WHERE x = $Address.street",
+		[]any{Address{}},
+		"SELECT street FROM t WHERE x = ?",
+	}, {
+		"SELECT p FROM t WHERE x = $Person.id",
+		[]any{Person{}},
+		"SELECT p FROM t WHERE x = ?",
+	}}
+	for _, test := range testList {
+		parser := expr.NewParser()
+		parsedExpr, _ := parser.Parse(test.input)
+		preparedExpr, err := parsedExpr.Prepare(test.prepareArgs...)
+
+		if err != nil {
+			c.Fatal(err)
+		}
+		c.Assert(preparedExpr.SQL, Equals, test.expectedPrepared)
+	}
+}
+
+func (s *ExprSuite) TestMismatchedInputStructName(c *C) {
+	sql := "SELECT street FROM t WHERE x = $Address.street"
+	parser := expr.NewParser()
+	parsedExpr, err := parser.Parse(sql)
+	_, err = parsedExpr.Prepare(Person{ID: 1})
+	c.Assert(err, ErrorMatches, `cannot prepare expression: unknown type: "Address"`)
+}
+
+func (s *ExprSuite) TestMissingTagInput(c *C) {
+	sql := "SELECT street FROM t WHERE x = $Address.number"
+	parser := expr.NewParser()
+	parsedExpr, err := parser.Parse(sql)
+	_, err = parsedExpr.Prepare(Address{ID: 1})
+	c.Assert(err, ErrorMatches, `cannot prepare expression: no tag with name "number" in "Address"`)
 }

--- a/internal/expr/parts.go
+++ b/internal/expr/parts.go
@@ -9,8 +9,8 @@ type queryPart interface {
 	// String returns the part's representation for debugging purposes.
 	String() string
 
-	// ToSQL returns the SQL representation of the part.
-	toSQL() string
+	// marker method
+	part()
 }
 
 // FullName represents a table column or a Go type identifier.
@@ -37,9 +37,7 @@ func (p *inputPart) String() string {
 	return fmt.Sprintf("Input[%+v]", p.source)
 }
 
-func (p *inputPart) toSQL() string {
-	return "?"
-}
+func (p *inputPart) part() {}
 
 // outputPart represents a named target output variable in the SQL expression,
 // as well as the source table and column where it will be read from.
@@ -52,9 +50,7 @@ func (p *outputPart) String() string {
 	return fmt.Sprintf("Output[%+v %+v]", p.source, p.target)
 }
 
-func (p *outputPart) toSQL() string {
-	return ""
-}
+func (p *outputPart) part() {}
 
 // bypassPart represents a part of the expression that we want to pass to the
 // backend database verbatim.
@@ -66,6 +62,4 @@ func (p *bypassPart) String() string {
 	return "Bypass[" + p.chunk + "]"
 }
 
-func (p *bypassPart) toSQL() string {
-	return p.chunk
-}
+func (p *bypassPart) part() {}

--- a/internal/expr/parts.go
+++ b/internal/expr/parts.go
@@ -38,7 +38,7 @@ func (p *inputPart) String() string {
 }
 
 func (p *inputPart) toSQL() string {
-	return ""
+	return "?"
 }
 
 // outputPart represents a named target output variable in the SQL expression,

--- a/internal/expr/prepare.go
+++ b/internal/expr/prepare.go
@@ -3,6 +3,7 @@ package expr
 import (
 	"bytes"
 	"fmt"
+	"sort"
 	"strings"
 )
 
@@ -21,6 +22,7 @@ func getKeys(m map[string]*info) []string {
 		keys[i] = k
 		i++
 	}
+	sort.Strings(keys)
 	return keys
 }
 
@@ -78,7 +80,7 @@ func (pe *ParsedExpr) Prepare(args ...any) (expr *PreparedExpr, err error) {
 		case *bypassPart:
 			sql.WriteString(p.chunk)
 		default:
-			return nil, fmt.Errorf("internal error")
+			return nil, fmt.Errorf("internal error: unknown query part type %T", part)
 		}
 	}
 

--- a/internal/expr/prepare.go
+++ b/internal/expr/prepare.go
@@ -1,0 +1,73 @@
+package expr
+
+import (
+	"bytes"
+	"fmt"
+)
+
+// PreparedExpr contains an SQL expression that is ready for execution.
+type PreparedExpr struct {
+	ParsedExpr *ParsedExpr
+	SQL        string
+}
+
+type typeNameToInfo map[string]*info
+
+// prepareInput checks that the input expression corresponds to a known type.
+func prepareInput(ti typeNameToInfo, p *inputPart) error {
+	inf, ok := ti[p.source.prefix]
+	if !ok {
+		return fmt.Errorf(`unknown type: "%s"`, p.source.prefix)
+	}
+
+	if _, ok = inf.tagToField[p.source.name]; !ok {
+		return fmt.Errorf(`no tag with name "%s" in "%s"`,
+			p.source.name, inf.structType.Name())
+	}
+
+	return nil
+}
+
+// Prepare takes a parsed expression and all the Go objects mentioned in it.
+// The IO parts of the statement are checked for validity against the types
+// and expanded if necessary.
+func (pe *ParsedExpr) Prepare(args ...any) (expr *PreparedExpr, err error) {
+	defer func() {
+		if err != nil {
+			err = fmt.Errorf("cannot prepare expression: %s", err)
+		}
+	}()
+
+	var ti = make(typeNameToInfo)
+
+	// Generate and save reflection info.
+	for _, arg := range args {
+		inf, err := typeInfo(arg)
+		if err != nil {
+			return nil, err
+		}
+		ti[inf.structType.Name()] = inf
+	}
+
+	var sql bytes.Buffer
+	// Check and expand each query part.
+	for _, part := range pe.queryParts {
+		if p, ok := part.(*inputPart); ok {
+			err := prepareInput(ti, p)
+			if err != nil {
+				return nil, err
+			}
+			sql.WriteString(p.toSQL())
+			continue
+		}
+		if p, ok := part.(*outputPart); ok {
+			// Do nothing for now.
+			sql.WriteString(p.toSQL())
+			continue
+		}
+		p := part.(*bypassPart)
+		sql.WriteString(p.toSQL())
+	}
+
+	return &PreparedExpr{ParsedExpr: pe, SQL: sql.String()}, nil
+}


### PR DESCRIPTION
This PR contains the Prepare stage for input parts. In the prepare stage the user passes instantiations of every Go struct that is mentioned in an input or output expression. These objects are used only for information about their type, the actual values inside the structs are irrelevant. 

The `prepareInput` function checks that the structs and tags mentioned in IO expressions in the query correspond to the types of the objects passed as arguments to `Prepare`.

This PR is an updated version of #24 which was a draft PR. However since the name of the branch needed changing this PR has been created.