### PR TITLE
Change decode to return an error.

### DIFF
--- a/package_test.go
+++ b/package_test.go
@@ -180,6 +180,7 @@ func (s *PackageSuite) TestValidDecode(c *C) {
 		}
 
 		iter := db.Query(nil, stmt, t.inputs...).Iter()
+		defer iter.Close()
 		i := 0
 		for iter.Next() {
 			if i >= len(t.outputs) {
@@ -285,6 +286,7 @@ func (s *PackageSuite) TestDecodeErrors(c *C) {
 		}
 
 		iter := db.Query(nil, stmt, t.inputs...).Iter()
+		defer iter.Close()
 		i := 0
 		for iter.Next() {
 			if i >= len(t.outputs) {
@@ -643,13 +645,13 @@ func (s *PackageSuite) TestQueryMultipleRuns(c *C) {
 	c.Assert(err, IsNil)
 
 	iter := q.Iter()
+	defer iter.Close()
 	i := 0
 	for iter.Next() {
 		if i >= len(iterOutputs) {
 			c.Fatalf("expected %d rows, got more", len(iterOutputs))
 		}
 		if err := iter.Decode(iterOutputs[i]); err != nil {
-			iter.Close()
 			c.Fatal(err)
 		}
 		i++
@@ -668,13 +670,13 @@ func (s *PackageSuite) TestQueryMultipleRuns(c *C) {
 	c.Assert(allOutput, DeepEquals, allExpected)
 
 	iter = q.Iter()
+	defer iter.Close()
 	i = 0
 	for iter.Next() {
 		if i >= len(iterOutputs) {
 			c.Fatalf("expected %d rows, got more", len(iterOutputs))
 		}
 		if err := iter.Decode(iterOutputs[i]); err != nil {
-			iter.Close()
 			c.Fatal(err)
 		}
 		i++
@@ -918,6 +920,7 @@ AND    l.model_uuid = $JujuLeaseKey.model_uuid`,
 		}
 
 		iter := db.Query(nil, stmt, t.inputs...).Iter()
+		defer iter.Close()
 		i := 0
 		for iter.Next() {
 			if i >= len(t.outputs) {

--- a/package_test.go
+++ b/package_test.go
@@ -628,6 +628,93 @@ DROP TABLE lease_type;
 
 }
 
+func (s *PackageSuite) TestIterMethodOrder(c *C) {
+	dropTables, sqldb, err := personAndAddressDB()
+	if err != nil {
+		c.Fatal(err)
+	}
+
+	db := sqlair.NewDB(sqldb)
+
+	var p = Person{}
+	stmt := sqlair.MustPrepare("SELECT &Person.* FROM person", Person{})
+
+	// Check immidiate Decode.
+	iter := db.Query(nil, stmt).Iter()
+	if iter.Decode(&p) {
+		c.Fatal("expected false, got true")
+	}
+	err = iter.Close()
+	c.Assert(err, ErrorMatches, "cannot decode result: sql: Scan called without calling Next")
+
+	// Check Next after closing.
+	iter = db.Query(nil, stmt).Iter()
+	err = iter.Close()
+	c.Assert(err, IsNil)
+	if iter.Next() {
+		c.Fatal("expected false, got true")
+	}
+	err = iter.Close()
+	c.Assert(err, IsNil)
+
+	// Check Decode after closing.
+	iter = db.Query(nil, stmt).Iter()
+	err = iter.Close()
+	c.Assert(err, IsNil)
+	if iter.Decode(&p) {
+		c.Fatal("expected false, got true")
+	}
+	err = iter.Close()
+	c.Assert(err, ErrorMatches, "cannot decode result: iteration ended or not started")
+
+	// Check multiple closes.
+	iter = db.Query(nil, stmt).Iter()
+	err = iter.Close()
+	c.Assert(err, IsNil)
+	err = iter.Close()
+	c.Assert(err, IsNil)
+
+	// Check SQL Scan error (scanning string into an int).
+	badTypesStmt := sqlair.MustPrepare("SELECT name AS &Person.id FROM person", Person{})
+	iter = db.Query(nil, badTypesStmt).Iter()
+	if !iter.Next() {
+		c.Fatal("expected true, got false")
+	}
+	// SQL scan error, try to
+	if iter.Decode(&p) {
+		c.Fatal("expected false, got true")
+	}
+	err = iter.Close()
+	c.Assert(err, ErrorMatches, `cannot decode result: sql: Scan error on column index 0, name "_sqlair_0": converting driver.Value type string \("Fred"\) to a int: invalid syntax`)
+
+	// Check rows close properly if we get a decode error.
+	// If they do not close properly we will not be able to
+	// drop the table as the connection will not be closed.
+
+	// SQLair error in decode
+	iter = db.Query(nil, stmt).Iter()
+	if !iter.Next() {
+		c.Fatal("expected true, got false")
+	}
+	// Decode is missing output struct (SQLair throws an error).
+	if iter.Decode() {
+		c.Fatal("expected false, got true")
+	}
+
+	// SQL error in decode
+	iter = db.Query(nil, badTypesStmt).Iter()
+	if !iter.Next() {
+		c.Fatal("expected true, got false")
+	}
+	// SQL scan error, try to scan string into an int.
+	if iter.Decode(&p) {
+		c.Fatal("expected false, got true")
+	}
+
+	_, err = db.PlainDB().Exec(dropTables)
+	c.Assert(err, IsNil)
+}
+
 func (s *PackageSuite) TestJujuStore(c *C) {
 	var tests = []struct {
 		summary  string

--- a/sqlair.go
+++ b/sqlair.go
@@ -112,33 +112,28 @@ func (iter *Iterator) Next() bool {
 // Decode decodes the current result into the structs in outputValues.
 // outputArgs must contain all the structs mentioned in the query.
 // If an error occurs it will be returned with Iter.Close().
-func (iter *Iterator) Decode(outputArgs ...any) (ok bool) {
+func (iter *Iterator) Decode(outputArgs ...any) (err error) {
 	if iter.err != nil {
-		return false
+		return iter.err
 	}
 	defer func() {
-		if !ok {
-			iter.err = fmt.Errorf("cannot decode result: %s", iter.err)
+		if err != nil {
+			err = fmt.Errorf("cannot decode result: %s", err)
 		}
 	}()
 
 	if iter.rows == nil {
-		iter.err = fmt.Errorf("iteration ended or not started")
-		return false
+		return fmt.Errorf("iteration ended or not started")
 	}
 
 	ptrs, err := iter.qe.ScanArgs(iter.cols, outputArgs)
 	if err != nil {
-		iter.rows.Close()
-		iter.err = err
-		return false
+		return err
 	}
 	if err := iter.rows.Scan(ptrs...); err != nil {
-		iter.rows.Close()
-		iter.err = err
-		return false
+		return err
 	}
-	return true
+	return nil
 }
 
 // Close finishes the iteration and returns any errors encountered.
@@ -160,7 +155,10 @@ func (q *Query) One(outputArgs ...any) error {
 	if !iter.Next() {
 		return ErrNoRows
 	}
-	iter.Decode(outputArgs...)
+	err := iter.Decode(outputArgs...)
+	if err != nil {
+		return err
+	}
 	return iter.Close()
 }
 
@@ -219,8 +217,9 @@ func (q *Query) All(sliceArgs ...any) (err error) {
 			}
 			outputArgs = append(outputArgs, outputArg.Interface())
 		}
-		if !iter.Decode(outputArgs...) {
-			break
+		if err := iter.Decode(outputArgs...); err != nil {
+			iter.Close()
+			return err
 		}
 		for i, outputArg := range outputArgs {
 			switch k := sliceVals[i].Type().Elem().Kind(); k {

--- a/sqlair.go
+++ b/sqlair.go
@@ -129,10 +129,12 @@ func (iter *Iterator) Decode(outputArgs ...any) (ok bool) {
 
 	ptrs, err := iter.qe.ScanArgs(iter.cols, outputArgs)
 	if err != nil {
+		iter.rows.Close()
 		iter.err = err
 		return false
 	}
 	if err := iter.rows.Scan(ptrs...); err != nil {
+		iter.rows.Close()
 		iter.err = err
 		return false
 	}


### PR DESCRIPTION
This PR now changes Decode to return an error instead of a bool so that issues can be dealt with straight away. It now doesn't close the rows since an error could be handled and iteration could continue.


Old description:
> This PR adds two lines in `Decode` to close the underlying `sql.Rows` if an error occurs in execution. This closes the underlying database connection.
> 
> If a call to `sql.Rows.Next` returns `false` the rows are automatically closed. Since we are stuck with this behaviour when making use of the underlying `sql.Rows` it makes sense that we are consistent with it between our `Iter.Next` and `Iter.Decode` which both return `bool`.
> 
> Moreover, if decode throws an error and the user _does not_ do `Iter.Close` then they will get obscure errors from subsequent actions due to the leaking of the underlying a database connection. In the interest of making the users life as pain-free as possible it makes sense to close this connection proactivally where possible.
> 
> It is very much good practice to do `Iter.Close` after `Next` or `Decode` has returned false not least to check for the error, regardless of this change.