### PR TITLE
Remove QueryContext

### DIFF
--- a/package_test.go
+++ b/package_test.go
@@ -178,7 +178,7 @@ func (s *PackageSuite) TestValidDecode(c *C) {
 			continue
 		}
 
-		iter := sqlairDB.Query(stmt, t.inputs...).Iter()
+		iter := sqlairDB.Query(nil, stmt, t.inputs...).Iter()
 		i := 0
 		for iter.Next() {
 			if i >= len(t.outputs) {
@@ -283,7 +283,7 @@ func (s *PackageSuite) TestDecodeErrors(c *C) {
 			continue
 		}
 
-		iter := sqlairDB.Query(stmt, t.inputs...).Iter()
+		iter := sqlairDB.Query(nil, stmt, t.inputs...).Iter()
 		i := 0
 		for iter.Next() {
 			if i > len(t.outputs) {
@@ -345,7 +345,7 @@ func (s *PackageSuite) TestValidOne(c *C) {
 			continue
 		}
 
-		q := sqlairDB.Query(stmt, t.inputs...)
+		q := sqlairDB.Query(nil, stmt, t.inputs...)
 		err = q.One(t.outputs...)
 		if err != nil {
 			c.Errorf("\ntest %q failed (One):\ninput: %s\nerr: %s\n", t.summary, t.query, err)
@@ -394,7 +394,7 @@ func (s *PackageSuite) TestOneErrors(c *C) {
 			continue
 		}
 
-		err = sqlairDB.Query(stmt, t.inputs...).One(t.outputs...)
+		err = sqlairDB.Query(nil, stmt, t.inputs...).One(t.outputs...)
 		c.Assert(err, ErrorMatches, t.err,
 			Commentf("\ntest %q failed:\ninput: %s\noutputs: %s", t.summary, t.query, t.outputs))
 	}
@@ -413,7 +413,7 @@ func (s *PackageSuite) TestErrNoRows(c *C) {
 
 	sqlairDB := sqlair.NewDB(db)
 	stmt := sqlair.MustPrepare("SELECT * AS &Person.* FROM person WHERE id=12312", Person{})
-	err = sqlairDB.Query(stmt).One(&Person{})
+	err = sqlairDB.Query(nil, stmt).One(&Person{})
 	if !errors.Is(err, sqlair.ErrNoRows) {
 		c.Errorf("test failed, error %q not the same as %q", err, sqlair.ErrNoRows)
 	}
@@ -486,7 +486,7 @@ func (s *PackageSuite) TestValidAll(c *C) {
 			continue
 		}
 
-		q := sqlairDB.Query(stmt, t.inputs...)
+		q := sqlairDB.Query(nil, stmt, t.inputs...)
 		err = q.All(t.slices...)
 		if err != nil {
 			c.Errorf("\ntest %q failed (All):\ninput: %s\nerr: %s\n", t.summary, t.query, err)
@@ -570,7 +570,7 @@ func (s *PackageSuite) TestAllErrors(c *C) {
 			continue
 		}
 
-		err = db.Query(stmt, t.inputs...).All(t.slices...)
+		err = db.Query(nil, stmt, t.inputs...).All(t.slices...)
 		c.Assert(err, ErrorMatches, t.err,
 			Commentf("\ntest %q failed:\ninput: %s\nslices: %s", t.summary, t.query, t.slices))
 	}
@@ -664,7 +664,7 @@ AND    l.model_uuid = $JujuLeaseKey.model_uuid`,
 			continue
 		}
 
-		iter := sqlairDB.Query(stmt, t.inputs...).Iter()
+		iter := sqlairDB.Query(nil, stmt, t.inputs...).Iter()
 		i := 0
 		for iter.Next() {
 			if i >= len(t.outputs) {

--- a/sqlair.go
+++ b/sqlair.go
@@ -72,16 +72,13 @@ type Iterator struct {
 	err  error
 }
 
-// Query takes a prepared SQLair Statement and returns a Query object for iterating over the results.
-// If an error occurs it will be returned with Query.Close().
-// Query uses QueryContext with context.Background internally.
-func (db *DB) Query(s *Statement, inputArgs ...any) *Query {
-	return db.QueryContext(context.Background(), s, inputArgs...)
-}
+// Query takes a context, prepared SQLair Statement and the structs mentioned in the query arguments.
+// It returns a Query object for iterating over the results.
+func (db *DB) Query(ctx context.Context, s *Statement, inputArgs ...any) *Query {
+	if ctx == nil {
+		ctx = context.Background()
+	}
 
-// QueryContext takes a prepared SQLair Statement and returns a Query object for iterating over the results.
-// If an error occurs it will be returned with Query.Close().
-func (db *DB) QueryContext(ctx context.Context, s *Statement, inputArgs ...any) *Query {
 	qe, err := s.pe.Query(inputArgs...)
 	q := func() (*sql.Rows, error) {
 		return db.db.QueryContext(ctx, qe.QuerySQL(), qe.QueryArgs()...)


### PR DESCRIPTION
This PR removes `DB.QueryContext` and adds `ctx` as the first argument to `Query`. If `ctx` is `nil` then `context.Background()` will be used.