### PR TITLE
Change SQLAir to SQLair

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -2,7 +2,7 @@ Code formatting
 ===============
 
 Go provides a tool, `go fmt`, which facilitates a standardised format to Go 
-source code. SQLAir has two additional policies:
+source code. SQLair has two additional policies:
 
 Imports
 -------
@@ -10,7 +10,7 @@ Imports
 Import statements are grouped into three sections: 
 - standard library 
 - third party libraries 
-- SQLAir imports 
+- SQLair imports 
 
 The tool "go fmt" can be used to ensure each group is alphabetically sorted, 
 for example:

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# SQLAir
+# SQLair
 
 Friendly type mapping for SQL databases.
 

--- a/internal/expr/typeinfo.go
+++ b/internal/expr/typeinfo.go
@@ -41,7 +41,7 @@ func typeInfo(value any) (*info, error) {
 }
 
 // generate produces and returns reflection information for the input
-// reflect.Value that is specifically required for SQLAir operation.
+// reflect.Value that is specifically required for SQLair operation.
 func generate(t reflect.Type) (*info, error) {
 	// Reflection information is only generated for structs.
 	if t.Kind() != reflect.Struct {
@@ -56,7 +56,7 @@ func generate(t reflect.Type) (*info, error) {
 
 	for i := 0; i < t.NumField(); i++ {
 		f := t.Field(i)
-		// Fields without a "db" tag are outside of SQLAir's remit.
+		// Fields without a "db" tag are outside of SQLair's remit.
 		tag := f.Tag.Get("db")
 		if tag == "" {
 			continue


### PR DESCRIPTION
This PR changes SQLAir -> SQLair. The new version matches the capitalisation of SQLite/DQLite and makes more sense as a pun ("Lair" sounds like "layer" and this library is a compatibility layer).