### PR TITLE
Add RunQuery

### DIFF
--- a/sqlair.go
+++ b/sqlair.go
@@ -103,6 +103,20 @@ func (q *Query) Run() error {
 	return nil
 }
 
+func (db *DB) RunQuery(ctx context.Context, query string, inputArgs ...any) error {
+	// Deference input args to use as type samples in prepare
+	var prepArgs = []any{}
+	for _, inputArg := range inputArgs {
+		prepArgs = append(prepArgs, reflect.Indirect(reflect.ValueOf(inputArg)).Interface())
+	}
+
+	stmt, err := Prepare(query, prepArgs...)
+	if err != nil {
+		return err
+	}
+	return db.Query(ctx, stmt, inputArgs...).Run()
+}
+
 // Iter returns an Iterator to iterate through the results row by row.
 func (q *Query) Iter() *Iterator {
 	if q.err != nil {

--- a/sqlair.go
+++ b/sqlair.go
@@ -103,6 +103,7 @@ func (q *Query) Run() error {
 	return nil
 }
 
+// RunQuery is shorthand for preparing a statement, building a query, then doing Query.Run.
 func (db *DB) RunQuery(ctx context.Context, query string, inputArgs ...any) error {
 	// Deference input args to use as type samples in prepare
 	var prepArgs = []any{}


### PR DESCRIPTION
This PR adds a method to `DB` called `RunQuery`. This method is shorthand for
```Go
stmt, err := Prepare(query, args...)
if err != nil {
    ...
}
err := db.Query(ctx, stmt, args...).Run()
```
For example instead of the above, you would write:
```Go
err := db.RunQuery(ctx, query, args...)
```

This PR is waiting on #63 