### PR TITLE
Allow Unicode struct (field) names and column names

### DIFF
--- a/internal/expr/expr_test.go
+++ b/internal/expr/expr_test.go
@@ -668,11 +668,6 @@ func (s *ExprSuite) TestValidQuery(c *C) {
 		[]any{Person{ID: 666}, StringMap{"street": "Highway to Hell"}},
 		[]any{sql.Named("sqlair_0", "Highway to Hell"), sql.Named("sqlair_1", 666)},
 	}, {
-		"SELECT foo FROM t WHERE x = $StringMap.street, y = $Person.id",
-		[]any{Person{}, StringMap{}},
-		[]any{Person{ID: 666}, StringMap{"street": "Highway to Hell"}},
-		[]any{sql.Named("sqlair_0", "Highway to Hell"), sql.Named("sqlair_1", 666)},
-	}, {
 		"SELECT FROM person WHERE id = $Unicode我Struct.საფოსტო",
 		[]any{Unicode我Struct{}},
 		[]any{Unicode我Struct{X人: 30}},

--- a/internal/expr/parser.go
+++ b/internal/expr/parser.go
@@ -39,15 +39,14 @@ func (p *Parser) init(input string) {
 	p.nextChar()
 }
 
-// nextChar reads the next character from the
-// input and increments the position.
+// nextChar reads the next character from the input and increments the
+// position.
 func (p *Parser) nextChar() {
 	if p.nextPos >= len(p.input) {
 		p.char = 0
 		p.pos = p.nextPos
 		return
 	}
-
 	var size int
 	p.char, size = utf8.DecodeRuneInString(p.input[p.nextPos:])
 	p.pos = p.nextPos

--- a/internal/expr/parser_helper_test.go
+++ b/internal/expr/parser_helper_test.go
@@ -5,7 +5,7 @@ import (
 )
 
 type parseHelperTest struct {
-	bytef    func(byte) bool
+	charf    func(rune) bool
 	stringf  func(string) bool
 	stringf0 func() bool
 	result   []bool
@@ -17,17 +17,17 @@ func (s *ExprInternalSuite) TestRunTable(c *C) {
 	var p = NewParser()
 	var parseTests = []parseHelperTest{
 
-		{bytef: p.peekByte, result: []bool{false}, input: "", data: []string{"a"}},
-		{bytef: p.peekByte, result: []bool{false}, input: "b", data: []string{"a"}},
-		{bytef: p.peekByte, result: []bool{true}, input: "a", data: []string{"a"}},
+		{charf: p.peekChar, result: []bool{false}, input: "", data: []string{"a"}},
+		{charf: p.peekChar, result: []bool{false}, input: "b", data: []string{"a"}},
+		{charf: p.peekChar, result: []bool{true}, input: "a", data: []string{"a"}},
 
-		{bytef: p.skipByte, result: []bool{false}, input: "", data: []string{"a"}},
-		{bytef: p.skipByte, result: []bool{false}, input: "abc", data: []string{"b"}},
-		{bytef: p.skipByte, result: []bool{true, true}, input: "abc", data: []string{"a", "b"}},
+		{charf: p.skipChar, result: []bool{false}, input: "", data: []string{"a"}},
+		{charf: p.skipChar, result: []bool{false}, input: "abc", data: []string{"b"}},
+		{charf: p.skipChar, result: []bool{true, true}, input: "abc", data: []string{"a", "b"}},
 
-		{bytef: p.skipByteFind, result: []bool{false}, input: "", data: []string{"a"}},
-		{bytef: p.skipByteFind, result: []bool{false, true, true}, input: "abcde", data: []string{"x", "b", "c"}},
-		{bytef: p.skipByteFind, result: []bool{true, false}, input: "abcde ", data: []string{" ", " "}},
+		{charf: p.skipCharFind, result: []bool{false}, input: "", data: []string{"a"}},
+		{charf: p.skipCharFind, result: []bool{false, true, true}, input: "abcde", data: []string{"x", "b", "c"}},
+		{charf: p.skipCharFind, result: []bool{true, false}, input: "abcde ", data: []string{" ", " "}},
 
 		{stringf0: p.skipBlanks, result: []bool{false}, input: "", data: []string{}},
 		{stringf0: p.skipBlanks, result: []bool{false}, input: "abc    d", data: []string{}},
@@ -43,19 +43,14 @@ func (s *ExprInternalSuite) TestRunTable(c *C) {
 		{stringf: p.skipString, result: []bool{false}, input: "", data: []string{"a"}},
 		{stringf: p.skipString, result: []bool{true, true}, input: "helloworld", data: []string{"hElLo", "w"}},
 		{stringf: p.skipString, result: []bool{true, true}, input: "hello world", data: []string{"hello", " "}},
-
-		{stringf0: p.skipName, result: []bool{false}, input: " hi", data: []string{}},
-		{stringf0: p.skipName, result: []bool{false}, input: "*", data: []string{}},
-		{stringf0: p.skipName, result: []bool{true}, input: "hello", data: []string{}},
-		{stringf0: p.skipName, result: []bool{false}, input: "2d3d", data: []string{}},
 	}
 	for _, v := range parseTests {
 		// Reset the input.
 		p.init(v.input)
 		for i, _ := range v.result {
 			var result bool
-			if v.bytef != nil {
-				result = v.bytef(v.data[i][0])
+			if v.charf != nil {
+				result = v.charf(rune(v.data[i][0]))
 			}
 			if v.stringf != nil {
 				result = v.stringf(v.data[i])

--- a/internal/expr/typeinfo_test.go
+++ b/internal/expr/typeinfo_test.go
@@ -111,9 +111,6 @@ func (s *ExprInternalSuite) TestReflectBadTagError(c *C) {
 
 	var invalidColumn = []any{
 		struct {
-			ID int64 `db:"5id"`
-		}{99},
-		struct {
 			ID int64 `db:"+id"`
 		}{99},
 		struct {

--- a/package_test.go
+++ b/package_test.go
@@ -59,6 +59,10 @@ type Manager Person
 
 type District struct{}
 
+type lowerCaseStruct struct {
+	X int `db:"id"`
+}
+
 func personAndAddressDB() (string, *sql.DB, error) {
 	createTables := `
 CREATE TABLE person (
@@ -397,6 +401,13 @@ func (s *PackageSuite) TestValidGet(c *C) {
 		inputs:   []any{Address{ID: 1000}, Person{ID: 30}},
 		outputs:  []any{&Person{}, &Address{}, &Manager{}},
 		expected: []any{&Person{30, "Fred", 1000}, &Address{1000, "Happy Land", "Main Street"}, &Manager{30, "Fred", 1000}},
+	}, {
+		summary:  "lower case struct",
+		query:    "SELECT &lowerCaseStruct.* FROM person",
+		types:    []any{lowerCaseStruct{}},
+		inputs:   []any{},
+		outputs:  []any{&lowerCaseStruct{}},
+		expected: []any{&lowerCaseStruct{X: 30}},
 	}}
 
 	dropTables, sqldb, err := personAndAddressDB()


### PR DESCRIPTION
Change the parser to cycle through the input by rune rather than by byte. Go allows certain Unicode characters to be used in struct names and SQLite allows them to be used in column names, therefore we should allow them in these places too.

Also update the column and struct tag parser to accept column names in quotes, since this is also allowed in SQLite.

The logic of the parser has been kept unchanged when possible.