### PR TITLE
Error on unexpected output in `GetAll`

### DIFF
--- a/package_test.go
+++ b/package_test.go
@@ -748,6 +748,13 @@ func (s *PackageSuite) TestGetAllErrors(c *C) {
 		inputs:  []any{},
 		slices:  []any{&[]int{}},
 		err:     `cannot populate slice: need slice of struct, got slice of int`,
+	}, {
+		summary: "output not referenced in query",
+		query:   "SELECT name FROM person",
+		types:   []any{},
+		inputs:  []any{},
+		slices:  []any{&[]Person{}},
+		err:     `cannot populate slice: output variables provided but not referenced in query`,
 	}}
 
 	dropTables, sqldb, err := personAndAddressDB()

--- a/sqlair.go
+++ b/sqlair.go
@@ -255,6 +255,9 @@ func (q *Query) GetAll(sliceArgs ...any) (err error) {
 			sliceArgs = sliceArgs[1:]
 		}
 	}
+	if !q.qe.HasOutputs() && len(sliceArgs) > 0 {
+		return fmt.Errorf("output variables provided but not referenced in query")
+	}
 	// Check slice inputs
 	var slicePtrVals = []reflect.Value{}
 	var sliceVals = []reflect.Value{}


### PR DESCRIPTION
The PR adds a check in `GetAll` that triggers an error if the query has no output expressions but arguments were passed to `GetAll`. This PR brings the behaviour of `GetAll` in line with `Get` which already implements this check.

This error is useful if a user has not realised that all results in a query need to be inside output expressions and write something like this:
```SQL
SELECT name FROM person
```
In SQLair this will be executed wit `sql.Exec` and no results will be available since it contains no output expressions.