### PR TITLE
Factor out QueryContext and ExecContext to seperate functions

### DIFF
--- a/internal/expr/expr_test.go
+++ b/internal/expr/expr_test.go
@@ -513,7 +513,7 @@ func (s *ExprSuite) TestValidQuery(c *C) {
 			c.Fatal(err)
 		}
 
-		c.Assert(query.QueryArgs(), DeepEquals, t.queryValues)
+		c.Assert(query.Args(), DeepEquals, t.queryValues)
 	}
 }
 

--- a/internal/expr/query.go
+++ b/internal/expr/query.go
@@ -8,11 +8,11 @@ import (
 	"strings"
 )
 
-func (qe *QueryExpr) QuerySQL() string {
+func (qe *QueryExpr) SQL() string {
 	return qe.sql
 }
 
-func (qe *QueryExpr) QueryArgs() []any {
+func (qe *QueryExpr) Args() []any {
 	return qe.args
 }
 

--- a/sqlair.go
+++ b/sqlair.go
@@ -96,11 +96,19 @@ func (q *Query) Run() error {
 	if q.err != nil {
 		return q.err
 	}
-	_, err := q.qs.ExecContext(q.ctx, q.qe.QuerySQL(), q.qe.QueryArgs()...)
+	_, err := q.exec()
 	if err != nil {
 		return err
 	}
 	return nil
+}
+
+func (q *Query) exec() (sql.Result, error) {
+	return q.qs.ExecContext(q.ctx, q.qe.QuerySQL(), q.qe.QueryArgs()...)
+}
+
+func (q *Query) query() (*sql.Rows, error) {
+	return q.qs.QueryContext(q.ctx, q.qe.QuerySQL(), q.qe.QueryArgs()...)
 }
 
 // Iter returns an Iterator to iterate through the results row by row.
@@ -109,7 +117,7 @@ func (q *Query) Iter() *Iterator {
 		return &Iterator{err: q.err}
 	}
 
-	rows, err := q.qs.QueryContext(q.ctx, q.qe.QuerySQL(), q.qe.QueryArgs()...)
+	rows, err := q.query()
 	if err != nil {
 		return &Iterator{err: err}
 	}

--- a/sqlair.go
+++ b/sqlair.go
@@ -137,11 +137,11 @@ func (q *Query) Get(outputArgs ...any) error {
 }
 
 func (q *Query) exec() (sql.Result, error) {
-	return q.qs.ExecContext(q.ctx, q.qe.QuerySQL(), q.qe.QueryArgs()...)
+	return q.qs.ExecContext(q.ctx, q.qe.SQL(), q.qe.Args()...)
 }
 
 func (q *Query) query() (*sql.Rows, error) {
-	return q.qs.QueryContext(q.ctx, q.qe.QuerySQL(), q.qe.QueryArgs()...)
+	return q.qs.QueryContext(q.ctx, q.qe.SQL(), q.qe.Args()...)
 }
 
 // Iter returns an Iterator to iterate through the results row by row.


### PR DESCRIPTION
This PR creates internal functions that are a part of `Query` to pass through to the `database/sql` functions.