### PR TITLE
Add Iterator to Query

### DIFF
--- a/package_test.go
+++ b/package_test.go
@@ -177,20 +177,20 @@ func (s *PackageSuite) TestValidDecode(c *C) {
 			continue
 		}
 
-		q := sqlairDB.Query(stmt, t.inputs...)
+		iter := sqlairDB.Query(stmt, t.inputs...).Iter()
 		i := 0
-		for q.Next() {
+		for iter.Next() {
 			if i >= len(t.outputs) {
 				c.Errorf("\ntest %q failed (Next):\ninput: %s\nerr: more rows that expected (%d >= %d)\n", t.summary, t.query, i, len(t.outputs))
 				break
 			}
-			if !q.Decode(t.outputs[i]...) {
+			if !iter.Decode(t.outputs[i]...) {
 				break
 			}
 			i++
 		}
 
-		err = q.Close()
+		err = iter.Close()
 		if err != nil {
 			c.Errorf("\ntest %q failed (Close):\ninput: %s\nerr: %s\n", t.summary, t.query, err)
 		}
@@ -275,20 +275,20 @@ func (s *PackageSuite) TestDecodeErrors(c *C) {
 			continue
 		}
 
-		q := sqlairDB.Query(stmt, t.inputs...)
+		iter := sqlairDB.Query(stmt, t.inputs...).Iter()
 		i := 0
-		for q.Next() {
+		for iter.Next() {
 			if i > len(t.outputs) {
 				c.Errorf("\ntest %q failed (Next):\ninput: %s\nerr: more rows that expected\n", t.summary, t.query)
 				break
 			}
-			if !q.Decode(t.outputs[i]...) {
+			if !iter.Decode(t.outputs[i]...) {
 				break
 			}
 			i++
 		}
 
-		err = q.Close()
+		err = iter.Close()
 		c.Assert(err, ErrorMatches, t.err,
 			Commentf("\ntest %q failed:\ninput: %s\noutputs: %s", t.summary, t.query, t.outputs))
 	}
@@ -480,26 +480,26 @@ AND    l.model_uuid = $JujuLeaseKey.model_uuid`,
 			continue
 		}
 
-		q := sqlairDB.Query(stmt, t.inputs...)
+		iter := sqlairDB.Query(stmt, t.inputs...).Iter()
 		i := 0
-		for q.Next() {
+		for iter.Next() {
 			if i > len(t.outputs) {
 				c.Errorf("\ntest %q failed (Next):\ninput: %s\nerr: more rows that expected\n", t.summary, t.query)
 				break
 			}
-			if !q.Decode(t.outputs[i]...) {
+			if !iter.Decode(t.outputs[i]...) {
 				break
 			}
 			i++
 		}
 
-		err = q.Close()
+		err = iter.Close()
 		if err != nil {
 			c.Errorf("\ntest %q failed (Close):\ninput: %s\nerr: %s\n", t.summary, t.query, err)
 		}
 	}
 
-	_, err = sqlairDB.SQLdb().Exec(dropTables)
+	_, err = sqlairDB.Unwrap().Exec(dropTables)
 	if err != nil {
 		c.Fatal(err)
 	}

--- a/sqlair.go
+++ b/sqlair.go
@@ -53,11 +53,19 @@ func (db *DB) Unwrap() *sql.DB {
 	return db.db
 }
 
-// Query holds a database query and is used to iterate over the results.
+// Query holds the results of a database query.
 type Query struct {
 	qe   *expr.QueryExpr
 	q    func() (*sql.Rows, error)
 	rows *sql.Rows
+	err  error
+}
+
+// Iterator is used to iterate over the results of the query.
+type Iterator struct {
+	qe   *expr.QueryExpr
+	rows *sql.Rows
+	cols []string
 	err  error
 }
 
@@ -78,77 +86,78 @@ func (db *DB) QueryContext(ctx context.Context, s *Statement, inputArgs ...any) 
 	return &Query{qe: qe, q: q, err: err}
 }
 
-// One runs a query and decodes the first row into outputArgs.
-func (q *Query) One(outputArgs ...any) error {
-	if !q.Next() {
-		return fmt.Errorf("cannot return one row: no results")
+// Iter returns an Iterator to iterate through the results row by row.
+func (q *Query) Iter() *Iterator {
+	rows, err := q.q()
+	if err != nil {
+		return &Iterator{err: err}
 	}
-	q.Decode(outputArgs...)
-	return q.Close()
+	cols, err := rows.Columns()
+	if err != nil {
+		return &Iterator{err: err}
+	}
+	return &Iterator{qe: q.qe, rows: rows, cols: cols, err: err}
 }
 
 // Next prepares the next row for decoding.
 // The first call to Next will execute the query.
-// If an error occurs it will be returned with Query.Close().
-func (q *Query) Next() bool {
-	if q.err != nil {
+// If an error occurs it will be returned with Iter.Close().
+func (i *Iterator) Next() bool {
+	if i.err != nil {
 		return false
 	}
-	if q.rows == nil {
-		rows, err := q.q()
-		if err != nil {
-			q.err = err
-			return false
-		}
-		q.rows = rows
-	}
-	return q.rows.Next()
+	return i.rows.Next()
 }
 
 // Decode decodes the current result into the structs in outputValues.
 // outputArgs must contain all the structs mentioned in the query.
-// If an error occurs it will be returned with Query.Close().
-func (q *Query) Decode(outputArgs ...any) (ok bool) {
-	if q.err != nil {
+// If an error occurs it will be returned with Iter.Close().
+func (iter *Iterator) Decode(outputArgs ...any) (ok bool) {
+	if iter.err != nil {
 		return false
 	}
 	defer func() {
 		if !ok {
-			q.err = fmt.Errorf("cannot decode result: %s", q.err)
+			iter.err = fmt.Errorf("cannot decode result: %s", iter.err)
 		}
 	}()
 
-	if q.rows == nil {
-		q.err = fmt.Errorf("iteration ended or not started")
+	if iter.rows == nil {
+		iter.err = fmt.Errorf("iteration ended or not started")
 		return false
 	}
 
-	cols, err := q.rows.Columns()
+	ptrs, err := iter.qe.ScanArgs(iter.cols, outputArgs)
 	if err != nil {
-		q.err = err
+		iter.err = err
 		return false
 	}
-	ptrs, err := q.qe.ScanArgs(cols, outputArgs)
-	if err != nil {
-		q.err = err
-		return false
-	}
-	if err := q.rows.Scan(ptrs...); err != nil {
-		q.err = err
+	if err := iter.rows.Scan(ptrs...); err != nil {
+		iter.err = err
 		return false
 	}
 	return true
 }
 
-// Close closes the query and returns any errors encountered during iteration.
-func (q *Query) Close() error {
-	if q.rows == nil {
-		return q.err
+// Close finishes the iteration and returns any errors encountered.
+func (i *Iterator) Close() error {
+	if i.rows == nil {
+		return i.err
 	}
-	err := q.rows.Close()
-	q.rows = nil
-	if q.err != nil {
-		return q.err
+	err := i.rows.Close()
+	i.rows = nil
+	if i.err != nil {
+		return i.err
 	}
 	return err
+}
+
+// One runs a query and decodes the first row into outputArgs.
+func (q *Query) One(outputArgs ...any) error {
+	iter := q.Iter()
+	if !iter.Next() {
+		return fmt.Errorf("cannot return one row: no results")
+	}
+	iter.Decode(outputArgs...)
+	return iter.Close()
 }

--- a/sqlair.go
+++ b/sqlair.go
@@ -102,11 +102,11 @@ func (q *Query) Iter() *Iterator {
 // Next prepares the next row for decoding.
 // The first call to Next will execute the query.
 // If an error occurs it will be returned with Iter.Close().
-func (i *Iterator) Next() bool {
-	if i.err != nil {
+func (iter *Iterator) Next() bool {
+	if iter.err != nil || iter.rows == nil {
 		return false
 	}
-	return i.rows.Next()
+	return iter.rows.Next()
 }
 
 // Decode decodes the current result into the structs in outputValues.
@@ -140,14 +140,14 @@ func (iter *Iterator) Decode(outputArgs ...any) (ok bool) {
 }
 
 // Close finishes the iteration and returns any errors encountered.
-func (i *Iterator) Close() error {
-	if i.rows == nil {
-		return i.err
+func (iter *Iterator) Close() error {
+	if iter.rows == nil {
+		return iter.err
 	}
-	err := i.rows.Close()
-	i.rows = nil
-	if i.err != nil {
-		return i.err
+	err := iter.rows.Close()
+	iter.rows = nil
+	if iter.err != nil {
+		return iter.err
 	}
 	return err
 }


### PR DESCRIPTION
This PR adds a new function `Query.Iter()` this returns an `Iterator` that can be used to iterate over the results. The iterator has the method `Next`, `Decode` and `Close`. The query is run on the database when `Query.Iter()` is called.