### PR TITLE
Raw user input in error's

### DIFF
--- a/internal/expr/expr_test.go
+++ b/internal/expr/expr_test.go
@@ -484,15 +484,15 @@ func (s *ExprSuite) TestPrepareInvalidAsteriskPlacement(c *C) {
 	}{{
 		sql:      "SELECT (&Person.*, &Person.*) FROM t",
 		structs:  []any{Address{}, Person{}},
-		errorstr: "cannot prepare expression: invalid asterisk in output expression: Output[[] [Person.* Person.*]]",
+		errorstr: "cannot prepare expression: invalid asterisk in output expression: (&Person.*, &Person.*)",
 	}, {
 		sql:      "SELECT (p.*, t.*) AS &Address.* FROM t",
 		structs:  []any{Address{}},
-		errorstr: "cannot prepare expression: invalid asterisk in output expression: Output[[p.* t.*] [Address.*]]",
+		errorstr: "cannot prepare expression: invalid asterisk in output expression: (p.*, t.*) AS &Address.*",
 	}, {
 		sql:      "SELECT p.* AS &Address.street FROM t",
 		structs:  []any{Address{}},
-		errorstr: "cannot prepare expression: invalid asterisk in output expression: Output[[p.*] [Address.street]]",
+		errorstr: "cannot prepare expression: invalid asterisk in output expression: p.* AS &Address.street",
 	}}
 
 	for i, test := range testList {
@@ -515,15 +515,15 @@ func (s *ExprSuite) TestPrepareAsteriskMix(c *C) {
 	}{{
 		sql:      "SELECT (&Address.*, &Address.id) FROM t",
 		structs:  []any{Address{}, Person{}},
-		errorstr: "cannot prepare expression: invalid asterisk in output expression: Output[[] [Address.* Address.id]]",
+		errorstr: "cannot prepare expression: invalid asterisk in output expression: (&Address.*, &Address.id)",
 	}, {
 		sql:      "SELECT (p.*, t.name) AS &Address.* FROM t",
 		structs:  []any{Address{}},
-		errorstr: "cannot prepare expression: invalid asterisk in output expression: Output[[p.* t.name] [Address.*]]",
+		errorstr: "cannot prepare expression: invalid asterisk in output expression: (p.*, t.name) AS &Address.*",
 	}, {
 		sql:      "SELECT (name, p.*) AS (&Person.id, &Person.*) FROM t",
 		structs:  []any{Address{}, Person{}},
-		errorstr: "cannot prepare expression: invalid asterisk in output expression: Output[[name p.*] [Person.id Person.*]]",
+		errorstr: "cannot prepare expression: invalid asterisk in output expression: (name, p.*) AS (&Person.id, &Person.*)",
 	}}
 
 	for i, test := range testList {
@@ -546,11 +546,11 @@ func (s *ExprSuite) TestPrepareMismatchedColsAndTargs(c *C) {
 	}{{
 		sql:      "SELECT (p.name, t.id) AS &Address.id FROM t",
 		structs:  []any{Address{}},
-		errorstr: "cannot prepare expression: mismatched number of cols and targets in output expression: Output[[p.name t.id] [Address.id]]",
+		errorstr: "cannot prepare expression: mismatched number of cols and targets in output expression: (p.name, t.id) AS &Address.id",
 	}, {
 		sql:      "SELECT p.name AS (&Address.district, &Address.street) FROM t",
 		structs:  []any{Address{}},
-		errorstr: "cannot prepare expression: mismatched number of cols and targets in output expression: Output[[p.name] [Address.district Address.street]]",
+		errorstr: "cannot prepare expression: mismatched number of cols and targets in output expression: p.name AS (&Address.district, &Address.street)",
 	}}
 
 	for i, test := range testList {

--- a/internal/expr/parser.go
+++ b/internal/expr/parser.go
@@ -450,12 +450,17 @@ func (p *Parser) parseTargets() ([]fullName, bool, error) {
 // parseOutputExpression requires that the ampersand before the identifiers must
 // be followed by a name byte.
 func (p *Parser) parseOutputExpression() (*outputPart, bool, error) {
+	start := p.pos
 
 	// Case 1: There are no columns e.g. "&Person.*".
 	if targets, ok, err := p.parseTargets(); err != nil {
 		return nil, false, err
 	} else if ok {
-		return &outputPart{[]fullName{}, targets}, true, nil
+		return &outputPart{
+			source: []fullName{},
+			target: targets,
+			raw:    p.input[start:p.pos],
+		}, true, nil
 	}
 
 	cp := p.save()
@@ -468,7 +473,11 @@ func (p *Parser) parseOutputExpression() (*outputPart, bool, error) {
 			if targets, ok, err := p.parseTargets(); err != nil {
 				return nil, false, err
 			} else if ok {
-				return &outputPart{cols, targets}, true, nil
+				return &outputPart{
+					source: cols,
+					target: targets,
+					raw:    p.input[start:p.pos],
+				}, true, nil
 			}
 		}
 	}
@@ -487,7 +496,7 @@ func (p *Parser) parseInputExpression() (*inputPart, bool, error) {
 				return nil, false, fmt.Errorf("asterisk not allowed "+
 					"in expression near %d", p.pos)
 			}
-			return &inputPart{fn}, true, nil
+			return &inputPart{source: fn, raw: p.input[cp.pos:p.pos]}, true, nil
 		} else if err != nil {
 			return nil, false, err
 		}

--- a/internal/expr/parts.go
+++ b/internal/expr/parts.go
@@ -33,6 +33,7 @@ func (fn fullName) String() string {
 // while performing the query.
 type inputPart struct {
 	source fullName
+	raw    string
 }
 
 func (p *inputPart) String() string {
@@ -46,6 +47,7 @@ func (p *inputPart) part() {}
 type outputPart struct {
 	source []fullName
 	target []fullName
+	raw    string
 }
 
 func (p *outputPart) String() string {

--- a/internal/expr/prepare.go
+++ b/internal/expr/prepare.go
@@ -50,10 +50,10 @@ func starCheckOutput(p *outputPart) error {
 
 	if targetStars > 1 || sourceStars > 1 || (sourceStars == 1 && targetStars == 0) ||
 		(starTarget && numTargets > 1) || (starSource && numSources > 1) {
-		return fmt.Errorf("invalid asterisk in output expression: %s", p)
+		return fmt.Errorf("invalid asterisk in output expression: %s", p.raw)
 	}
 	if !starTarget && (numSources > 0 && (numTargets != numSources)) {
-		return fmt.Errorf("mismatched number of cols and targets in output expression: %s", p)
+		return fmt.Errorf("mismatched number of cols and targets in output expression: %s", p.raw)
 	}
 	return nil
 }


### PR DESCRIPTION
This PR adds an extra field to `inputPart` and `outputPart` called `rawString`. This contains the section of the input that was parsed by the `parseInput` or `parseOutput`. This is then used in error messages in the prepare phase. 