### PR TITLE
Add Prepare stage for outputs

### DIFF
--- a/internal/expr/expr_test.go
+++ b/internal/expr/expr_test.go
@@ -538,7 +538,7 @@ func (s *ExprSuite) TestPrepareMixedTypes(c *C) {
 			c.Fatal(err)
 		}
 		_, err = parsedExpr.Prepare(test.structs...)
-		c.Assert(err, ErrorMatches, "cannot prepare expression: multiple types in single output expression",
+		c.Assert(err, ErrorMatches, "cannot prepare expression: multiple target types in: .*",
 			Commentf("test %d failed:\nsql: '%s'\nstructs:'%+v'", i, test.sql, test.structs))
 	}
 }
@@ -565,7 +565,7 @@ func (s *ExprSuite) TestPrepareAsteriskMix(c *C) {
 			c.Fatal(err)
 		}
 		_, err = parsedExpr.Prepare(test.structs...)
-		c.Assert(err, ErrorMatches, "cannot prepare expression: invalid mix of asterisk and none asterisk columns in output expression",
+		c.Assert(err, ErrorMatches, "cannot prepare expression: invalid asterisk columns in: .*",
 			Commentf("test %d failed:\nsql: '%s'\nstructs:'%+v'", i, test.sql, test.structs))
 	}
 }
@@ -589,7 +589,7 @@ func (s *ExprSuite) TestPrepareMismatchedColsAndTargs(c *C) {
 			c.Fatal(err)
 		}
 		_, err = parsedExpr.Prepare(test.structs...)
-		c.Assert(err, ErrorMatches, "cannot prepare expression: mismatched number of cols and targets in output expression",
+		c.Assert(err, ErrorMatches, "cannot prepare expression: mismatched number of cols and targets in: .*",
 			Commentf("test %d failed:\nsql: '%s'\nstructs:'%+v'", i, test.sql, test.structs))
 	}
 }

--- a/internal/expr/expr_test.go
+++ b/internal/expr/expr_test.go
@@ -46,13 +46,13 @@ var tests = []struct {
 	"SELECT p.* AS &Person.*",
 	"[Bypass[SELECT ] Output[[p.*] [Person.*]]]",
 	[]any{Person{}},
-	"SELECT p.address_id AS [a-zA-Z_0-9]+, p.id AS [a-zA-Z_0-9]+, p.name AS [a-zA-Z_0-9]+",
+	"SELECT p.address_id AS _sqlair_0, p.id AS _sqlair_1, p.name AS _sqlair_2",
 }, {
 	"spaces and tabs",
 	"SELECT p.* 	AS 		   &Person.*",
 	"[Bypass[SELECT ] Output[[p.*] [Person.*]]]",
 	[]any{Person{}},
-	"SELECT p.address_id AS [a-zA-Z_0-9]+, p.id AS [a-zA-Z_0-9]+, p.name AS [a-zA-Z_0-9]+",
+	"SELECT p.address_id AS _sqlair_0, p.id AS _sqlair_1, p.name AS _sqlair_2",
 }, {
 	"new lines",
 	`SELECT
@@ -73,7 +73,7 @@ var tests = []struct {
 		x = y]]`,
 	[]any{Person{}},
 	`SELECT
-		p.address_id AS [a-zA-Z_0-9]+, p.id AS [a-zA-Z_0-9]+, p.name AS [a-zA-Z_0-9]+,
+		p.address_id AS _sqlair_0, p.id AS _sqlair_1, p.name AS _sqlair_2,
 		foo
 	 FROM t
 	 WHERE
@@ -85,97 +85,103 @@ var tests = []struct {
 	"SELECT p.* AS &Person.*, '&notAnOutputExpresion.*' AS literal FROM t",
 	"[Bypass[SELECT ] Output[[p.*] [Person.*]] Bypass[, '&notAnOutputExpresion.*' AS literal FROM t]]",
 	[]any{Person{}},
-	"SELECT p.address_id AS [a-zA-Z_0-9]+, p.id AS [a-zA-Z_0-9]+, p.name AS [a-zA-Z_0-9]+, '&notAnOutputExpresion.*' AS literal FROM t",
+	"SELECT p.address_id AS _sqlair_0, p.id AS _sqlair_1, p.name AS _sqlair_2, '&notAnOutputExpresion.*' AS literal FROM t",
 }, {
 	"quoted input expression",
 	"SELECT foo FROM t WHERE bar = '$NotAn.input'",
 	"[Bypass[SELECT foo FROM t WHERE bar = '$NotAn.input']]",
 	[]any{},
-	`SELECT foo FROM t WHERE bar = '\$NotAn\.input'`,
+	`SELECT foo FROM t WHERE bar = '$NotAn.input'`,
 }, {
 	"star as output",
 	"SELECT * AS &Person.* FROM t",
 	"[Bypass[SELECT ] Output[[*] [Person.*]] Bypass[ FROM t]]",
 	[]any{Person{}},
-	"SELECT address_id AS [a-zA-Z_0-9]+, id AS [a-zA-Z_0-9]+, name AS [a-zA-Z_0-9]+ FROM t",
+	"SELECT address_id AS _sqlair_0, id AS _sqlair_1, name AS _sqlair_2 FROM t",
 }, {
 	"input v1",
 	"SELECT foo, bar FROM table WHERE foo = $Person.id",
 	"[Bypass[SELECT foo, bar FROM table WHERE foo = ] Input[Person.id]]",
 	[]any{Person{}},
-	`SELECT foo, bar FROM table WHERE foo = \?`,
+	`SELECT foo, bar FROM table WHERE foo = ?`,
 }, {
 	"input v2",
 	"SELECT p FROM person WHERE p.name = $Person.name",
 	"[Bypass[SELECT p FROM person WHERE p.name = ] Input[Person.name]]",
 	[]any{Person{}},
-	`SELECT p FROM person WHERE p.name = \?`,
+	`SELECT p FROM person WHERE p.name = ?`,
 }, {
 	"input v3",
 	"SELECT p.*, a.district FROM person AS p JOIN address AS a ON p.address_id = a.id WHERE p.name = $Person.name",
 	"[Bypass[SELECT p.*, a.district FROM person AS p JOIN address AS a ON p.address_id = a.id WHERE p.name = ] Input[Person.name]]",
 	[]any{Person{}},
-	`SELECT p.*, a.district FROM person AS p JOIN address AS a ON p.address_id = a.id WHERE p.name = \?`,
+	`SELECT p.*, a.district FROM person AS p JOIN address AS a ON p.address_id = a.id WHERE p.name = ?`,
 }, {
 	"output and input",
 	"SELECT &Person.* FROM table WHERE foo = $Address.id",
 	"[Bypass[SELECT ] Output[[] [Person.*]] Bypass[ FROM table WHERE foo = ] Input[Address.id]]",
 	[]any{Person{}, Address{}},
-	`SELECT address_id AS [a-zA-Z_0-9]+, id AS [a-zA-Z_0-9]+, name AS [a-zA-Z_0-9]+ FROM table WHERE foo = \?`,
+	`SELECT address_id AS _sqlair_0, id AS _sqlair_1, name AS _sqlair_2 FROM table WHERE foo = ?`,
 }, {
 	"output and quote",
 	"SELECT foo, bar, &Person.id FROM table WHERE foo = 'xx'",
 	"[Bypass[SELECT foo, bar, ] Output[[] [Person.id]] Bypass[ FROM table WHERE foo = 'xx']]",
 	[]any{Person{}},
-	"SELECT foo, bar, id AS [a-zA-Z_0-9]+ FROM table WHERE foo = 'xx'",
+	"SELECT foo, bar, id AS _sqlair_0 FROM table WHERE foo = 'xx'",
 }, {
 	"two outputs and quote",
 	"SELECT foo, &Person.id, bar, baz, &Manager.manager_name FROM table WHERE foo = 'xx'",
 	"[Bypass[SELECT foo, ] Output[[] [Person.id]] Bypass[, bar, baz, ] Output[[] [Manager.manager_name]] Bypass[ FROM table WHERE foo = 'xx']]",
 	[]any{Person{}, Manager{}},
-	"SELECT foo, id AS [a-zA-Z_0-9]+, bar, baz, manager_name AS [a-zA-Z_0-9]+ FROM table WHERE foo = 'xx'",
+	"SELECT foo, id AS _sqlair_0, bar, baz, manager_name AS _sqlair_1 FROM table WHERE foo = 'xx'",
 }, {
 	"star as output and quote",
 	"SELECT * AS &Person.* FROM person WHERE name = 'Fred'",
 	"[Bypass[SELECT ] Output[[*] [Person.*]] Bypass[ FROM person WHERE name = 'Fred']]",
 	[]any{Person{}},
-	"SELECT address_id AS [a-zA-Z_0-9]+, id AS [a-zA-Z_0-9]+, name AS [a-zA-Z_0-9]+ FROM person WHERE name = 'Fred'",
+	"SELECT address_id AS _sqlair_0, id AS _sqlair_1, name AS _sqlair_2 FROM person WHERE name = 'Fred'",
 }, {
 	"star output and quote",
 	"SELECT &Person.* FROM person WHERE name = 'Fred'",
 	"[Bypass[SELECT ] Output[[] [Person.*]] Bypass[ FROM person WHERE name = 'Fred']]",
 	[]any{Person{}},
-	"SELECT address_id AS [a-zA-Z_0-9]+, id AS [a-zA-Z_0-9]+, name AS [a-zA-Z_0-9]+ FROM person WHERE name = 'Fred'",
+	"SELECT address_id AS _sqlair_0, id AS _sqlair_1, name AS _sqlair_2 FROM person WHERE name = 'Fred'",
 }, {
 	"two star as outputs and quote",
 	"SELECT * AS &Person.*, a.* AS &Address.* FROM person, address a WHERE name = 'Fred'",
 	"[Bypass[SELECT ] Output[[*] [Person.*]] Bypass[, ] Output[[a.*] [Address.*]] Bypass[ FROM person, address a WHERE name = 'Fred']]",
 	[]any{Person{}, Address{}},
-	"SELECT address_id AS [a-zA-Z_0-9]+, id AS [a-zA-Z_0-9]+, name AS [a-zA-Z_0-9]+, a.district AS [a-zA-Z_0-9]+, a.id AS [a-zA-Z_0-9]+, a.street AS [a-zA-Z_0-9]+ FROM person, address a WHERE name = 'Fred'",
+	"SELECT address_id AS _sqlair_0, id AS _sqlair_1, name AS _sqlair_2, a.district AS _sqlair_3, a.id AS _sqlair_4, a.street AS _sqlair_5 FROM person, address a WHERE name = 'Fred'",
 }, {
 	"multicolumn output v1",
 	"SELECT (a.district, a.street) AS (&Address.district, &Address.street) FROM address AS a",
 	"[Bypass[SELECT ] Output[[a.district a.street] [Address.district Address.street]] Bypass[ FROM address AS a]]",
 	[]any{Address{}, District{}},
-	"SELECT a.district AS [a-zA-Z_0-9]+, a.street AS [a-zA-Z_0-9]+ FROM address AS a",
+	"SELECT a.district AS _sqlair_0, a.street AS _sqlair_1 FROM address AS a",
 }, {
 	"multicolumn output v2",
 	"SELECT (a.district, a.street) AS (&Address.district, &Address.street), a.id AS &Person.id FROM address AS a",
 	"[Bypass[SELECT ] Output[[a.district a.street] [Address.district Address.street]] Bypass[, ] Output[[a.id] [Person.id]] Bypass[ FROM address AS a]]",
 	[]any{Person{}, Address{}},
-	"SELECT a.district AS [a-zA-Z_0-9]+, a.street AS [a-zA-Z_0-9]+, a.id AS [a-zA-Z_0-9]+ FROM address AS a",
+	"SELECT a.district AS _sqlair_0, a.street AS _sqlair_1, a.id AS _sqlair_2 FROM address AS a",
 }, {
 	"multicolumn output v3",
-	"SELECT (a.district, a.street) AS (&Address.district, &Address.street), &Person.* FROM address AS a",
-	"[Bypass[SELECT ] Output[[a.district a.street] [Address.district Address.street]] Bypass[, ] Output[[] [Person.*]] Bypass[ FROM address AS a]]",
+	"SELECT (a.district, a.id) AS (&Address.district, &Person.address_id) FROM address AS a",
+	"[Bypass[SELECT ] Output[[a.district a.id] [Address.district Person.address_id]] Bypass[ FROM address AS a]]",
 	[]any{Person{}, Address{}},
-	"SELECT a.district AS [a-zA-Z_0-9]+, a.street AS [a-zA-Z_0-9]+, address_id AS [a-zA-Z_0-9]+, id AS [a-zA-Z_0-9]+, name AS [a-zA-Z_0-9]+ FROM address AS a",
+	"SELECT a.district AS _sqlair_0, a.id AS _sqlair_1 FROM address AS a",
 }, {
 	"multicolumn output v4",
 	"SELECT (a.district, a.street) AS &Address.* FROM address AS a WHERE p.name = 'Fred'",
 	"[Bypass[SELECT ] Output[[a.district a.street] [Address.*]] Bypass[ FROM address AS a WHERE p.name = 'Fred']]",
 	[]any{Address{}},
-	"SELECT a.district AS [a-zA-Z_0-9]+, a.street AS [a-zA-Z_0-9]+ FROM address AS a WHERE p.name = 'Fred'",
+	"SELECT a.district AS _sqlair_0, a.street AS _sqlair_1 FROM address AS a WHERE p.name = 'Fred'",
+}, {
+	"multicolumn output v5",
+	"SELECT (&Address.street, &Person.id) FROM address AS a WHERE p.name = 'Fred'",
+	"[Bypass[SELECT ] Output[[] [Address.street Person.id]] Bypass[ FROM address AS a WHERE p.name = 'Fred']]",
+	[]any{Address{}, Person{}},
+	"SELECT street AS _sqlair_0, id AS _sqlair_1 FROM address AS a WHERE p.name = 'Fred'",
 }, {
 	"quote",
 	"SELECT 1 FROM person WHERE p.name = 'Fred'",
@@ -187,43 +193,43 @@ var tests = []struct {
 	"SELECT p.* AS &Person.*, (a.district, a.street) AS &Address.*, (5+7), (col1 * col2) AS calculated_value FROM person AS p JOIN address AS a ON p.address_id = a.id WHERE p.name = 'Fred'",
 	"[Bypass[SELECT ] Output[[p.*] [Person.*]] Bypass[, ] Output[[a.district a.street] [Address.*]] Bypass[, (5+7), (col1 * col2) AS calculated_value FROM person AS p JOIN address AS a ON p.address_id = a.id WHERE p.name = 'Fred']]",
 	[]any{Person{}, Address{}},
-	`SELECT p.address_id AS [a-zA-Z_0-9]+, p.id AS [a-zA-Z_0-9]+, p.name AS [a-zA-Z_0-9]+, a.district AS [a-zA-Z_0-9]+, a.street AS [a-zA-Z_0-9]+, \(5\+7\), \(col1 \* col2\) AS calculated_value FROM person AS p JOIN address AS a ON p.address_id = a.id WHERE p.name = 'Fred'`,
+	`SELECT p.address_id AS _sqlair_0, p.id AS _sqlair_1, p.name AS _sqlair_2, a.district AS _sqlair_3, a.street AS _sqlair_4, (5+7), (col1 * col2) AS calculated_value FROM person AS p JOIN address AS a ON p.address_id = a.id WHERE p.name = 'Fred'`,
 }, {
 	"complex query v2",
 	"SELECT p.* AS &Person.*, (a.district, a.street) AS &Address.* FROM person AS p JOIN address AS a ON p .address_id = a.id WHERE p.name = 'Fred'",
 	"[Bypass[SELECT ] Output[[p.*] [Person.*]] Bypass[, ] Output[[a.district a.street] [Address.*]] Bypass[ FROM person AS p JOIN address AS a ON p .address_id = a.id WHERE p.name = 'Fred']]",
 	[]any{Person{}, Address{}},
-	"SELECT p.address_id AS [a-zA-Z_0-9]+, p.id AS [a-zA-Z_0-9]+, p.name AS [a-zA-Z_0-9]+, a.district AS [a-zA-Z_0-9]+, a.street AS [a-zA-Z_0-9]+ FROM person AS p JOIN address AS a ON p .address_id = a.id WHERE p.name = 'Fred'",
+	"SELECT p.address_id AS _sqlair_0, p.id AS _sqlair_1, p.name AS _sqlair_2, a.district AS _sqlair_3, a.street AS _sqlair_4 FROM person AS p JOIN address AS a ON p .address_id = a.id WHERE p.name = 'Fred'",
 }, {
 	"complex query v3",
 	"SELECT p.* AS &Person.*, (a.district, a.street) AS &Address.* FROM person AS p JOIN address AS a ON p.address_id = a.id WHERE p.name IN (SELECT name FROM table WHERE table.n = $Person.name)",
 	"[Bypass[SELECT ] Output[[p.*] [Person.*]] Bypass[, ] Output[[a.district a.street] [Address.*]] Bypass[ FROM person AS p JOIN address AS a ON p.address_id = a.id WHERE p.name IN (SELECT name FROM table WHERE table.n = ] Input[Person.name] Bypass[)]]",
 	[]any{Person{}, Address{}},
-	`SELECT p.address_id AS [a-zA-Z_0-9]+, p.id AS [a-zA-Z_0-9]+, p.name AS [a-zA-Z_0-9]+, a.district AS [a-zA-Z_0-9]+, a.street AS [a-zA-Z_0-9]+ FROM person AS p JOIN address AS a ON p.address_id = a.id WHERE p.name IN \(SELECT name FROM table WHERE table.n = \?\)`,
+	`SELECT p.address_id AS _sqlair_0, p.id AS _sqlair_1, p.name AS _sqlair_2, a.district AS _sqlair_3, a.street AS _sqlair_4 FROM person AS p JOIN address AS a ON p.address_id = a.id WHERE p.name IN (SELECT name FROM table WHERE table.n = ?)`,
 }, {
 	"complex query v4",
 	"SELECT p.* AS &Person.*, (a.district, a.street) AS &Address.* FROM person WHERE p.name IN (SELECT name FROM table WHERE table.n = $Person.name) UNION SELECT p.* AS &Person.*, (a.district, a.street) AS &Address.* FROM person WHERE p.name IN (SELECT name FROM table WHERE table.n = $Person.name)",
 	"[Bypass[SELECT ] Output[[p.*] [Person.*]] Bypass[, ] Output[[a.district a.street] [Address.*]] Bypass[ FROM person WHERE p.name IN (SELECT name FROM table WHERE table.n = ] Input[Person.name] Bypass[) UNION SELECT ] Output[[p.*] [Person.*]] Bypass[, ] Output[[a.district a.street] [Address.*]] Bypass[ FROM person WHERE p.name IN (SELECT name FROM table WHERE table.n = ] Input[Person.name] Bypass[)]]",
 	[]any{Person{}, Address{}},
-	`SELECT p.address_id AS [a-zA-Z_0-9]+, p.id AS [a-zA-Z_0-9]+, p.name AS [a-zA-Z_0-9]+, a.district AS [a-zA-Z_0-9]+, a.street AS [a-zA-Z_0-9]+ FROM person WHERE p.name IN \(SELECT name FROM table WHERE table.n = \?\) UNION SELECT p.address_id AS [a-zA-Z_0-9]+, p.id AS [a-zA-Z_0-9]+, p.name AS [a-zA-Z_0-9]+, a.district AS [a-zA-Z_0-9]+, a.street AS [a-zA-Z_0-9]+ FROM person WHERE p.name IN \(SELECT name FROM table WHERE table.n = \?\)`,
+	`SELECT p.address_id AS _sqlair_0, p.id AS _sqlair_1, p.name AS _sqlair_2, a.district AS _sqlair_3, a.street AS _sqlair_4 FROM person WHERE p.name IN (SELECT name FROM table WHERE table.n = ?) UNION SELECT p.address_id AS _sqlair_5, p.id AS _sqlair_6, p.name AS _sqlair_7, a.district AS _sqlair_8, a.street AS _sqlair_9 FROM person WHERE p.name IN (SELECT name FROM table WHERE table.n = ?)`,
 }, {
 	"complex query v5",
 	"SELECT p.* AS &Person.*, &District.* FROM person AS p JOIN address AS a ON p.address_id = a.id WHERE p.name = $Person.name AND p.address_id = $Person.address_id",
 	"[Bypass[SELECT ] Output[[p.*] [Person.*]] Bypass[, ] Output[[] [District.*]] Bypass[ FROM person AS p JOIN address AS a ON p.address_id = a.id WHERE p.name = ] Input[Person.name] Bypass[ AND p.address_id = ] Input[Person.address_id]]",
 	[]any{Person{}, District{}},
-	`SELECT p.address_id AS [a-zA-Z_0-9]+, p.id AS [a-zA-Z_0-9]+, p.name AS [a-zA-Z_0-9]+,  FROM person AS p JOIN address AS a ON p.address_id = a.id WHERE p.name = \? AND p.address_id = \?`,
+	`SELECT p.address_id AS _sqlair_0, p.id AS _sqlair_1, p.name AS _sqlair_2,  FROM person AS p JOIN address AS a ON p.address_id = a.id WHERE p.name = ? AND p.address_id = ?`,
 }, {
 	"complex query v6",
 	"SELECT p.* AS &Person.*, FROM person AS p INNER JOIN address AS a ON p.address_id = $Address.id WHERE p.name = $Person.name AND p.address_id = $Person.address_id",
 	"[Bypass[SELECT ] Output[[p.*] [Person.*]] Bypass[, FROM person AS p INNER JOIN address AS a ON p.address_id = ] Input[Address.id] Bypass[ WHERE p.name = ] Input[Person.name] Bypass[ AND p.address_id = ] Input[Person.address_id]]",
 	[]any{Person{}, Address{}},
-	`SELECT p.address_id AS [a-zA-Z_0-9]+, p.id AS [a-zA-Z_0-9]+, p.name AS [a-zA-Z_0-9]+, FROM person AS p INNER JOIN address AS a ON p.address_id = \? WHERE p.name = \? AND p.address_id = \?`,
+	`SELECT p.address_id AS _sqlair_0, p.id AS _sqlair_1, p.name AS _sqlair_2, FROM person AS p INNER JOIN address AS a ON p.address_id = ? WHERE p.name = ? AND p.address_id = ?`,
 }, {
 	"join v1",
 	"SELECT p.* AS &Person.*, m.* AS &Manager.* FROM person AS p JOIN person AS m ON p.manager_id = m.id WHERE p.name = 'Fred'",
 	"[Bypass[SELECT ] Output[[p.*] [Person.*]] Bypass[, ] Output[[m.*] [Manager.*]] Bypass[ FROM person AS p JOIN person AS m ON p.manager_id = m.id WHERE p.name = 'Fred']]",
 	[]any{Person{}, Manager{}},
-	"SELECT p.address_id AS [a-zA-Z_0-9]+, p.id AS [a-zA-Z_0-9]+, p.name AS [a-zA-Z_0-9]+, m.manager_name AS [a-zA-Z_0-9]+ FROM person AS p JOIN person AS m ON p.manager_id = m.id WHERE p.name = 'Fred'",
+	"SELECT p.address_id AS _sqlair_0, p.id AS _sqlair_1, p.name AS _sqlair_2, m.manager_name AS _sqlair_3 FROM person AS p JOIN person AS m ON p.manager_id = m.id WHERE p.name = 'Fred'",
 }, {
 	"join v2",
 	"SELECT person.*, address.district FROM person JOIN address ON person.address_id = address.id WHERE person.name = 'Fred'",
@@ -235,31 +241,31 @@ var tests = []struct {
 	"INSERT INTO person (name) VALUES $Person.name",
 	"[Bypass[INSERT INTO person (name) VALUES ] Input[Person.name]]",
 	[]any{Person{}},
-	`INSERT INTO person \(name\) VALUES \?`,
+	`INSERT INTO person (name) VALUES ?`,
 }, {
 	"ignore dollar v1",
 	"SELECT $ FROM moneytable",
 	"[Bypass[SELECT $ FROM moneytable]]",
 	[]any{},
-	`SELECT \$ FROM moneytable`,
+	`SELECT $ FROM moneytable`,
 }, {
 	"ignore dollar v2",
 	"SELECT foo FROM data$",
 	"[Bypass[SELECT foo FROM data$]]",
 	[]any{},
-	`SELECT foo FROM data\$`,
+	`SELECT foo FROM data$`,
 }, {
 	"ignore dollar v3",
 	"SELECT dollerrow$ FROM moneytable",
 	"[Bypass[SELECT dollerrow$ FROM moneytable]]",
 	[]any{},
-	`SELECT dollerrow\$ FROM moneytable`,
+	`SELECT dollerrow$ FROM moneytable`,
 }, {
 	"input with no space",
 	"SELECT p.*, a.district FROM person AS p WHERE p.name=$Person.name",
 	"[Bypass[SELECT p.*, a.district FROM person AS p WHERE p.name=] Input[Person.name]]",
 	[]any{Person{}},
-	`SELECT p.*, a.district FROM person AS p WHERE p.name=\?`,
+	`SELECT p.*, a.district FROM person AS p WHERE p.name=?`,
 }, {
 	"escaped double quote",
 	`SELECT foo FROM t WHERE t.p = "Jimmy ""Quickfingers"" Jones"`,
@@ -277,13 +283,13 @@ var tests = []struct {
 	`SELECT * AS &Person.* FROM person WHERE name IN ('Lorn', 'Onos T''oolan', '', ''' ''');`,
 	`[Bypass[SELECT ] Output[[*] [Person.*]] Bypass[ FROM person WHERE name IN ('Lorn', 'Onos T''oolan', '', ''' ''');]]`,
 	[]any{Person{}},
-	`SELECT address_id AS [a-zA-Z_0-9]+, id AS [a-zA-Z_0-9]+, name AS [a-zA-Z_0-9]+ FROM person WHERE name IN \('Lorn', 'Onos T''oolan', '', ''' '''\);`,
+	`SELECT address_id AS _sqlair_0, id AS _sqlair_1, name AS _sqlair_2 FROM person WHERE name IN ('Lorn', 'Onos T''oolan', '', ''' ''');`,
 }, {
 	"update",
 	"UPDATE person SET person.address_id = $Address.id WHERE person.id = $Person.id",
 	"[Bypass[UPDATE person SET person.address_id = ] Input[Address.id] Bypass[ WHERE person.id = ] Input[Person.id]]",
 	[]any{Person{}, Address{}},
-	`UPDATE person SET person.address_id = \? WHERE person.id = \?`,
+	`UPDATE person SET person.address_id = ? WHERE person.id = ?`,
 }}
 
 func (s *ExprSuite) TestExpr(c *C) {
@@ -303,7 +309,7 @@ func (s *ExprSuite) TestExpr(c *C) {
 		if preparedExpr, err = parsedExpr.Prepare(test.prepareArgs...); err != nil {
 			c.Errorf("test %d failed (Prepare):\nsummary: %s\ninput: %s\nexpected: %s\nerr: %s\n", i, test.summary, test.input, test.expectedPrepared, err)
 		} else {
-			c.Check(preparedExpr.SQL, Matches, test.expectedPrepared,
+			c.Check(preparedExpr.SQL, Equals, test.expectedPrepared,
 				Commentf("test %d failed (Prepare):\nsummary: %s\ninput: %s\nexpected: %s\nactual:   %s\n", i, test.summary, test.input, test.expectedPrepared, preparedExpr.SQL))
 		}
 	}
@@ -407,35 +413,6 @@ func FuzzParser(f *testing.F) {
 	})
 }
 
-func (s *ExprSuite) TestValidPrepare(c *C) {
-	testList := []struct {
-		input            string
-		prepareArgs      []any
-		expectedPrepared string
-	}{{
-		"SELECT street FROM t WHERE x = $Address.street",
-		[]any{Address{}},
-		"SELECT street FROM t WHERE x = ?",
-	}, {
-		"SELECT p FROM t WHERE x = $Person.id",
-		[]any{Person{}},
-		"SELECT p FROM t WHERE x = ?",
-	}}
-	for _, test := range testList {
-		parser := expr.NewParser()
-		parsedExpr, err := parser.Parse(test.input)
-		if err != nil {
-			c.Fatal(err)
-		}
-
-		preparedExpr, err := parsedExpr.Prepare(test.prepareArgs...)
-		if err != nil {
-			c.Fatal(err)
-		}
-		c.Assert(preparedExpr.SQL, Equals, test.expectedPrepared)
-	}
-}
-
 func (s *ExprSuite) TestPrepareMismatchedStructName(c *C) {
 	testList := []struct {
 		sql     string
@@ -515,30 +492,6 @@ func (s *ExprSuite) TestPrepareInvalidAsteriskPlacement(c *C) {
 		}
 		_, err = parsedExpr.Prepare(test.structs...)
 		c.Assert(err, ErrorMatches, "cannot prepare expression: invalid asterisk in output expression: .*",
-			Commentf("test %d failed:\nsql: '%s'\nstructs:'%+v'", i, test.sql, test.structs))
-	}
-}
-
-func (s *ExprSuite) TestPrepareMixedTypes(c *C) {
-	testList := []struct {
-		sql     string
-		structs []any
-	}{{
-		sql:     "SELECT (&Address.street, &Person.id) FROM t",
-		structs: []any{Address{}, Person{}},
-	}, {
-		sql:     "SELECT (name, p.id) AS (&Person.id, &Address.id) FROM t",
-		structs: []any{Address{}, Person{}},
-	}}
-
-	for i, test := range testList {
-		parser := expr.NewParser()
-		parsedExpr, err := parser.Parse(test.sql)
-		if err != nil {
-			c.Fatal(err)
-		}
-		_, err = parsedExpr.Prepare(test.structs...)
-		c.Assert(err, ErrorMatches, "cannot prepare expression: multiple target types in: .*",
 			Commentf("test %d failed:\nsql: '%s'\nstructs:'%+v'", i, test.sql, test.structs))
 	}
 }

--- a/internal/expr/expr_test.go
+++ b/internal/expr/expr_test.go
@@ -36,25 +36,23 @@ type District struct {
 type M map[string]any
 
 var tests = []struct {
-	summary        string
-	input          string
-	expectedParsed string
+	summary          string
+	input            string
+	expectedParsed   string
+	prepareArgs      []any
+	expectedPrepared string
 }{{
 	"star table as output",
 	"SELECT p.* AS &Person.*",
 	"[Bypass[SELECT ] Output[[p.*] [Person.*]]]",
-}, {
-	"multiple-quoted bypass expression",
-	`SELECT '''' AS &Person.*`,
-	`[Bypass[SELECT '''' AS ] Output[[] [Person.*]]]`,
-}, {
-	"single quote in double quotes",
-	`SELECT "'" AS &Person.*`,
-	`[Bypass[SELECT "'" AS ] Output[[] [Person.*]]]`,
+	[]any{Person{}},
+	"SELECT p.address_id AS [a-zA-Z_0-9]+, p.id AS [a-zA-Z_0-9]+, p.name AS [a-zA-Z_0-9]+",
 }, {
 	"spaces and tabs",
 	"SELECT p.* 	AS 		   &Person.*",
 	"[Bypass[SELECT ] Output[[p.*] [Person.*]]]",
+	[]any{Person{}},
+	"SELECT p.address_id AS [a-zA-Z_0-9]+, p.id AS [a-zA-Z_0-9]+, p.name AS [a-zA-Z_0-9]+",
 }, {
 	"new lines",
 	`SELECT
@@ -73,157 +71,240 @@ var tests = []struct {
 		foo = bar
 		and
 		x = y]]`,
+	[]any{Person{}},
+	`SELECT
+		p.address_id AS [a-zA-Z_0-9]+, p.id AS [a-zA-Z_0-9]+, p.name AS [a-zA-Z_0-9]+,
+		foo
+	 FROM t
+	 WHERE
+		foo = bar
+		and
+		x = y`,
 }, {
 	"quoted output expression",
 	"SELECT p.* AS &Person.*, '&notAnOutputExpresion.*' AS literal FROM t",
 	"[Bypass[SELECT ] Output[[p.*] [Person.*]] Bypass[, '&notAnOutputExpresion.*' AS literal FROM t]]",
+	[]any{Person{}},
+	"SELECT p.address_id AS [a-zA-Z_0-9]+, p.id AS [a-zA-Z_0-9]+, p.name AS [a-zA-Z_0-9]+, '&notAnOutputExpresion.*' AS literal FROM t",
 }, {
 	"quoted input expression",
 	"SELECT foo FROM t WHERE bar = '$NotAn.input'",
 	"[Bypass[SELECT foo FROM t WHERE bar = '$NotAn.input']]",
+	[]any{},
+	`SELECT foo FROM t WHERE bar = '\$NotAn\.input'`,
 }, {
 	"star as output",
 	"SELECT * AS &Person.* FROM t",
 	"[Bypass[SELECT ] Output[[*] [Person.*]] Bypass[ FROM t]]",
+	[]any{Person{}},
+	"SELECT address_id AS [a-zA-Z_0-9]+, id AS [a-zA-Z_0-9]+, name AS [a-zA-Z_0-9]+ FROM t",
 }, {
 	"input v1",
 	"SELECT foo, bar FROM table WHERE foo = $Person.id",
 	"[Bypass[SELECT foo, bar FROM table WHERE foo = ] Input[Person.id]]",
+	[]any{Person{}},
+	`SELECT foo, bar FROM table WHERE foo = \?`,
 }, {
 	"input v2",
 	"SELECT p FROM person WHERE p.name = $Person.name",
 	"[Bypass[SELECT p FROM person WHERE p.name = ] Input[Person.name]]",
+	[]any{Person{}},
+	`SELECT p FROM person WHERE p.name = \?`,
 }, {
 	"input v3",
 	"SELECT p.*, a.district FROM person AS p JOIN address AS a ON p.address_id = a.id WHERE p.name = $Person.name",
 	"[Bypass[SELECT p.*, a.district FROM person AS p JOIN address AS a ON p.address_id = a.id WHERE p.name = ] Input[Person.name]]",
+	[]any{Person{}},
+	`SELECT p.*, a.district FROM person AS p JOIN address AS a ON p.address_id = a.id WHERE p.name = \?`,
 }, {
 	"output and input",
 	"SELECT &Person.* FROM table WHERE foo = $Address.id",
 	"[Bypass[SELECT ] Output[[] [Person.*]] Bypass[ FROM table WHERE foo = ] Input[Address.id]]",
-}, {
-	"star output and input",
-	"SELECT &Person.* FROM table WHERE foo = $Address.id",
-	"[Bypass[SELECT ] Output[[] [Person.*]] Bypass[ FROM table WHERE foo = ] Input[Address.id]]",
+	[]any{Person{}, Address{}},
+	`SELECT address_id AS [a-zA-Z_0-9]+, id AS [a-zA-Z_0-9]+, name AS [a-zA-Z_0-9]+ FROM table WHERE foo = \?`,
 }, {
 	"output and quote",
 	"SELECT foo, bar, &Person.id FROM table WHERE foo = 'xx'",
 	"[Bypass[SELECT foo, bar, ] Output[[] [Person.id]] Bypass[ FROM table WHERE foo = 'xx']]",
+	[]any{Person{}},
+	"SELECT foo, bar, id AS [a-zA-Z_0-9]+ FROM table WHERE foo = 'xx'",
 }, {
 	"two outputs and quote",
-	"SELECT foo, &Person.id, bar, baz, &Manager.name FROM table WHERE foo = 'xx'",
-	"[Bypass[SELECT foo, ] Output[[] [Person.id]] Bypass[, bar, baz, ] Output[[] [Manager.name]] Bypass[ FROM table WHERE foo = 'xx']]",
+	"SELECT foo, &Person.id, bar, baz, &Manager.manager_name FROM table WHERE foo = 'xx'",
+	"[Bypass[SELECT foo, ] Output[[] [Person.id]] Bypass[, bar, baz, ] Output[[] [Manager.manager_name]] Bypass[ FROM table WHERE foo = 'xx']]",
+	[]any{Person{}, Manager{}},
+	"SELECT foo, id AS [a-zA-Z_0-9]+, bar, baz, manager_name AS [a-zA-Z_0-9]+ FROM table WHERE foo = 'xx'",
 }, {
 	"star as output and quote",
 	"SELECT * AS &Person.* FROM person WHERE name = 'Fred'",
 	"[Bypass[SELECT ] Output[[*] [Person.*]] Bypass[ FROM person WHERE name = 'Fred']]",
+	[]any{Person{}},
+	"SELECT address_id AS [a-zA-Z_0-9]+, id AS [a-zA-Z_0-9]+, name AS [a-zA-Z_0-9]+ FROM person WHERE name = 'Fred'",
 }, {
 	"star output and quote",
 	"SELECT &Person.* FROM person WHERE name = 'Fred'",
 	"[Bypass[SELECT ] Output[[] [Person.*]] Bypass[ FROM person WHERE name = 'Fred']]",
+	[]any{Person{}},
+	"SELECT address_id AS [a-zA-Z_0-9]+, id AS [a-zA-Z_0-9]+, name AS [a-zA-Z_0-9]+ FROM person WHERE name = 'Fred'",
 }, {
 	"two star as outputs and quote",
 	"SELECT * AS &Person.*, a.* AS &Address.* FROM person, address a WHERE name = 'Fred'",
 	"[Bypass[SELECT ] Output[[*] [Person.*]] Bypass[, ] Output[[a.*] [Address.*]] Bypass[ FROM person, address a WHERE name = 'Fred']]",
+	[]any{Person{}, Address{}},
+	"SELECT address_id AS [a-zA-Z_0-9]+, id AS [a-zA-Z_0-9]+, name AS [a-zA-Z_0-9]+, a.district AS [a-zA-Z_0-9]+, a.id AS [a-zA-Z_0-9]+, a.street AS [a-zA-Z_0-9]+ FROM person, address a WHERE name = 'Fred'",
 }, {
-	"multicolumn output",
+	"multicolumn output v1",
 	"SELECT (a.district, a.street) AS (&Address.district, &Address.street) FROM address AS a",
 	"[Bypass[SELECT ] Output[[a.district a.street] [Address.district Address.street]] Bypass[ FROM address AS a]]",
+	[]any{Address{}, District{}},
+	"SELECT a.district AS [a-zA-Z_0-9]+, a.street AS [a-zA-Z_0-9]+ FROM address AS a",
 }, {
-	"multicolumn output and output",
+	"multicolumn output v2",
 	"SELECT (a.district, a.street) AS (&Address.district, &Address.street), a.id AS &Person.id FROM address AS a",
 	"[Bypass[SELECT ] Output[[a.district a.street] [Address.district Address.street]] Bypass[, ] Output[[a.id] [Person.id]] Bypass[ FROM address AS a]]",
+	[]any{Person{}, Address{}},
+	"SELECT a.district AS [a-zA-Z_0-9]+, a.street AS [a-zA-Z_0-9]+, a.id AS [a-zA-Z_0-9]+ FROM address AS a",
 }, {
-	"multicolumn output and star",
+	"multicolumn output v3",
 	"SELECT (a.district, a.street) AS (&Address.district, &Address.street), &Person.* FROM address AS a",
 	"[Bypass[SELECT ] Output[[a.district a.street] [Address.district Address.street]] Bypass[, ] Output[[] [Person.*]] Bypass[ FROM address AS a]]",
+	[]any{Person{}, Address{}},
+	"SELECT a.district AS [a-zA-Z_0-9]+, a.street AS [a-zA-Z_0-9]+, address_id AS [a-zA-Z_0-9]+, id AS [a-zA-Z_0-9]+, name AS [a-zA-Z_0-9]+ FROM address AS a",
 }, {
-	"multicolumn output and quote",
+	"multicolumn output v4",
 	"SELECT (a.district, a.street) AS &Address.* FROM address AS a WHERE p.name = 'Fred'",
 	"[Bypass[SELECT ] Output[[a.district a.street] [Address.*]] Bypass[ FROM address AS a WHERE p.name = 'Fred']]",
+	[]any{Address{}},
+	"SELECT a.district AS [a-zA-Z_0-9]+, a.street AS [a-zA-Z_0-9]+ FROM address AS a WHERE p.name = 'Fred'",
 }, {
 	"quote",
 	"SELECT 1 FROM person WHERE p.name = 'Fred'",
 	"[Bypass[SELECT 1 FROM person WHERE p.name = 'Fred']]",
+	[]any{},
+	"SELECT 1 FROM person WHERE p.name = 'Fred'",
 }, {
 	"complex query v1",
 	"SELECT p.* AS &Person.*, (a.district, a.street) AS &Address.*, (5+7), (col1 * col2) AS calculated_value FROM person AS p JOIN address AS a ON p.address_id = a.id WHERE p.name = 'Fred'",
 	"[Bypass[SELECT ] Output[[p.*] [Person.*]] Bypass[, ] Output[[a.district a.street] [Address.*]] Bypass[, (5+7), (col1 * col2) AS calculated_value FROM person AS p JOIN address AS a ON p.address_id = a.id WHERE p.name = 'Fred']]",
+	[]any{Person{}, Address{}},
+	`SELECT p.address_id AS [a-zA-Z_0-9]+, p.id AS [a-zA-Z_0-9]+, p.name AS [a-zA-Z_0-9]+, a.district AS [a-zA-Z_0-9]+, a.street AS [a-zA-Z_0-9]+, \(5\+7\), \(col1 \* col2\) AS calculated_value FROM person AS p JOIN address AS a ON p.address_id = a.id WHERE p.name = 'Fred'`,
 }, {
 	"complex query v2",
 	"SELECT p.* AS &Person.*, (a.district, a.street) AS &Address.* FROM person AS p JOIN address AS a ON p .address_id = a.id WHERE p.name = 'Fred'",
 	"[Bypass[SELECT ] Output[[p.*] [Person.*]] Bypass[, ] Output[[a.district a.street] [Address.*]] Bypass[ FROM person AS p JOIN address AS a ON p .address_id = a.id WHERE p.name = 'Fred']]",
+	[]any{Person{}, Address{}},
+	"SELECT p.address_id AS [a-zA-Z_0-9]+, p.id AS [a-zA-Z_0-9]+, p.name AS [a-zA-Z_0-9]+, a.district AS [a-zA-Z_0-9]+, a.street AS [a-zA-Z_0-9]+ FROM person AS p JOIN address AS a ON p .address_id = a.id WHERE p.name = 'Fred'",
 }, {
 	"complex query v3",
 	"SELECT p.* AS &Person.*, (a.district, a.street) AS &Address.* FROM person AS p JOIN address AS a ON p.address_id = a.id WHERE p.name IN (SELECT name FROM table WHERE table.n = $Person.name)",
 	"[Bypass[SELECT ] Output[[p.*] [Person.*]] Bypass[, ] Output[[a.district a.street] [Address.*]] Bypass[ FROM person AS p JOIN address AS a ON p.address_id = a.id WHERE p.name IN (SELECT name FROM table WHERE table.n = ] Input[Person.name] Bypass[)]]",
+	[]any{Person{}, Address{}},
+	`SELECT p.address_id AS [a-zA-Z_0-9]+, p.id AS [a-zA-Z_0-9]+, p.name AS [a-zA-Z_0-9]+, a.district AS [a-zA-Z_0-9]+, a.street AS [a-zA-Z_0-9]+ FROM person AS p JOIN address AS a ON p.address_id = a.id WHERE p.name IN \(SELECT name FROM table WHERE table.n = \?\)`,
 }, {
 	"complex query v4",
 	"SELECT p.* AS &Person.*, (a.district, a.street) AS &Address.* FROM person WHERE p.name IN (SELECT name FROM table WHERE table.n = $Person.name) UNION SELECT p.* AS &Person.*, (a.district, a.street) AS &Address.* FROM person WHERE p.name IN (SELECT name FROM table WHERE table.n = $Person.name)",
 	"[Bypass[SELECT ] Output[[p.*] [Person.*]] Bypass[, ] Output[[a.district a.street] [Address.*]] Bypass[ FROM person WHERE p.name IN (SELECT name FROM table WHERE table.n = ] Input[Person.name] Bypass[) UNION SELECT ] Output[[p.*] [Person.*]] Bypass[, ] Output[[a.district a.street] [Address.*]] Bypass[ FROM person WHERE p.name IN (SELECT name FROM table WHERE table.n = ] Input[Person.name] Bypass[)]]",
+	[]any{Person{}, Address{}},
+	`SELECT p.address_id AS [a-zA-Z_0-9]+, p.id AS [a-zA-Z_0-9]+, p.name AS [a-zA-Z_0-9]+, a.district AS [a-zA-Z_0-9]+, a.street AS [a-zA-Z_0-9]+ FROM person WHERE p.name IN \(SELECT name FROM table WHERE table.n = \?\) UNION SELECT p.address_id AS [a-zA-Z_0-9]+, p.id AS [a-zA-Z_0-9]+, p.name AS [a-zA-Z_0-9]+, a.district AS [a-zA-Z_0-9]+, a.street AS [a-zA-Z_0-9]+ FROM person WHERE p.name IN \(SELECT name FROM table WHERE table.n = \?\)`,
 }, {
 	"complex query v5",
-	"SELECT p.* AS &Person.*, a.district AS &District.* FROM person AS p JOIN address AS a ON p.address_id = a.id WHERE p.name = $Person.name AND p.address_id = $Person.address_id",
-	"[Bypass[SELECT ] Output[[p.*] [Person.*]] Bypass[, ] Output[[a.district] [District.*]] Bypass[ FROM person AS p JOIN address AS a ON p.address_id = a.id WHERE p.name = ] Input[Person.name] Bypass[ AND p.address_id = ] Input[Person.address_id]]",
+	"SELECT p.* AS &Person.*, &District.* FROM person AS p JOIN address AS a ON p.address_id = a.id WHERE p.name = $Person.name AND p.address_id = $Person.address_id",
+	"[Bypass[SELECT ] Output[[p.*] [Person.*]] Bypass[, ] Output[[] [District.*]] Bypass[ FROM person AS p JOIN address AS a ON p.address_id = a.id WHERE p.name = ] Input[Person.name] Bypass[ AND p.address_id = ] Input[Person.address_id]]",
+	[]any{Person{}, District{}},
+	`SELECT p.address_id AS [a-zA-Z_0-9]+, p.id AS [a-zA-Z_0-9]+, p.name AS [a-zA-Z_0-9]+,  FROM person AS p JOIN address AS a ON p.address_id = a.id WHERE p.name = \? AND p.address_id = \?`,
 }, {
 	"complex query v6",
-	"SELECT p.* AS &Person.*, a.district AS &District.* FROM person AS p INNER JOIN address AS a ON p.address_id = $Address.id WHERE p.name = $Person.name AND p.address_id = $Person.address_id",
-	"[Bypass[SELECT ] Output[[p.*] [Person.*]] Bypass[, ] Output[[a.district] [District.*]] Bypass[ FROM person AS p INNER JOIN address AS a ON p.address_id = ] Input[Address.id] Bypass[ WHERE p.name = ] Input[Person.name] Bypass[ AND p.address_id = ] Input[Person.address_id]]",
+	"SELECT p.* AS &Person.*, FROM person AS p INNER JOIN address AS a ON p.address_id = $Address.id WHERE p.name = $Person.name AND p.address_id = $Person.address_id",
+	"[Bypass[SELECT ] Output[[p.*] [Person.*]] Bypass[, FROM person AS p INNER JOIN address AS a ON p.address_id = ] Input[Address.id] Bypass[ WHERE p.name = ] Input[Person.name] Bypass[ AND p.address_id = ] Input[Person.address_id]]",
+	[]any{Person{}, Address{}},
+	`SELECT p.address_id AS [a-zA-Z_0-9]+, p.id AS [a-zA-Z_0-9]+, p.name AS [a-zA-Z_0-9]+, FROM person AS p INNER JOIN address AS a ON p.address_id = \? WHERE p.name = \? AND p.address_id = \?`,
 }, {
 	"join v1",
 	"SELECT p.* AS &Person.*, m.* AS &Manager.* FROM person AS p JOIN person AS m ON p.manager_id = m.id WHERE p.name = 'Fred'",
 	"[Bypass[SELECT ] Output[[p.*] [Person.*]] Bypass[, ] Output[[m.*] [Manager.*]] Bypass[ FROM person AS p JOIN person AS m ON p.manager_id = m.id WHERE p.name = 'Fred']]",
+	[]any{Person{}, Manager{}},
+	"SELECT p.address_id AS [a-zA-Z_0-9]+, p.id AS [a-zA-Z_0-9]+, p.name AS [a-zA-Z_0-9]+, m.manager_name AS [a-zA-Z_0-9]+ FROM person AS p JOIN person AS m ON p.manager_id = m.id WHERE p.name = 'Fred'",
 }, {
 	"join v2",
 	"SELECT person.*, address.district FROM person JOIN address ON person.address_id = address.id WHERE person.name = 'Fred'",
 	"[Bypass[SELECT person.*, address.district FROM person JOIN address ON person.address_id = address.id WHERE person.name = 'Fred']]",
+	[]any{},
+	"SELECT person.*, address.district FROM person JOIN address ON person.address_id = address.id WHERE person.name = 'Fred'",
 }, {
 	"insert",
 	"INSERT INTO person (name) VALUES $Person.name",
 	"[Bypass[INSERT INTO person (name) VALUES ] Input[Person.name]]",
+	[]any{Person{}},
+	`INSERT INTO person \(name\) VALUES \?`,
 }, {
 	"ignore dollar v1",
 	"SELECT $ FROM moneytable",
 	"[Bypass[SELECT $ FROM moneytable]]",
+	[]any{},
+	`SELECT \$ FROM moneytable`,
 }, {
 	"ignore dollar v2",
 	"SELECT foo FROM data$",
 	"[Bypass[SELECT foo FROM data$]]",
+	[]any{},
+	`SELECT foo FROM data\$`,
 }, {
 	"ignore dollar v3",
 	"SELECT dollerrow$ FROM moneytable",
 	"[Bypass[SELECT dollerrow$ FROM moneytable]]",
+	[]any{},
+	`SELECT dollerrow\$ FROM moneytable`,
 }, {
 	"input with no space",
 	"SELECT p.*, a.district FROM person AS p WHERE p.name=$Person.name",
 	"[Bypass[SELECT p.*, a.district FROM person AS p WHERE p.name=] Input[Person.name]]",
+	[]any{Person{}},
+	`SELECT p.*, a.district FROM person AS p WHERE p.name=\?`,
 }, {
 	"escaped double quote",
 	`SELECT foo FROM t WHERE t.p = "Jimmy ""Quickfingers"" Jones"`,
 	`[Bypass[SELECT foo FROM t WHERE t.p = "Jimmy ""Quickfingers"" Jones"]]`,
+	[]any{},
+	`SELECT foo FROM t WHERE t.p = "Jimmy ""Quickfingers"" Jones"`,
 }, {
 	"escaped single quote",
 	`SELECT foo FROM t WHERE t.p = 'Olly O''Flanagan'`,
 	`[Bypass[SELECT foo FROM t WHERE t.p = 'Olly O''Flanagan']]`,
+	[]any{},
+	`SELECT foo FROM t WHERE t.p = 'Olly O''Flanagan'`,
 }, {
 	"complex escaped quotes",
 	`SELECT * AS &Person.* FROM person WHERE name IN ('Lorn', 'Onos T''oolan', '', ''' ''');`,
 	`[Bypass[SELECT ] Output[[*] [Person.*]] Bypass[ FROM person WHERE name IN ('Lorn', 'Onos T''oolan', '', ''' ''');]]`,
+	[]any{Person{}},
+	`SELECT address_id AS [a-zA-Z_0-9]+, id AS [a-zA-Z_0-9]+, name AS [a-zA-Z_0-9]+ FROM person WHERE name IN \('Lorn', 'Onos T''oolan', '', ''' '''\);`,
 }, {
 	"update",
 	"UPDATE person SET person.address_id = $Address.id WHERE person.id = $Person.id",
 	"[Bypass[UPDATE person SET person.address_id = ] Input[Address.id] Bypass[ WHERE person.id = ] Input[Person.id]]",
+	[]any{Person{}, Address{}},
+	`UPDATE person SET person.address_id = \? WHERE person.id = \?`,
 }}
 
 func (s *ExprSuite) TestExpr(c *C) {
 	parser := expr.NewParser()
 	for i, test := range tests {
-		var parsedExpr *expr.ParsedExpr
-		var err error
+		var (
+			parsedExpr   *expr.ParsedExpr
+			preparedExpr *expr.PreparedExpr
+			err          error
+		)
 		if parsedExpr, err = parser.Parse(test.input); err != nil {
 			c.Errorf("test %d failed (Parse):\nsummary: %s\ninput: %s\nexpected: %s\nerr: %s\n", i, test.summary, test.input, test.expectedParsed, err)
 		} else if parsedExpr.String() != test.expectedParsed {
 			c.Errorf("test %d failed (Parse):\nsummary: %s\ninput: %s\nexpected: %s\nactual:   %s\n", i, test.summary, test.input, test.expectedParsed, parsedExpr.String())
+		}
+
+		if preparedExpr, err = parsedExpr.Prepare(test.prepareArgs...); err != nil {
+			c.Errorf("test %d failed (Prepare):\nsummary: %s\ninput: %s\nexpected: %s\nerr: %s\n", i, test.summary, test.input, test.expectedPrepared, err)
+		} else {
+			c.Check(preparedExpr.SQL, Matches, test.expectedPrepared,
+				Commentf("test %d failed (Prepare):\nsummary: %s\ninput: %s\nexpected: %s\nactual:   %s\n", i, test.summary, test.input, test.expectedPrepared, preparedExpr.SQL))
 		}
 	}
 }
@@ -342,9 +423,12 @@ func (s *ExprSuite) TestValidPrepare(c *C) {
 	}}
 	for _, test := range testList {
 		parser := expr.NewParser()
-		parsedExpr, _ := parser.Parse(test.input)
-		preparedExpr, err := parsedExpr.Prepare(test.prepareArgs...)
+		parsedExpr, err := parser.Parse(test.input)
+		if err != nil {
+			c.Fatal(err)
+		}
 
+		preparedExpr, err := parsedExpr.Prepare(test.prepareArgs...)
 		if err != nil {
 			c.Fatal(err)
 		}
@@ -352,18 +436,158 @@ func (s *ExprSuite) TestValidPrepare(c *C) {
 	}
 }
 
-func (s *ExprSuite) TestMismatchedInputStructName(c *C) {
-	sql := "SELECT street FROM t WHERE x = $Address.street"
-	parser := expr.NewParser()
-	parsedExpr, err := parser.Parse(sql)
-	_, err = parsedExpr.Prepare(Person{ID: 1}, Manager{})
-	c.Assert(err, ErrorMatches, `cannot prepare expression: type Address unknown, have: Manager, Person`)
+func (s *ExprSuite) TestPrepareMismatchedStructName(c *C) {
+	testList := []struct {
+		sql     string
+		structs []any
+	}{{
+		sql:     "SELECT street FROM t WHERE x = $Address.street",
+		structs: []any{Person{ID: 1}},
+	}, {
+		sql:     "SELECT street AS &Address.street FROM t",
+		structs: []any{},
+	}, {
+		sql:     "SELECT street AS &Address.id FROM t",
+		structs: []any{Person{ID: 1}},
+	}}
+
+	for i, test := range testList {
+		parser := expr.NewParser()
+		parsedExpr, err := parser.Parse(test.sql)
+		if err != nil {
+			c.Fatal(err)
+		}
+		_, err = parsedExpr.Prepare(test.structs...)
+		c.Assert(err, ErrorMatches, `cannot prepare expression: unknown type: .*`,
+			Commentf("test %d failed:\nsql: '%s'\nstructs: '%+v'", i, test.sql, test.structs))
+	}
 }
 
-func (s *ExprSuite) TestMissingTagInput(c *C) {
-	sql := "SELECT street FROM t WHERE x = $Address.number"
-	parser := expr.NewParser()
-	parsedExpr, err := parser.Parse(sql)
-	_, err = parsedExpr.Prepare(Address{ID: 1})
-	c.Assert(err, ErrorMatches, `cannot prepare expression: type Address has no "number" db tag`)
+func (s *ExprSuite) TestPrepareMissingTag(c *C) {
+	testList := []struct {
+		sql     string
+		structs []any
+	}{{
+		sql:     "SELECT street FROM t WHERE x = $Address.number",
+		structs: []any{Address{ID: 1}},
+	}, {
+		sql:     "SELECT (street, road) AS &Address.* FROM t",
+		structs: []any{Address{ID: 1}},
+	}, {
+		sql:     "SELECT &Address.road FROM t",
+		structs: []any{Address{ID: 1}},
+	}}
+
+	for i, test := range testList {
+		parser := expr.NewParser()
+		parsedExpr, err := parser.Parse(test.sql)
+		if err != nil {
+			c.Fatal(err)
+		}
+		_, err = parsedExpr.Prepare(test.structs...)
+		c.Assert(err, ErrorMatches, `cannot prepare expression: no tag with name .*`,
+			Commentf("test %d failed:\nsql: '%s'\nstructs:'%+v'", i, test.sql, test.structs))
+	}
+}
+
+func (s *ExprSuite) TestPrepareInvalidAsteriskPlacement(c *C) {
+	testList := []struct {
+		sql     string
+		structs []any
+	}{{
+		sql:     "SELECT (&Person.*, &Person.*) FROM t",
+		structs: []any{Address{}, Person{}},
+	}, {
+		sql:     "SELECT (p.*, t.*) AS &Address.* FROM t",
+		structs: []any{Address{}},
+	}, {
+		sql:     "SELECT p.* AS &Address.street FROM t",
+		structs: []any{Address{}},
+	}}
+
+	for i, test := range testList {
+		parser := expr.NewParser()
+		parsedExpr, err := parser.Parse(test.sql)
+		if err != nil {
+			c.Fatal(err)
+		}
+		_, err = parsedExpr.Prepare(test.structs...)
+		c.Assert(err, ErrorMatches, "cannot prepare expression: invalid asterisk in output expression",
+			Commentf("test %d failed:\nsql: '%s'\nstructs:'%+v'", i, test.sql, test.structs))
+	}
+}
+
+func (s *ExprSuite) TestPrepareMixedTypes(c *C) {
+	testList := []struct {
+		sql     string
+		structs []any
+	}{{
+		sql:     "SELECT (&Address.street, &Person.id) FROM t",
+		structs: []any{Address{}, Person{}},
+	}, {
+		sql:     "SELECT (name, p.id) AS (&Person.id, &Address.id) FROM t",
+		structs: []any{Address{}, Person{}},
+	}}
+
+	for i, test := range testList {
+		parser := expr.NewParser()
+		parsedExpr, err := parser.Parse(test.sql)
+		if err != nil {
+			c.Fatal(err)
+		}
+		_, err = parsedExpr.Prepare(test.structs...)
+		c.Assert(err, ErrorMatches, "cannot prepare expression: multiple types in single output expression",
+			Commentf("test %d failed:\nsql: '%s'\nstructs:'%+v'", i, test.sql, test.structs))
+	}
+}
+
+func (s *ExprSuite) TestPrepareAsteriskMix(c *C) {
+	testList := []struct {
+		sql     string
+		structs []any
+	}{{
+		sql:     "SELECT (&Address.*, &Address.id) FROM t",
+		structs: []any{Address{}, Person{}},
+	}, {
+		sql:     "SELECT (p.*, t.name) AS &Address.* FROM t",
+		structs: []any{Address{}},
+	}, {
+		sql:     "SELECT (name, p.*) AS (&Person.id, &Person.*) FROM t",
+		structs: []any{Address{}, Person{}},
+	}}
+
+	for i, test := range testList {
+		parser := expr.NewParser()
+		parsedExpr, err := parser.Parse(test.sql)
+		if err != nil {
+			c.Fatal(err)
+		}
+		_, err = parsedExpr.Prepare(test.structs...)
+		c.Assert(err, ErrorMatches, "cannot prepare expression: invalid mix of asterisk and none asterisk columns in output expression",
+			Commentf("test %d failed:\nsql: '%s'\nstructs:'%+v'", i, test.sql, test.structs))
+	}
+}
+
+func (s *ExprSuite) TestPrepareMismatchedColsAndTargs(c *C) {
+	testList := []struct {
+		sql     string
+		structs []any
+	}{{
+		sql:     "SELECT (p.name, t.id) AS &Address.id FROM t",
+		structs: []any{Address{}},
+	}, {
+		sql:     "SELECT p.name AS (&Address.district, &Address.street) FROM t",
+		structs: []any{Address{}},
+	}}
+
+	for i, test := range testList {
+		parser := expr.NewParser()
+		parsedExpr, err := parser.Parse(test.sql)
+		if err != nil {
+			c.Fatal(err)
+		}
+		_, err = parsedExpr.Prepare(test.structs...)
+		c.Assert(err, ErrorMatches, "cannot prepare expression: mismatched number of cols and targets in output expression",
+			Commentf("test %d failed:\nsql: '%s'\nstructs:'%+v'", i, test.sql, test.structs))
+	}
 }

--- a/internal/expr/expr_test.go
+++ b/internal/expr/expr_test.go
@@ -458,9 +458,10 @@ func (s *ExprSuite) TestPrepareMismatchedStructName(c *C) {
 			c.Fatal(err)
 		}
 		_, err = parsedExpr.Prepare(test.structs...)
-		c.Assert(err, ErrorMatches, `cannot prepare expression: unknown type: .*`,
+		c.Assert(err, ErrorMatches, `cannot prepare expression: type [a-zA-Z_\.0-9]+ unknown, have: .*`,
 			Commentf("test %d failed:\nsql: '%s'\nstructs: '%+v'", i, test.sql, test.structs))
 	}
+
 }
 
 func (s *ExprSuite) TestPrepareMissingTag(c *C) {
@@ -485,8 +486,9 @@ func (s *ExprSuite) TestPrepareMissingTag(c *C) {
 			c.Fatal(err)
 		}
 		_, err = parsedExpr.Prepare(test.structs...)
-		c.Assert(err, ErrorMatches, `cannot prepare expression: no tag with name .*`,
+		c.Assert(err, ErrorMatches, `cannot prepare expression: type [a-zA-Z_\.0-9]+ has no "[a-zA-Z_\.0-9]+" db tag`,
 			Commentf("test %d failed:\nsql: '%s'\nstructs:'%+v'", i, test.sql, test.structs))
+
 	}
 }
 

--- a/internal/expr/expr_test.go
+++ b/internal/expr/expr_test.go
@@ -514,7 +514,7 @@ func (s *ExprSuite) TestPrepareInvalidAsteriskPlacement(c *C) {
 			c.Fatal(err)
 		}
 		_, err = parsedExpr.Prepare(test.structs...)
-		c.Assert(err, ErrorMatches, "cannot prepare expression: invalid asterisk in output expression",
+		c.Assert(err, ErrorMatches, "cannot prepare expression: invalid asterisk in output expression: .*",
 			Commentf("test %d failed:\nsql: '%s'\nstructs:'%+v'", i, test.sql, test.structs))
 	}
 }
@@ -565,7 +565,7 @@ func (s *ExprSuite) TestPrepareAsteriskMix(c *C) {
 			c.Fatal(err)
 		}
 		_, err = parsedExpr.Prepare(test.structs...)
-		c.Assert(err, ErrorMatches, "cannot prepare expression: invalid asterisk columns in: .*",
+		c.Assert(err, ErrorMatches, "cannot prepare expression: invalid asterisk in output expression: .*",
 			Commentf("test %d failed:\nsql: '%s'\nstructs:'%+v'", i, test.sql, test.structs))
 	}
 }
@@ -589,7 +589,7 @@ func (s *ExprSuite) TestPrepareMismatchedColsAndTargs(c *C) {
 			c.Fatal(err)
 		}
 		_, err = parsedExpr.Prepare(test.structs...)
-		c.Assert(err, ErrorMatches, "cannot prepare expression: mismatched number of cols and targets in: .*",
+		c.Assert(err, ErrorMatches, "cannot prepare expression: mismatched number of cols and targets in output expression: .*",
 			Commentf("test %d failed:\nsql: '%s'\nstructs:'%+v'", i, test.sql, test.structs))
 	}
 }

--- a/internal/expr/parts.go
+++ b/internal/expr/parts.go
@@ -1,6 +1,8 @@
 package expr
 
-import "fmt"
+import (
+	"fmt"
+)
 
 // A QueryPart represents a section of a parsed SQL statement, which forms
 // a complete query when processed together with its surrounding parts, in

--- a/internal/expr/prepare.go
+++ b/internal/expr/prepare.go
@@ -4,7 +4,6 @@ import (
 	"bytes"
 	"fmt"
 	"reflect"
-	"regexp"
 	"sort"
 	"strings"
 )
@@ -16,7 +15,7 @@ type PreparedExpr struct {
 	SQL     string
 }
 
-// Maps the output types to the columns they are assosiated with
+// typeToCols maps the output types to the columns they are assosiated with.
 type typeToCols map[reflect.Type]numRange
 
 type numRange struct {
@@ -24,9 +23,8 @@ type numRange struct {
 	lastCol  int
 }
 
-type typeNameToInfo map[string]*info
-
-func getKeys(m map[string]*info) []string {
+// getKeys returns the keys of a string map in a deterministic order.
+func getKeys[T any](m map[string]T) []string {
 	i := 0
 	keys := make([]string, len(m))
 	for k := range m {
@@ -62,6 +60,9 @@ func starCount(fns []fullName) int {
 	return s
 }
 
+// prepareOutput checks that the output expressions corresponds to a known type.
+// It then checks the asterisk are in the right place and finally generates the
+// columns needed from the database.
 func prepareOutput(ti typeNameToInfo, p *outputPart) ([]fullName, error) {
 
 	var outCols []fullName = make([]fullName, 0)
@@ -161,7 +162,7 @@ func prepareOutput(ti typeNameToInfo, p *outputPart) ([]fullName, error) {
 	return outCols, nil
 }
 
-var alphaNum = regexp.MustCompile("[^a-zA-Z0-9]+")
+type typeNameToInfo map[string]*info
 
 // Prepare takes a parsed expression and struct instantiations of all the types
 // mentioned in it.

--- a/internal/expr/prepare.go
+++ b/internal/expr/prepare.go
@@ -18,7 +18,7 @@ type PreparedExpr struct {
 
 type outputDest struct {
 	structType reflect.Type
-	fieldNum   int
+	field      field
 }
 
 // getKeys returns the keys of a string map in a deterministic order.
@@ -108,7 +108,7 @@ func prepareOutput(ti typeNameToInfo, p *outputPart) ([]fullName, []outputDest, 
 			}
 			// For a none star expression we record output destinations here.
 			// For a star expression we fill out the destinations as we generate the columns.
-			outDests = append(outDests, outputDest{info.structType, f.index})
+			outDests = append(outDests, outputDest{info.structType, f})
 
 		}
 	}
@@ -132,7 +132,7 @@ func prepareOutput(ti typeNameToInfo, p *outputPart) ([]fullName, []outputDest, 
 			tags := getKeys(info.tagToField)
 			for _, tag := range tags {
 				outCols = append(outCols, fullName{pref, tag})
-				outDests = append(outDests, outputDest{info.structType, info.tagToField[tag].index})
+				outDests = append(outDests, outputDest{info.structType, info.tagToField[tag]})
 			}
 			return outCols, outDests, nil
 		}
@@ -145,7 +145,7 @@ func prepareOutput(ti typeNameToInfo, p *outputPart) ([]fullName, []outputDest, 
 					return nil, nil, fmt.Errorf(`type %s has no %q db tag`, info.structType.Name(), c.name)
 				}
 				outCols = append(outCols, c)
-				outDests = append(outDests, outputDest{info.structType, f.index})
+				outDests = append(outDests, outputDest{info.structType, f})
 			}
 			return outCols, outDests, nil
 		}

--- a/internal/expr/prepare.go
+++ b/internal/expr/prepare.go
@@ -79,14 +79,14 @@ func prepareInput(ti typeNameToInfo, p *inputPart) error {
 	return nil
 }
 
-// prepareOutput checks that the output expressions are correspond to a known types.
+// prepareOutput checks that the output expressions correspond to known types.
 // It then checks they are formatted correctly and finally generates the columns for the query.
 func prepareOutput(ti typeNameToInfo, p *outputPart) ([]fullName, []outputDest, error) {
 
 	var outCols = make([]fullName, 0)
 	var outDests = make([]outputDest, 0)
 
-	// Check the asterisk are well formed (if present).
+	// Check the asterisks are well formed (if present).
 	if err := starCheckOutput(p); err != nil {
 		return nil, nil, err
 	}
@@ -109,7 +109,6 @@ func prepareOutput(ti typeNameToInfo, p *outputPart) ([]fullName, []outputDest, 
 			// For a none star expression we record output destinations here.
 			// For a star expression we fill out the destinations as we generate the columns.
 			outDests = append(outDests, outputDest{info.structType, f})
-
 		}
 	}
 

--- a/internal/expr/prepare.go
+++ b/internal/expr/prepare.go
@@ -9,8 +9,8 @@ import (
 
 // PreparedExpr contains an SQL expression that is ready for execution.
 type PreparedExpr struct {
-	inputs []*inputPart
-	SQL    string
+	ParsedExpr *ParsedExpr
+	SQL        string
 }
 
 type typeNameToInfo map[string]*info
@@ -41,7 +41,118 @@ func prepareInput(ti typeNameToInfo, p *inputPart) error {
 	return nil
 }
 
-// Prepare takes a parsed expression and all the Go objects mentioned in it.
+func starCount(fns []fullName) int {
+	s := 0
+	for _, fn := range fns {
+		if fn.name == "*" {
+			s++
+		}
+	}
+	return s
+}
+
+func prepareOutput(ti typeNameToInfo, p *outputPart) ([]string, error) {
+
+	var outCols []string = make([]string, 0)
+
+	// Check target struct type and its tags are valid.
+	var inf *info
+	var ok bool
+
+	for i, t := range p.target {
+		if i == 0 {
+			inf, ok = ti[t.prefix]
+			if !ok {
+				return nil, fmt.Errorf("unknown type: %s", t.prefix)
+			}
+		} else if t.prefix != inf.structType.Name() {
+			return nil, fmt.Errorf("multiple types in single output expression")
+		}
+
+		_, ok = inf.tagToField[t.name]
+		if !ok && t.name != "*" {
+			return nil, fmt.Errorf(`no tag with name "%s" in "%s"`, t.name, inf.structType.Name())
+		}
+	}
+
+	// Check asterisk are in correct places.
+
+	sct := starCount(p.target)
+	scc := starCount(p.source)
+
+	if sct > 1 || scc > 1 || (scc == 1 && sct == 0) {
+		return nil, fmt.Errorf("invalid asterisk in output expression")
+	}
+
+	starTarget := sct == 1
+	starSource := scc == 1
+
+	numSources := len(p.source)
+	numTargets := len(p.target)
+
+	if (starTarget && numTargets > 1) || (starSource && numSources > 1) {
+		return nil, fmt.Errorf("invalid mix of asterisk and none asterisk columns in output expression")
+	}
+
+	if !starTarget && (numSources > 0 && (numTargets != numSources)) {
+		return nil, fmt.Errorf("mismatched number of cols and targets in output expression")
+	}
+
+	// Case 1: Star target cases e.g. "...&P.*".
+	if starTarget {
+		inf, _ := ti[p.target[0].prefix]
+
+		// Case 1.1: Single star e.g. "t.* AS &P.*" or "&P.*"
+		if starSource || numSources == 0 {
+			pref := ""
+
+			// Prepend table name. E.g. "t" in "t.* AS &P.*".
+			if numSources > 0 && p.source[0].prefix != "" {
+				pref = p.source[0].prefix + "."
+			}
+
+			for tag := range inf.tagToField {
+				outCols = append(outCols, pref+tag)
+			}
+
+			// The strings are sorted to give a deterministic order for
+			// testing.
+			sort.Strings(outCols)
+			return outCols, nil
+		}
+
+		// Case 1.2: Explicit columns e.g. "(col1, t.col2) AS &P.*".
+		if numSources > 0 {
+			for _, c := range p.source {
+				if _, ok := inf.tagToField[c.name]; !ok {
+					return nil, fmt.Errorf(`no tag with name "%s" in "%s"`,
+						c.name, inf.structType.Name())
+				}
+				outCols = append(outCols, c.String())
+			}
+			return outCols, nil
+		}
+	}
+
+	// Case 2: None star target cases e.g. "...&(P.name, P.id)".
+
+	// Case 2.1: Explicit columns e.g. "name_1 AS P.name".
+	if numSources > 0 {
+		for _, c := range p.source {
+			outCols = append(outCols, c.String())
+		}
+		return outCols, nil
+	}
+
+	// Case 2.2: No columns e.g. "&(P.name, P.id)".
+	for _, t := range p.target {
+		outCols = append(outCols, t.name)
+	}
+	return outCols, nil
+}
+
+// Prepare takes a parsed expression and struct instantiations of all the types
+// mentioned in it.
 // The IO parts of the statement are checked for validity against the types
 // and expanded if necessary.
 func (pe *ParsedExpr) Prepare(args ...any) (expr *PreparedExpr, err error) {
@@ -77,6 +188,14 @@ func (pe *ParsedExpr) Prepare(args ...any) (expr *PreparedExpr, err error) {
 			sql.WriteString("?")
 			ins = append(ins, p)
 		case *outputPart:
+			outCols, err := prepareOutput(ti, p)
+			if err != nil {
+				return nil, err
+			}
+			s := p.toSQL(outCols, n)
+			n += len(outCols)
+			sql.WriteString(s)
+			continue
 		case *bypassPart:
 			sql.WriteString(p.chunk)
 		default:

--- a/internal/expr/prepare.go
+++ b/internal/expr/prepare.go
@@ -78,7 +78,7 @@ func prepareOutput(ti typeNameToInfo, p *outputPart) ([]fullName, error) {
 				return nil, fmt.Errorf(`type %s unknown, have: %s`, t.prefix, strings.Join(getKeys(ti), ", "))
 			}
 		} else if t.prefix != info.structType.Name() {
-			return nil, fmt.Errorf("multiple types in single output expression")
+			return nil, fmt.Errorf("multiple target types in: %s", p.String())
 		}
 
 		_, ok = info.tagToField[t.name]
@@ -88,27 +88,27 @@ func prepareOutput(ti typeNameToInfo, p *outputPart) ([]fullName, error) {
 	}
 
 	// Check asterisk are in correct places.
-
 	sct := starCount(p.target)
-	scc := starCount(p.source)
+	scs := starCount(p.source)
 
-	if sct > 1 || scc > 1 || (scc == 1 && sct == 0) {
+	if sct > 1 || scs > 1 || (scs == 1 && sct == 0) {
 		return nil, fmt.Errorf("invalid asterisk in output expression")
 	}
 
 	starTarget := sct == 1
-	starSource := scc == 1
-
+	starSource := scs == 1
 	numSources := len(p.source)
 	numTargets := len(p.target)
 
 	if (starTarget && numTargets > 1) || (starSource && numSources > 1) {
-		return nil, fmt.Errorf("invalid mix of asterisk and none asterisk columns in output expression")
+		return nil, fmt.Errorf("invalid asterisk columns in: %s", p.String())
 	}
 
 	if !starTarget && (numSources > 0 && (numTargets != numSources)) {
-		return nil, fmt.Errorf("mismatched number of cols and targets in output expression")
+		return nil, fmt.Errorf("mismatched number of cols and targets in: %s", p.String())
 	}
+
+	// Generate columns to inject into SQL query.
 
 	// Case 1: Star target cases e.g. "...&P.*".
 	if starTarget {

--- a/internal/expr/prepare.go
+++ b/internal/expr/prepare.go
@@ -192,9 +192,8 @@ func (pe *ParsedExpr) Prepare(args ...any) (expr *PreparedExpr, err error) {
 			if err != nil {
 				return nil, err
 			}
-			s := p.toSQL(outCols, n)
 			n += len(outCols)
-			sql.WriteString(s)
+			sql.WriteString(p.toSQL(outCols, n))
 			continue
 		case *bypassPart:
 			sql.WriteString(p.chunk)


### PR DESCRIPTION
This PR adds the prepare stage for outputs. The prepare function takes instansiations of all the types mentioned in the output expressions of the query. The output expressions are checked against these types. If an output expression contains a * this is substituted for a list of all the tags in the output expression struct.

All output expression columns are given an alias with prefix `_sqlair` and suffix `_n` where `n` is the position of the output in the query. This will be used in the scan/decode stage to retrieve the relevant columns.