### PR TITLE
Change mapKey and structField to be passed by reference

### DIFF
--- a/internal/expr/prepare.go
+++ b/internal/expr/prepare.go
@@ -89,7 +89,7 @@ func prepareInput(ti typeNameToInfo, p *inputPart) (typeMember, error) {
 	}
 	switch info := info.(type) {
 	case *mapInfo:
-		return mapKey{name: p.source.name, mapType: info.typ()}, nil
+		return &mapKey{name: p.source.name, mapType: info.typ()}, nil
 	case *structInfo:
 		f, ok := info.tagToField[p.source.name]
 		if !ok {
@@ -126,7 +126,7 @@ func prepareOutput(ti typeNameToInfo, p *outputPart) ([]fullName, []typeMember, 
 			// For a star expression we fill out the destinations as we generate the columns.
 			switch info := info.(type) {
 			case *mapInfo:
-				typeMembers = append(typeMembers, mapKey{name: t.name, mapType: info.typ()})
+				typeMembers = append(typeMembers, &mapKey{name: t.name, mapType: info.typ()})
 			case *structInfo:
 				f, ok := info.tagToField[t.name]
 				if !ok {
@@ -173,7 +173,7 @@ func prepareOutput(ti typeNameToInfo, p *outputPart) ([]fullName, []typeMember, 
 			case *mapInfo:
 				for _, c := range p.source {
 					outCols = append(outCols, c)
-					typeMembers = append(typeMembers, mapKey{name: c.name, mapType: info.typ()})
+					typeMembers = append(typeMembers, &mapKey{name: c.name, mapType: info.typ()})
 				}
 				return outCols, typeMembers, nil
 			case *structInfo:

--- a/internal/expr/query.go
+++ b/internal/expr/query.go
@@ -87,9 +87,9 @@ func (pe *PreparedExpr) Query(args ...any) (ce *QueryExpr, err error) {
 		}
 		var val reflect.Value
 		switch tm := typeMember.(type) {
-		case structField:
+		case *structField:
 			val = v.FieldByIndex(tm.index)
-		case mapKey:
+		case *mapKey:
 			val = v.MapIndex(reflect.ValueOf(tm.name))
 			if val.Kind() == reflect.Invalid {
 				return nil, fmt.Errorf(`map %q does not contain key %q`, outerType.Name(), tm.name)
@@ -169,13 +169,13 @@ func (qe *QueryExpr) ScanArgs(columns []string, outputArgs []any) (scanArgs []an
 			return nil, nil, fmt.Errorf("type %q found in query but not passed to get", typeMember.outerType().Name())
 		}
 		switch tm := typeMember.(type) {
-		case structField:
+		case *structField:
 			val := outputVal.FieldByIndex(tm.index)
 			if !val.CanSet() {
 				return nil, nil, fmt.Errorf("internal error: cannot set field %s of struct %s", tm.name, tm.structType.Name())
 			}
 			ptrs = append(ptrs, val.Addr().Interface())
-		case mapKey:
+		case *mapKey:
 			scanVal := reflect.New(tm.mapType.Elem()).Elem()
 			ptrs = append(ptrs, scanVal.Addr().Interface())
 			mapSetInfos = append(mapSetInfos, mapSetInfo{keyVal: reflect.ValueOf(tm.name), scanVal: scanVal, mapVal: outputVal})

--- a/internal/expr/typeinfo.go
+++ b/internal/expr/typeinfo.go
@@ -18,7 +18,7 @@ type mapKey struct {
 	mapType reflect.Type
 }
 
-func (mk mapKey) outerType() reflect.Type {
+func (mk *mapKey) outerType() reflect.Type {
 	return mk.mapType
 }
 
@@ -37,7 +37,7 @@ type structField struct {
 	omitEmpty bool
 }
 
-func (f structField) outerType() reflect.Type {
+func (f *structField) outerType() reflect.Type {
 	return f.structType
 }
 
@@ -51,7 +51,7 @@ type structInfo struct {
 	// Ordered list of tags
 	tags []string
 
-	tagToField map[string]structField
+	tagToField map[string]*structField
 }
 
 func (si *structInfo) typ() reflect.Type {
@@ -108,7 +108,7 @@ func generateTypeInfo(t reflect.Type) (typeInfo, error) {
 		return &mapInfo{mapType: t}, nil
 	case reflect.Struct:
 		info := structInfo{
-			tagToField: make(map[string]structField),
+			tagToField: make(map[string]*structField),
 			structType: t,
 		}
 		tags := []string{}
@@ -129,7 +129,7 @@ func generateTypeInfo(t reflect.Type) (typeInfo, error) {
 				return nil, fmt.Errorf("cannot parse tag for field %s.%s: %s", t.Name(), f.Name, err)
 			}
 			tags = append(tags, tag)
-			info.tagToField[tag] = structField{
+			info.tagToField[tag] = &structField{
 				name:       f.Name,
 				index:      f.Index,
 				omitEmpty:  omitEmpty,


### PR DESCRIPTION
This PR changes the implementation of `typeMember` for `mapKey` and `structField`. It is now the pointer that implements the type rather than the struct itself. The structs are also passed by reference around the code rather than being copied.