### PR TITLE
Add Exec

### DIFF
--- a/internal/expr/exec.go
+++ b/internal/expr/exec.go
@@ -1,0 +1,43 @@
+package expr
+
+import (
+	"context"
+	"database/sql"
+)
+
+type ResultExpr struct {
+	outputs []field
+	rows    *sql.Rows
+}
+
+type DB struct {
+	*sql.DB
+}
+
+func NewDB(db *sql.DB) *DB {
+	return &DB{db}
+}
+
+func (db *DB) Query(ce *CompletedExpr) (*ResultExpr, error) {
+	return db.QueryContext(ce, context.Background())
+}
+
+func (db *DB) QueryContext(ce *CompletedExpr, ctx context.Context) (*ResultExpr, error) {
+	rows, err := db.DB.QueryContext(ctx, ce.sql, ce.args...)
+	if err != nil {
+		return nil, err
+	}
+	return &ResultExpr{ce.outputs, rows}, nil
+}
+
+func (db *DB) Exec(ce *CompletedExpr) (sql.Result, error) {
+	return db.ExecContext(ce, context.Background())
+}
+
+func (db *DB) ExecContext(ce *CompletedExpr, ctx context.Context) (sql.Result, error) {
+	res, err := db.DB.ExecContext(ctx, ce.sql, ce.args...)
+	if err != nil {
+		return nil, err
+	}
+	return res, nil
+}

--- a/internal/expr/exec.go
+++ b/internal/expr/exec.go
@@ -27,7 +27,7 @@ func (db *DB) QueryContext(ce *CompletedExpr, ctx context.Context) (*ResultExpr,
 	if err != nil {
 		return nil, err
 	}
-	return &ResultExpr{ce.outputs, rows}, nil
+	return &ResultExpr{outputs: ce.outputs, rows: rows}, nil
 }
 
 func (db *DB) Exec(ce *CompletedExpr) (sql.Result, error) {


### PR DESCRIPTION
This PR adds an exec.go file that contains `sqlair` versions of `Exec`, `Query` and their contextualised versions.

The standard go `sql.DB` type is embedded in `sqlair.DB` meaning all its methods are still accessible (though they will only work with queries containing the `sqlair` DML if the method is overwritten in `exec.go`). 