### PR TITLE
Add support for embedded/nested structs

### DIFF
--- a/internal/typeinfo/arginfo_test.go
+++ b/internal/typeinfo/arginfo_test.go
@@ -36,27 +36,27 @@ func (s *typeInfoSuite) TestArgInfoStruct(c *C) {
 	// AllStructOutputs.
 	structFields := []struct {
 		fieldName string
-		index     int
+		index     []int
 		omitEmpty bool
 		tag       string
 	}{{
 		fieldName: "ValidTag2",
-		index:     3,
+		index:     []int{3},
 		omitEmpty: false,
 		tag:       "IdENT99",
 	}, {
 		fieldName: "ValidTag1",
-		index:     2,
+		index:     []int{2},
 		omitEmpty: false,
 		tag:       "_i_d_55_",
 	}, {
 		fieldName: "ID",
-		index:     0,
+		index:     []int{0},
 		omitEmpty: false,
 		tag:       "id",
 	}, {
 		fieldName: "Name",
-		index:     1,
+		index:     []int{1},
 		omitEmpty: true,
 		tag:       "name",
 	}}

--- a/internal/typeinfo/valuelocator.go
+++ b/internal/typeinfo/valuelocator.go
@@ -113,8 +113,8 @@ type structField struct {
 	// structType is the reflected type of the struct containing this field.
 	structType reflect.Type
 
-	// index for Type.Field.
-	index int
+	// index for Type.FieldByIndex.
+	index []int
 
 	// tag is the struct tag associated with this field.
 	tag string
@@ -137,7 +137,7 @@ func (f *structField) LocateParams(typeToValue TypeToValue) ([]reflect.Value, er
 	if !ok {
 		return nil, valueNotFoundError(typeToValue, f.structType)
 	}
-	return []reflect.Value{s.Field(f.index)}, nil
+	return []reflect.Value{s.FieldByIndex(f.index)}, nil
 }
 
 // Desc returns a natural language description of the struct field for use in
@@ -161,7 +161,7 @@ func (f *structField) LocateScanTarget(typeToValue TypeToValue) (any, *ScanProxy
 	if !ok {
 		return nil, nil, valueNotFoundError(typeToValue, f.structType)
 	}
-	val := s.Field(f.index)
+	val := s.FieldByIndex(f.index)
 	if !val.CanSet() {
 		return nil, nil, fmt.Errorf("internal error: cannot set field %s of struct %s", f.name, f.structType.Name())
 	}


### PR DESCRIPTION
Add support for embedded/nested structs to SQLair input and output expressions. Embedded structs are structs included without a field name and nested structs are those included with a field name.
e.g. embedded:
```go
type S struct {
    E
}
```
and nested:
```go
type S struct {
    e E
}
```
A SQLair output expression can now be something like `&MyStruct.myfieldtag` where the tagged field was nested/embedded multiple layers deep. The tags of the inner structs are referenced as if they were tags of the top level struct. An asterisk expression (e.g. `&MyStruct.*`) will now include all embedded/nested tagged fields in a struct.

Pointers to nested structs are also handled as above.

If the field containing a nested struct has a tag on it then it will be ignored (unless the struct in the field implements `sql.Scanner`).

If there are clashing tags between nested structs an error will be returned from `Prepare`.

