### PR TITLE
No rows error

### DIFF
--- a/package_test.go
+++ b/package_test.go
@@ -370,7 +370,7 @@ func (s *PackageSuite) TestOneErrors(c *C) {
 		types:   []any{Person{}},
 		inputs:  []any{},
 		outputs: []any{&Person{}},
-		err:     "one error: no rows returned by query",
+		err:     "cannot return row: no rows in query result",
 	}}
 
 	dropTables, db, err := personAndAddressDB()

--- a/package_test.go
+++ b/package_test.go
@@ -370,7 +370,7 @@ func (s *PackageSuite) TestOneErrors(c *C) {
 		types:   []any{Person{}},
 		inputs:  []any{},
 		outputs: []any{&Person{}},
-		err:     "cannot return row: no rows in query result",
+		err:     "cannot return row: sql: no rows in result set",
 	}}
 
 	dropTables, db, err := personAndAddressDB()
@@ -408,7 +408,10 @@ func (s *PackageSuite) TestPackageErrors(c *C) {
 	stmt := sqlair.MustPrepare("SELECT * AS &Person.* FROM person WHERE id=12312", Person{})
 	err = sqlairDB.Query(stmt).One(&Person{})
 	if !errors.Is(err, sqlair.ErrNoRows) {
-		c.Errorf("test failed, error %q not found", sqlair.ErrNoRows)
+		c.Errorf("test failed, error %q not the same as %q", err, sqlair.ErrNoRows)
+	}
+	if !errors.Is(err, sql.ErrNoRows) {
+		c.Errorf("test failed, error %q not the same as %q", err, sql.ErrNoRows)
 	}
 
 	_, err = db.Exec(dropTables)

--- a/package_test.go
+++ b/package_test.go
@@ -370,7 +370,7 @@ func (s *PackageSuite) TestOneErrors(c *C) {
 		types:   []any{Person{}},
 		inputs:  []any{},
 		outputs: []any{&Person{}},
-		err:     "cannot return row: sql: no rows in result set",
+		err:     "sql: no rows in result set",
 	}}
 
 	dropTables, db, err := personAndAddressDB()

--- a/package_test.go
+++ b/package_test.go
@@ -398,7 +398,7 @@ func (s *PackageSuite) TestOneErrors(c *C) {
 	}
 }
 
-func (s *PackageSuite) TestPackageErrors(c *C) {
+func (s *PackageSuite) TestErrNoRows(c *C) {
 	dropTables, db, err := personAndAddressDB()
 	if err != nil {
 		c.Fatal(err)

--- a/sqlair.go
+++ b/sqlair.go
@@ -3,10 +3,13 @@ package sqlair
 import (
 	"context"
 	"database/sql"
+	"errors"
 	"fmt"
 
 	"github.com/canonical/sqlair/internal/expr"
 )
+
+var ErrNoRows = errors.New("no rows returned by query")
 
 // Statement represents a SQL statemnt with valid SQLair expressions.
 // It is ready to be run on a SQLair DB.
@@ -156,7 +159,7 @@ func (iter *Iterator) Close() error {
 func (q *Query) One(outputArgs ...any) error {
 	iter := q.Iter()
 	if !iter.Next() {
-		return fmt.Errorf("cannot return one row: no results")
+		return fmt.Errorf("one error: %w", ErrNoRows)
 	}
 	iter.Decode(outputArgs...)
 	return iter.Close()

--- a/sqlair.go
+++ b/sqlair.go
@@ -158,7 +158,7 @@ func (iter *Iterator) Close() error {
 func (q *Query) One(outputArgs ...any) error {
 	iter := q.Iter()
 	if !iter.Next() {
-		return fmt.Errorf("cannot return row: %w", ErrNoRows)
+		return ErrNoRows
 	}
 	iter.Decode(outputArgs...)
 	return iter.Close()

--- a/sqlair.go
+++ b/sqlair.go
@@ -9,7 +9,7 @@ import (
 	"github.com/canonical/sqlair/internal/expr"
 )
 
-var ErrNoRows = errors.New("no rows returned by query")
+var ErrNoRows = errors.New("no rows in query result")
 
 // Statement represents a SQL statemnt with valid SQLair expressions.
 // It is ready to be run on a SQLair DB.
@@ -159,7 +159,7 @@ func (iter *Iterator) Close() error {
 func (q *Query) One(outputArgs ...any) error {
 	iter := q.Iter()
 	if !iter.Next() {
-		return fmt.Errorf("one error: %w", ErrNoRows)
+		return fmt.Errorf("cannot return row: %w", ErrNoRows)
 	}
 	iter.Decode(outputArgs...)
 	return iter.Close()

--- a/sqlair.go
+++ b/sqlair.go
@@ -3,13 +3,12 @@ package sqlair
 import (
 	"context"
 	"database/sql"
-	"errors"
 	"fmt"
 
 	"github.com/canonical/sqlair/internal/expr"
 )
 
-var ErrNoRows = errors.New("no rows in query result")
+var ErrNoRows = sql.ErrNoRows
 
 // Statement represents a SQL statemnt with valid SQLair expressions.
 // It is ready to be run on a SQLair DB.


### PR DESCRIPTION
This PR adds an error to the public API that indicates no rows were found in the query results. This is returned by `One` if the results contain no rows.