### PR TITLE
Adjust saved reflection information 

### DIFF
--- a/internal/expr/info.go
+++ b/internal/expr/info.go
@@ -6,7 +6,7 @@ import (
 
 // Field represents a single field from a struct type.
 type field struct {
-	fieldType reflect.Type
+	typ reflect.Type
 
 	// Name is the name of the struct field.
 	name string
@@ -21,11 +21,11 @@ type field struct {
 
 // Info represents reflected information about a struct type.
 type info struct {
-	structType reflect.Type
+	typ reflect.Type
+
+	// Ordered list of tags
+	tags []string
 
 	// Relate tag names to fields.
 	tagToField map[string]field
-
-	// Relate field names to tags.
-	fieldToTag map[string]string
 }

--- a/internal/expr/info.go
+++ b/internal/expr/info.go
@@ -4,11 +4,10 @@ import (
 	"reflect"
 )
 
-// Field represents a single field from a struct type.
+// field represents reflection information about a field from some struct type.
 type field struct {
 	typ reflect.Type
 
-	// Name is the name of the struct field.
 	name string
 
 	// Index of this field in the structure.
@@ -26,6 +25,5 @@ type info struct {
 	// Ordered list of tags
 	tags []string
 
-	// Relate tag names to fields.
 	tagToField map[string]field
 }

--- a/internal/expr/info.go
+++ b/internal/expr/info.go
@@ -10,8 +10,8 @@ type field struct {
 
 	name string
 
-	// Index of this field in the structure.
-	index int
+	// index sequence for Type.FieldByIndex
+	index []int
 
 	// OmitEmpty is true when "omitempty" is
 	// a property of the field's "db" tag.

--- a/internal/expr/prepare.go
+++ b/internal/expr/prepare.go
@@ -73,7 +73,7 @@ func prepareInput(ti typeNameToInfo, p *inputPart) error {
 
 	if _, ok = info.tagToField[p.source.name]; !ok {
 		return fmt.Errorf(`type %s has no %q db tag`,
-			info.structType.Name(), p.source.name)
+			info.typ.Name(), p.source.name)
 	}
 
 	return nil
@@ -104,11 +104,11 @@ func prepareOutput(ti typeNameToInfo, p *outputPart) ([]fullName, []outputDest, 
 		if t.name != "*" {
 			f, ok := info.tagToField[t.name]
 			if !ok {
-				return nil, nil, fmt.Errorf(`type %s has no %q db tag`, info.structType.Name(), t.name)
+				return nil, nil, fmt.Errorf(`type %s has no %q db tag`, info.typ.Name(), t.name)
 			}
 			// For a none star expression we record output destinations here.
 			// For a star expression we fill out the destinations as we generate the columns.
-			outDests = append(outDests, outputDest{info.structType, f})
+			outDests = append(outDests, outputDest{info.typ, f})
 		}
 	}
 
@@ -127,11 +127,9 @@ func prepareOutput(ti typeNameToInfo, p *outputPart) ([]fullName, []outputDest, 
 				pref = p.source[0].prefix
 			}
 
-			// getKeys also sorts the keys.
-			tags := getKeys(info.tagToField)
-			for _, tag := range tags {
+			for _, tag := range info.tags {
 				outCols = append(outCols, fullName{pref, tag})
-				outDests = append(outDests, outputDest{info.structType, info.tagToField[tag]})
+				outDests = append(outDests, outputDest{info.typ, info.tagToField[tag]})
 			}
 			return outCols, outDests, nil
 		}
@@ -141,10 +139,10 @@ func prepareOutput(ti typeNameToInfo, p *outputPart) ([]fullName, []outputDest, 
 			for _, c := range p.source {
 				f, ok := info.tagToField[c.name]
 				if !ok {
-					return nil, nil, fmt.Errorf(`type %s has no %q db tag`, info.structType.Name(), c.name)
+					return nil, nil, fmt.Errorf(`type %s has no %q db tag`, info.typ.Name(), c.name)
 				}
 				outCols = append(outCols, c)
-				outDests = append(outDests, outputDest{info.structType, f})
+				outDests = append(outDests, outputDest{info.typ, f})
 			}
 			return outCols, outDests, nil
 		}
@@ -188,7 +186,7 @@ func (pe *ParsedExpr) Prepare(args ...any) (expr *PreparedExpr, err error) {
 		if err != nil {
 			return nil, err
 		}
-		ti[info.structType.Name()] = info
+		ti[info.typ.Name()] = info
 	}
 
 	var sql bytes.Buffer

--- a/internal/expr/typeinfo.go
+++ b/internal/expr/typeinfo.go
@@ -4,6 +4,7 @@ import (
 	"fmt"
 	"reflect"
 	"regexp"
+	"sort"
 	"strings"
 	"sync"
 )
@@ -49,9 +50,9 @@ func generate(value reflect.Value) (*info, error) {
 
 	info := info{
 		tagToField: make(map[string]field),
-		fieldToTag: make(map[string]string),
-		structType: value.Type(),
+		typ:        value.Type(),
 	}
+	tags := []string{}
 
 	typ := value.Type()
 	for i := 0; i < typ.NumField(); i++ {
@@ -65,14 +66,17 @@ func generate(value reflect.Value) (*info, error) {
 		if err != nil {
 			return nil, fmt.Errorf("cannot parse tag for field %s.%s: %s", typ.Name(), f.Name, err)
 		}
+		tags = append(tags, tag)
 		info.tagToField[tag] = field{
 			name:      f.Name,
 			index:     i,
 			omitEmpty: omitEmpty,
-			fieldType: reflect.TypeOf(value.Field(i).Interface()),
+			typ:       reflect.TypeOf(value.Field(i).Interface()),
 		}
-		info.fieldToTag[f.Name] = tag
 	}
+
+	sort.Strings(tags)
+	info.tags = tags
 
 	return &info, nil
 }

--- a/internal/expr/typeinfo_test.go
+++ b/internal/expr/typeinfo_test.go
@@ -171,3 +171,24 @@ func (s *ExprInternalSuite) TestReflectValidTag(c *C) {
 		c.Assert(err, IsNil)
 	}
 }
+
+func (s *ExprInternalSuite) TestUnexportedField(c *C) {
+	var unexportedFields = []any{
+		struct {
+			ID    int64 `db:"id"`
+			unexp int64 `db:"unexp"`
+		}{99, 100},
+		struct {
+			unexp int64 `db:"unexp"`
+			ID    int64 `db:"id"`
+		}{99, 100},
+		struct {
+			unexp int64 `db:"unexp"`
+		}{100},
+	}
+
+	for _, value := range unexportedFields {
+		_, err := typeInfo(value)
+		c.Assert(err, ErrorMatches, `field "unexp" of struct  not exported`)
+	}
+}

--- a/internal/expr/typeinfo_test.go
+++ b/internal/expr/typeinfo_test.go
@@ -27,8 +27,8 @@ func (e *ExprInternalSuite) TestReflectStruct(c *C) {
 	info, err := typeInfo(s)
 	c.Assert(err, IsNil)
 
-	c.Assert(reflect.Struct, Equals, info.structType.Kind())
-	c.Assert(reflect.TypeOf(s), Equals, info.structType)
+	c.Assert(reflect.Struct, Equals, info.typ.Kind())
+	c.Assert(reflect.TypeOf(s), Equals, info.typ)
 
 	c.Assert(info.tagToField, HasLen, 2)
 


### PR DESCRIPTION
This PR removes the usued `fieldToTag` map from the `info` struct and adds in an ordered list of tags: `tags`. This change is made to reflect how the `info` struct was used in the `Prepare` stage and makes the code slightly more efficient.

It fixed the bug where a panic would occur if an unexported field has a db tag. It now throws an error.

It stops`typeInfo` from unnecessarley reflecting the value when only the type is used.

It changes the names `structType` and `fieldType` to `typ` as this is the more idiomatic way of doing things in Go (the struct they are fields of tells us what they are the type of).