### PR TITLE
Add go doc for project

### DIFF
--- a/doc.go
+++ b/doc.go
@@ -49,16 +49,19 @@ Where Type is a struct and col_name is a `db` tag on one of those fields.
 SQLair Output expressions, however, can take many forms:
 
  1. &Type.col_name
- 2. &Type.*
- 3. table.* AS &Type.*
- 4. (col_name1, col_name2) AS &Type.*
- 5. (renamed_col1, renamed_col2) AS (&Type.col_name1, &Type.col_name2)
+    - Fetches col_name and sets the corresponding field of Type.
 
-1. Fetches col_name and sets the corresponding field of Type.
-2. Fetches and sets all the tagged fields of Type.
-3. Does the sames 2 but prepends all columns with the table name.
-4. Fetches and sets only the specified columns.
-5. Fetches the renamed columns from the database and sets them to the fields of the named columns.
+ 2. &Type.*
+    - Fetches and sets all the tagged fields of Type.
+
+ 3. table.* AS &Type.*
+    - Does the sames 2 but prepends all columns with the table name.
+
+ 4. (col_name1, col_name2) AS &Type.*
+    - Fetches and sets only the specified columns.
+
+ 5. (renamed_col1, renamed_col2) AS (&Type.col_name1, &Type.col_name2)
+    - Fetches the renamed columns from the database and sets them to the fields of the named columns.
 
 Multiple input and output expressions can be written in a single query.
 

--- a/doc.go
+++ b/doc.go
@@ -1,0 +1,66 @@
+/*
+SQLair is a convenience layer for SQL databases that embeds Go structs directly into SQL queries.
+
+The SQL syntax is expanded with SQLair input and output expressions which indicate parts of the query that correspond to Go structs.
+This allows the user to specify the Go structs they want in the SQL query itself whilst allowing the full power of SQL to be utilised.
+This package also provides an alternative API for reading the rows from the database.
+It does not copy database/sql, it instead improves upon it and removes inconsistencies.
+
+# Basics
+
+To read the results of a query into a struct the columns listed in the SQL are replaced by a SQLair output expression.
+The output expressions are parsed and replaced with the column names found in the `db` tags of the struct.
+Similarly, to use a query argument directly from a Go struct the question mark is replaced by a SQLair input expression.
+This package does not parse the SQL query, only the SQLair expressions found within it.
+
+The characters $ and & are used to specify input and outputs expressions respectively.
+For example, given the following tagged struct "Person":
+
+	type Person struct {
+		Name	string	`db:"name"`
+		ID	int		`db:"id"`
+		Team	string  `db:"team"`
+	}
+
+Instead of the SQL query:
+
+	SELECT name, id, team
+	FROM person
+	WHERE manager_name = ?
+
+With SQLair one would write:
+
+	SELECT &Person.*
+	FROM person
+	WHERE manager_name = $Manager.name
+
+SQLair substitutes &Person.* for all columns in the `db` tags of Person.
+$Manager.name instructs SQLair to pass the Name field of the struct Manager as a query argument.
+Note that in the SQLair expressions the `db` tags (i.e. the column names) are used to specify the struct fields _not_ the field names.
+
+# Syntax
+
+SQLair input expressions only take one format:
+
+	$Type.col_name
+
+Where Type is a struct and col_name is a `db` tag on one of those fields.
+
+SQLair Output expressions, however, can take many forms:
+
+ 1. &Type.col_name
+ 2. &Type.*
+ 3. table.* AS &Type.*
+ 4. (col_name1, col_name2) AS &Type.*
+ 5. (renamed_col1, renamed_col2) AS (&Type.col_name1, &Type.col_name2)
+
+1. Fetches col_name and sets the corresponding field of Type.
+2. Fetches and sets all the tagged fields of Type.
+3. Does the sames 2 but prepends all columns with the table name.
+4. Fetches and sets only the specified columns.
+5. Fetches the renamed columns from the database and sets them to the fields of the named columns.
+
+Multiple input and output expressions can be written in a single query.
+A SQLair expression will never be substituted for a wildcard asterisk in a SQL query.
+*/
+package sqlair

--- a/doc.go
+++ b/doc.go
@@ -8,10 +8,10 @@ It does not copy database/sql, it instead improves upon it and removes inconsist
 
 # Basics
 
-To read the results of a query into a struct the columns listed in the SQL are replaced by a SQLair output expression.
+To read the results of a query into a struct, the columns listed in the SQL are replaced by a SQLair output expression.
 The output expressions are parsed and replaced with the column names found in the `db` tags of the struct.
 Similarly, to use a query argument directly from a Go struct the question mark is replaced by a SQLair input expression.
-This package does not parse the SQL query, only the SQLair expressions found within it.
+This package does not parse the SQL query, only the SQLair input/output expressions found within it.
 
 The characters $ and & are used to specify input and outputs expressions respectively.
 For example, given the following tagged struct "Person":
@@ -35,8 +35,9 @@ With SQLair one would write:
 	WHERE manager_name = $Manager.name
 
 SQLair substitutes &Person.* for all columns in the `db` tags of Person.
-$Manager.name instructs SQLair to pass the Name field of the struct Manager as a query argument.
-Note that in the SQLair expressions the `db` tags (i.e. the column names) are used to specify the struct fields _not_ the field names.
+The input expression, $Manager.name, instructs SQLair to pass the Name field of the struct Manager as a query argument.
+
+Note that in the SQLair `db` tags (i.e. the column names) appear in the input/output expressions, not the field names.
 
 # Syntax
 
@@ -44,7 +45,7 @@ SQLair input expressions only take one format:
 
 	$Type.col_name
 
-Where Type is a struct and col_name is a `db` tag on one of those fields.
+Where Type is a struct and col_name is a `db` tag on one of the structs fields.
 
 SQLair Output expressions, however, can take many forms:
 

--- a/doc.go
+++ b/doc.go
@@ -18,7 +18,7 @@ For example, given the following tagged struct "Person":
 
 	type Person struct {
 		Name	string	`db:"name"`
-		ID	int		`db:"id"`
+		ID	int	`db:"id"`
 		Team	string  `db:"team"`
 	}
 
@@ -61,6 +61,7 @@ SQLair Output expressions, however, can take many forms:
 5. Fetches the renamed columns from the database and sets them to the fields of the named columns.
 
 Multiple input and output expressions can be written in a single query.
+
 A SQLair expression will never be substituted for a wildcard asterisk in a SQL query.
 */
 package sqlair

--- a/doc.go
+++ b/doc.go
@@ -4,16 +4,11 @@ SQLair is a convenience layer for SQL databases that embeds Go structs directly 
 The SQL syntax is expanded with SQLair input and output expressions which indicate parts of the query that correspond to Go structs.
 This allows the user to specify the Go structs they want in the SQL query itself whilst allowing the full power of SQL to be utilised.
 This package also provides an alternative API for reading the rows from the database.
-It does not copy database/sql, it instead improves upon it and removes inconsistencies.
+SQLair relies on database/sql for all the underlying operations.
 
 # Basics
 
-To read the results of a query into a struct, the columns listed in the SQL are replaced by a SQLair output expression.
-The output expressions are parsed and replaced with the column names found in the `db` tags of the struct.
-Similarly, to use a query argument directly from a Go struct the question mark is replaced by a SQLair input expression.
-This package does not parse the SQL query, only the SQLair input/output expressions found within it.
-
-The characters $ and & are used to specify input and outputs expressions respectively.
+The characters $ and & are used to specify SQLair input and outputs expressions respectively.
 For example, given the following tagged struct "Person":
 
 	type Person struct {
@@ -34,20 +29,17 @@ With SQLair one would write:
 	FROM person
 	WHERE manager_name = $Manager.name
 
-SQLair substitutes &Person.* for all columns in the `db` tags of Person.
-The input expression, $Manager.name, instructs SQLair to pass the Name field of the struct Manager as a query argument.
-
 Note that in the SQLair `db` tags (i.e. the column names) appear in the input/output expressions, not the field names.
 
 # Syntax
 
-SQLair input expressions only take one format:
+SQLair input expressions take the format:
 
 	$Type.col_name
 
 Where Type is a struct and col_name is a `db` tag on one of the structs fields.
 
-SQLair Output expressions, however, can take many forms:
+SQLair output expressions can take the following formats:
 
  1. &Type.col_name
     - Fetches col_name and sets the corresponding field of Type.
@@ -56,16 +48,14 @@ SQLair Output expressions, however, can take many forms:
     - Fetches and sets all the tagged fields of Type.
 
  3. table.* AS &Type.*
-    - Does the sames 2 but prepends all columns with the table name.
+    - Does the same as 2 but prepends all columns with the table name.
 
- 4. (col_name1, col_name2) AS &Type.*
-    - Fetches and sets only the specified columns.
+ 4. (t1.col_name1, t2.col_name2) AS &Type.*
+    - Fetches and sets only the specified columns (the table is optional).
 
  5. (renamed_col1, renamed_col2) AS (&Type.col_name1, &Type.col_name2)
     - Fetches the renamed columns from the database and sets them to the fields of the named columns.
 
 Multiple input and output expressions can be written in a single query.
-
-A SQLair expression will never be substituted for a wildcard asterisk in a SQL query.
 */
 package sqlair


### PR DESCRIPTION
This PR adds a doc.go to explain the SQLair syntax and give a quick overview of the library.