### PR TITLE
Enforce matching bracketing in output expressions

### DIFF
--- a/internal/expr/expr_test.go
+++ b/internal/expr/expr_test.go
@@ -376,16 +376,16 @@ func (s *ExprSuite) TestParseErrors(c *C) {
 		err:   `cannot parse expression: column 36: unqualified type, expected Address.* or Address.<db tag>`,
 	}, {
 		query: "SELECT name AS (&Person.*)",
-		err:   `cannot parse expression: column 26: unexpected brackets around types after "AS"`,
+		err:   `cannot parse expression: column 26: unexpected parentheses around types after "AS"`,
 	}, {
 		query: "SELECT name AS (&Person.name, &Person.id)",
-		err:   `cannot parse expression: column 41: unexpected brackets around types after "AS"`,
+		err:   `cannot parse expression: column 41: unexpected parentheses around types after "AS"`,
 	}, {
 		query: "SELECT (name) AS &Person.*",
-		err:   `cannot parse expression: column 26: missing brackets around types after "AS"`,
+		err:   `cannot parse expression: column 26: missing parentheses around types after "AS"`,
 	}, {
 		query: "SELECT (name, id) AS &Person.*",
-		err:   `cannot parse expression: column 30: missing brackets around types after "AS"`,
+		err:   `cannot parse expression: column 30: missing parentheses around types after "AS"`,
 	}}
 
 	for _, t := range tests {

--- a/internal/expr/expr_test.go
+++ b/internal/expr/expr_test.go
@@ -116,8 +116,8 @@ AND z = @sqlair_0 -- The line with $Person.id on it
 `,
 }, {
 	"comments v2",
-	`SELECT (&Person.name, /* ... */ &Person.id), (&Address.id /* ... */, &Address.street) FROM p -- End of the line`,
-	`[Bypass[SELECT ] Output[[] [Person.name Person.id]] Bypass[, ] Output[[] [Address.id Address.street]] Bypass[ FROM p -- End of the line]]`,
+	`SELECT (*) AS (&Person.name, /* ... */ &Person.id), (*) AS (&Address.id /* ... */, &Address.street) FROM p -- End of the line`,
+	`[Bypass[SELECT ] Output[[*] [Person.name Person.id]] Bypass[, ] Output[[*] [Address.id Address.street]] Bypass[ FROM p -- End of the line]]`,
 	[]any{Person{}, Address{}},
 	`SELECT name AS _sqlair_0, id AS _sqlair_1, id AS _sqlair_2, street AS _sqlair_3 FROM p -- End of the line`,
 }, {
@@ -134,13 +134,13 @@ AND z = @sqlair_0 -- The line with $Person.id on it
 	"SELECT address_id AS _sqlair_0, id AS _sqlair_1, name AS _sqlair_2 FROM t",
 }, {
 	"star as output multitype",
-	"SELECT * AS (&Person.*, &Address.*) FROM t",
+	"SELECT (*) AS (&Person.*, &Address.*) FROM t",
 	"[Bypass[SELECT ] Output[[*] [Person.* Address.*]] Bypass[ FROM t]]",
 	[]any{Person{}, Address{}},
 	"SELECT address_id AS _sqlair_0, id AS _sqlair_1, name AS _sqlair_2, district AS _sqlair_3, id AS _sqlair_4, street AS _sqlair_5 FROM t",
 }, {
 	"multiple multitype",
-	"SELECT t.* AS (&Person.*, &M.uid), (district, street, postcode) AS (&Address.district, &Address.street, &M.postcode) FROM t",
+	"SELECT (t.*) AS (&Person.*, &M.uid), (district, street, postcode) AS (&Address.district, &Address.street, &M.postcode) FROM t",
 	"[Bypass[SELECT ] Output[[t.*] [Person.* M.uid]] Bypass[, ] Output[[district street postcode] [Address.district Address.street M.postcode]] Bypass[ FROM t]]",
 	[]any{Person{}, Address{}, sqlair.M{}},
 	"SELECT t.address_id AS _sqlair_0, t.id AS _sqlair_1, t.name AS _sqlair_2, t.uid AS _sqlair_3, district AS _sqlair_4, street AS _sqlair_5, postcode AS _sqlair_6 FROM t",
@@ -176,7 +176,7 @@ AND z = @sqlair_0 -- The line with $Person.id on it
 	"SELECT address_id AS _sqlair_0, id AS _sqlair_1, name AS _sqlair_2, a.district AS _sqlair_3, a.id AS _sqlair_4, a.street AS _sqlair_5 FROM person, address a WHERE name = 'Fred'",
 }, {
 	"map input and output",
-	"SELECT (p.name, a.id) AS &M.*, street AS &StringMap.*, &IntMap.id FROM person, address a WHERE name = $M.name",
+	"SELECT (p.name, a.id) AS (&M.*), street AS &StringMap.*, &IntMap.id FROM person, address a WHERE name = $M.name",
 	"[Bypass[SELECT ] Output[[p.name a.id] [M.*]] Bypass[, ] Output[[street] [StringMap.*]] Bypass[, ] Output[[] [IntMap.id]] Bypass[ FROM person, address a WHERE name = ] Input[M.name]]",
 	[]any{sqlair.M{}, IntMap{}, StringMap{}},
 	"SELECT p.name AS _sqlair_0, a.id AS _sqlair_1, street AS _sqlair_2, id AS _sqlair_3 FROM person, address a WHERE name = @sqlair_0",
@@ -194,43 +194,43 @@ AND z = @sqlair_0 -- The line with $Person.id on it
 	"SELECT a.district AS _sqlair_0, a.id AS _sqlair_1 FROM address AS a",
 }, {
 	"multicolumn output v3",
-	"SELECT * AS (&Person.address_id, &Address.*, &Manager.id) FROM address AS a",
+	"SELECT (*) AS (&Person.address_id, &Address.*, &Manager.id) FROM address AS a",
 	"[Bypass[SELECT ] Output[[*] [Person.address_id Address.* Manager.id]] Bypass[ FROM address AS a]]",
 	[]any{Person{}, Address{}, Manager{}},
 	"SELECT address_id AS _sqlair_0, district AS _sqlair_1, id AS _sqlair_2, street AS _sqlair_3, id AS _sqlair_4 FROM address AS a",
 }, {
 	"multicolumn output v4",
-	"SELECT (a.district, a.street) AS &Address.* FROM address AS a WHERE p.name = 'Fred'",
+	"SELECT (a.district, a.street) AS (&Address.*) FROM address AS a WHERE p.name = 'Fred'",
 	"[Bypass[SELECT ] Output[[a.district a.street] [Address.*]] Bypass[ FROM address AS a WHERE p.name = 'Fred']]",
 	[]any{Address{}},
 	"SELECT a.district AS _sqlair_0, a.street AS _sqlair_1 FROM address AS a WHERE p.name = 'Fred'",
 }, {
 	"multicolumn output v5",
 	"SELECT (&Address.street, &Person.id) FROM address AS a WHERE p.name = 'Fred'",
-	"[Bypass[SELECT ] Output[[] [Address.street Person.id]] Bypass[ FROM address AS a WHERE p.name = 'Fred']]",
+	"[Bypass[SELECT (] Output[[] [Address.street]] Bypass[, ] Output[[] [Person.id]] Bypass[) FROM address AS a WHERE p.name = 'Fred']]",
 	[]any{Address{}, Person{}},
-	"SELECT street AS _sqlair_0, id AS _sqlair_1 FROM address AS a WHERE p.name = 'Fred'",
+	"SELECT (street AS _sqlair_0, id AS _sqlair_1) FROM address AS a WHERE p.name = 'Fred'",
 }, {
 	"complex query v1",
-	"SELECT p.* AS &Person.*, (a.district, a.street) AS &Address.*, (5+7), (col1 * col2) AS calculated_value FROM person AS p JOIN address AS a ON p.address_id = a.id WHERE p.name = 'Fred'",
+	"SELECT p.* AS &Person.*, (a.district, a.street) AS (&Address.*), (5+7), (col1 * col2) AS calculated_value FROM person AS p JOIN address AS a ON p.address_id = a.id WHERE p.name = 'Fred'",
 	"[Bypass[SELECT ] Output[[p.*] [Person.*]] Bypass[, ] Output[[a.district a.street] [Address.*]] Bypass[, (5+7), (col1 * col2) AS calculated_value FROM person AS p JOIN address AS a ON p.address_id = a.id WHERE p.name = 'Fred']]",
 	[]any{Person{}, Address{}},
 	`SELECT p.address_id AS _sqlair_0, p.id AS _sqlair_1, p.name AS _sqlair_2, a.district AS _sqlair_3, a.street AS _sqlair_4, (5+7), (col1 * col2) AS calculated_value FROM person AS p JOIN address AS a ON p.address_id = a.id WHERE p.name = 'Fred'`,
 }, {
 	"complex query v2",
-	"SELECT p.* AS &Person.*, (a.district, a.street) AS &Address.* FROM person AS p JOIN address AS a ON p .address_id = a.id WHERE p.name = 'Fred'",
+	"SELECT p.* AS &Person.*, (a.district, a.street) AS (&Address.*) FROM person AS p JOIN address AS a ON p .address_id = a.id WHERE p.name = 'Fred'",
 	"[Bypass[SELECT ] Output[[p.*] [Person.*]] Bypass[, ] Output[[a.district a.street] [Address.*]] Bypass[ FROM person AS p JOIN address AS a ON p .address_id = a.id WHERE p.name = 'Fred']]",
 	[]any{Person{}, Address{}},
 	"SELECT p.address_id AS _sqlair_0, p.id AS _sqlair_1, p.name AS _sqlair_2, a.district AS _sqlair_3, a.street AS _sqlair_4 FROM person AS p JOIN address AS a ON p .address_id = a.id WHERE p.name = 'Fred'",
 }, {
 	"complex query v3",
-	"SELECT p.* AS &Person.*, (a.district, a.street) AS &Address.* FROM person AS p JOIN address AS a ON p.address_id = a.id WHERE p.name IN (SELECT name FROM table WHERE table.n = $Person.name)",
+	"SELECT p.* AS &Person.*, (a.district, a.street) AS (&Address.*) FROM person AS p JOIN address AS a ON p.address_id = a.id WHERE p.name IN (SELECT name FROM table WHERE table.n = $Person.name)",
 	"[Bypass[SELECT ] Output[[p.*] [Person.*]] Bypass[, ] Output[[a.district a.street] [Address.*]] Bypass[ FROM person AS p JOIN address AS a ON p.address_id = a.id WHERE p.name IN (SELECT name FROM table WHERE table.n = ] Input[Person.name] Bypass[)]]",
 	[]any{Person{}, Address{}},
 	`SELECT p.address_id AS _sqlair_0, p.id AS _sqlair_1, p.name AS _sqlair_2, a.district AS _sqlair_3, a.street AS _sqlair_4 FROM person AS p JOIN address AS a ON p.address_id = a.id WHERE p.name IN (SELECT name FROM table WHERE table.n = @sqlair_0)`,
 }, {
 	"complex query v4",
-	"SELECT p.* AS &Person.* FROM person WHERE p.name IN (SELECT name FROM table WHERE table.n = $Person.name) UNION SELECT (a.district, a.street) AS &Address.* FROM person WHERE p.name IN (SELECT name FROM table WHERE table.n = $Person.name)",
+	"SELECT p.* AS &Person.* FROM person WHERE p.name IN (SELECT name FROM table WHERE table.n = $Person.name) UNION SELECT (a.district, a.street) AS (&Address.*) FROM person WHERE p.name IN (SELECT name FROM table WHERE table.n = $Person.name)",
 	"[Bypass[SELECT ] Output[[p.*] [Person.*]] Bypass[ FROM person WHERE p.name IN (SELECT name FROM table WHERE table.n = ] Input[Person.name] Bypass[) UNION SELECT ] Output[[a.district a.street] [Address.*]] Bypass[ FROM person WHERE p.name IN (SELECT name FROM table WHERE table.n = ] Input[Person.name] Bypass[)]]",
 	[]any{Person{}, Address{}},
 	`SELECT p.address_id AS _sqlair_0, p.id AS _sqlair_1, p.name AS _sqlair_2 FROM person WHERE p.name IN (SELECT name FROM table WHERE table.n = @sqlair_0) UNION SELECT a.district AS _sqlair_3, a.street AS _sqlair_4 FROM person WHERE p.name IN (SELECT name FROM table WHERE table.n = @sqlair_1)`,
@@ -374,6 +374,18 @@ func (s *ExprSuite) TestParseErrors(c *C) {
 	}, {
 		query: "SELECT foo FROM t WHERE x = $Address",
 		err:   `cannot parse expression: column 36: unqualified type, expected Address.* or Address.<db tag>`,
+	}, {
+		query: "SELECT name AS (&Person.*)",
+		err:   `cannot parse expression: column 26: unexpected brackets around types after "AS"`,
+	}, {
+		query: "SELECT name AS (&Person.name, &Person.id)",
+		err:   `cannot parse expression: column 41: unexpected brackets around types after "AS"`,
+	}, {
+		query: "SELECT (name) AS &Person.*",
+		err:   `cannot parse expression: column 26: missing brackets around types after "AS"`,
+	}, {
+		query: "SELECT (name, id) AS &Person.*",
+		err:   `cannot parse expression: column 30: missing brackets around types after "AS"`,
 	}}
 
 	for _, t := range tests {
@@ -406,21 +418,21 @@ func (s *ExprSuite) TestPrepareErrors(c *C) {
 		prepareArgs []any
 		err         string
 	}{{
-		query:       "SELECT (p.name, t.id) AS &Address.id FROM t",
+		query:       "SELECT (p.name, t.id) AS (&Address.id) FROM t",
 		prepareArgs: []any{Address{}},
-		err:         "cannot prepare expression: mismatched number of columns and targets in output expression: (p.name, t.id) AS &Address.id",
+		err:         "cannot prepare expression: mismatched number of columns and targets in output expression: (p.name, t.id) AS (&Address.id)",
 	}, {
-		query:       "SELECT p.name AS (&Address.district, &Address.street) FROM t",
+		query:       "SELECT (p.name) AS (&Address.district, &Address.street) FROM t",
 		prepareArgs: []any{Address{}},
-		err:         "cannot prepare expression: mismatched number of columns and targets in output expression: p.name AS (&Address.district, &Address.street)",
+		err:         "cannot prepare expression: mismatched number of columns and targets in output expression: (p.name) AS (&Address.district, &Address.street)",
 	}, {
 		query:       "SELECT (&Address.*, &Address.id) FROM t",
 		prepareArgs: []any{Address{}, Person{}},
 		err:         `cannot prepare expression: member "id" of type "Address" appears more than once`,
 	}, {
-		query:       "SELECT (p.*, t.name) AS &Address.* FROM t",
+		query:       "SELECT (p.*, t.name) AS (&Address.*) FROM t",
 		prepareArgs: []any{Address{}},
-		err:         "cannot prepare expression: invalid asterisk in output expression columns: (p.*, t.name) AS &Address.*",
+		err:         "cannot prepare expression: invalid asterisk in output expression columns: (p.*, t.name) AS (&Address.*)",
 	}, {
 		query:       "SELECT (name, p.*) AS (&Person.id, &Person.*) FROM t",
 		prepareArgs: []any{Address{}, Person{}},
@@ -430,9 +442,9 @@ func (s *ExprSuite) TestPrepareErrors(c *C) {
 		prepareArgs: []any{Address{}, Person{}},
 		err:         `cannot prepare expression: member "address_id" of type "Person" appears more than once`,
 	}, {
-		query:       "SELECT (p.*, t.*) AS &Address.* FROM t",
+		query:       "SELECT (p.*, t.*) AS (&Address.*) FROM t",
 		prepareArgs: []any{Address{}},
-		err:         "cannot prepare expression: invalid asterisk in output expression columns: (p.*, t.*) AS &Address.*",
+		err:         "cannot prepare expression: invalid asterisk in output expression columns: (p.*, t.*) AS (&Address.*)",
 	}, {
 		query:       "SELECT (id, name) AS (&Person.id, &Address.*) FROM t",
 		prepareArgs: []any{Address{}, Person{}},
@@ -450,7 +462,7 @@ func (s *ExprSuite) TestPrepareErrors(c *C) {
 		prepareArgs: []any{Address{}},
 		err:         `cannot prepare expression: type "Address" has no "number" db tag`,
 	}, {
-		query:       "SELECT (street, road) AS &Address.* FROM t",
+		query:       "SELECT (street, road) AS (&Address.*) FROM t",
 		prepareArgs: []any{Address{}},
 		err:         `cannot prepare expression: type "Address" has no "road" db tag`,
 	}, {

--- a/internal/expr/parser.go
+++ b/internal/expr/parser.go
@@ -452,8 +452,8 @@ func (p *Parser) parseList(parseFn func(p *Parser) (fullName, bool, error)) ([]f
 }
 
 // parseColumns parses a single column or a list of columns. Lists must be
-// enclosed in brackets.
-func (p *Parser) parseColumns() (cols []fullName, bracketed bool, ok bool) {
+// enclosed in parentheses.
+func (p *Parser) parseColumns() (cols []fullName, parentheses bool, ok bool) {
 	// Case 1: A single column e.g. "p.name".
 	if col, ok, _ := p.parseColumn(); ok {
 		return []fullName{col}, false, true
@@ -468,8 +468,8 @@ func (p *Parser) parseColumns() (cols []fullName, bracketed bool, ok bool) {
 }
 
 // parseTargetTypes parses a single output type or a list of output types.
-// Lists of types must be enclosed in brackets.
-func (p *Parser) parseTargetTypes() (types []fullName, bracketed bool, ok bool, err error) {
+// Lists of types must be enclosed in parentheses.
+func (p *Parser) parseTargetTypes() (types []fullName, parentheses bool, ok bool, err error) {
 	// Case 1: A single target e.g. "&Person.name".
 	if targetTypes, ok, err := p.parseTargetType(); err != nil {
 		return nil, false, false, err
@@ -506,18 +506,18 @@ func (p *Parser) parseOutputExpression() (*outputPart, bool, error) {
 	cp := p.save()
 
 	// Case 2: There are columns e.g. "p.col1 AS &Person.*".
-	if cols, colsBracketed, ok := p.parseColumns(); ok {
+	if cols, parenCols, ok := p.parseColumns(); ok {
 		p.skipBlanks()
 		if p.skipString("AS") {
 			p.skipBlanks()
-			if targetTypes, typesBracketed, ok, err := p.parseTargetTypes(); err != nil {
+			if targetTypes, parenTypes, ok, err := p.parseTargetTypes(); err != nil {
 				return nil, false, err
 			} else if ok {
-				if colsBracketed && !typesBracketed {
-					return nil, false, fmt.Errorf(`column %d: missing brackets around types after "AS"`, p.pos)
+				if parenCols && !parenTypes {
+					return nil, false, fmt.Errorf(`column %d: missing parentheses around types after "AS"`, p.pos)
 				}
-				if !colsBracketed && typesBracketed {
-					return nil, false, fmt.Errorf(`column %d: unexpected brackets around types after "AS"`, p.pos)
+				if !parenCols && parenTypes {
+					return nil, false, fmt.Errorf(`column %d: unexpected parentheses around types after "AS"`, p.pos)
 				}
 				return &outputPart{
 					sourceColumns: cols,

--- a/internal/expr/parser.go
+++ b/internal/expr/parser.go
@@ -448,7 +448,7 @@ func (p *Parser) parseList(parseFn func(p *Parser) (fullName, bool, error)) ([]f
 
 		nextItem = p.skipByte(',')
 	}
-	return nil, false, fmt.Errorf("column %d: missing closing brackets", parenPos)
+	return nil, false, fmt.Errorf("column %d: missing closing parentheses", parenPos)
 }
 
 // parseColumns parses a single column or a list of columns. Lists must be

--- a/internal/expr/parser.go
+++ b/internal/expr/parser.go
@@ -453,22 +453,18 @@ func (p *Parser) parseList(parseFn func(p *Parser) (fullName, bool, error)) ([]f
 
 // parseColumns parses a single column or a list of columns. Lists must be
 // enclosed in brackets.
-func (p *Parser) parseColumns() (cols []fullName, bracketed bool, ok bool, err error) {
+func (p *Parser) parseColumns() (cols []fullName, bracketed bool, ok bool) {
 	// Case 1: A single column e.g. "p.name".
-	if col, ok, err := p.parseColumn(); err != nil {
-		return nil, false, false, err
-	} else if ok {
-		return []fullName{col}, false, true, nil
+	if col, ok, _ := p.parseColumn(); ok {
+		return []fullName{col}, false, true
 	}
 
 	// Case 2: Multiple columns e.g. "(p.name, p.id)".
-	if cols, ok, err := p.parseList((*Parser).parseColumn); err != nil {
-		return nil, true, false, err
-	} else if ok {
-		return cols, true, true, nil
+	if cols, ok, _ := p.parseList((*Parser).parseColumn); ok {
+		return cols, true, true
 	}
 
-	return nil, false, false, nil
+	return nil, false, false
 }
 
 // parseTargetTypes parses a single output type or a list of output types.
@@ -507,11 +503,10 @@ func (p *Parser) parseOutputExpression() (*outputPart, bool, error) {
 		}, true, nil
 	}
 
-	// Case 2: There are columns e.g. "p.col1 AS &Person.*".
 	cp := p.save()
-	// The error from parseColumns is ignored. It indicates we have not found
-	// an output expression.
-	if cols, colsBracketed, ok, _ := p.parseColumns(); ok {
+
+	// Case 2: There are columns e.g. "p.col1 AS &Person.*".
+	if cols, colsBracketed, ok := p.parseColumns(); ok {
 		p.skipBlanks()
 		if p.skipString("AS") {
 			p.skipBlanks()

--- a/package_test.go
+++ b/package_test.go
@@ -140,7 +140,7 @@ func (s *PackageSuite) TestValidIterGet(c *C) {
 		expected: [][]any{{&Address{Street: "Fred", ID: 1000}}},
 	}, {
 		summary:  "select into star struct",
-		query:    "SELECT (name, address_id) AS &Person.* FROM person WHERE address_id IN ( $Manager.address_id, $Address.district )",
+		query:    "SELECT (name, address_id) AS (&Person.*) FROM person WHERE address_id IN ( $Manager.address_id, $Address.district )",
 		types:    []any{Person{}, Address{}, Manager{}},
 		inputs:   []any{Manager{PostalCode: 1000}, Address{ID: 2000}},
 		outputs:  [][]any{{&Person{}}},
@@ -154,14 +154,14 @@ func (s *PackageSuite) TestValidIterGet(c *C) {
 		expected: [][]any{{sqlair.M{"name": "Fred"}}, {sqlair.M{"name": "Mark"}}},
 	}, {
 		summary:  "select into star map",
-		query:    "SELECT (name, address_id) AS &M.* FROM person WHERE address_id = $M.p1",
+		query:    "SELECT (name, address_id) AS (&M.*) FROM person WHERE address_id = $M.p1",
 		types:    []any{sqlair.M{}},
 		inputs:   []any{sqlair.M{"p1": 1000}},
 		outputs:  [][]any{{&sqlair.M{"address_id": 0}}},
 		expected: [][]any{{&sqlair.M{"name": "Fred", "address_id": int64(1000)}}},
 	}, {
 		summary:  "select into custom map",
-		query:    "SELECT (name, address_id) AS &CustomMap.* FROM person WHERE address_id IN ( $CustomMap.address_id, $CustomMap.district)",
+		query:    "SELECT (name, address_id) AS (&CustomMap.*) FROM person WHERE address_id IN ( $CustomMap.address_id, $CustomMap.district)",
 		types:    []any{CustomMap{}},
 		inputs:   []any{CustomMap{"address_id": 1000, "district": 2000}},
 		outputs:  [][]any{{&CustomMap{"address_id": 0}}},
@@ -1172,7 +1172,7 @@ func (s *PackageSuite) TestJujuStore(c *C) {
 	}{{
 		summary: "juju store lease group query",
 		query: `
-SELECT (t.type, l.model_uuid, l.name) AS &JujuLeaseKey.*, (l.holder, l.expiry) AS &JujuLeaseInfo.*
+SELECT (t.type, l.model_uuid, l.name) AS (&JujuLeaseKey.*), (l.holder, l.expiry) AS (&JujuLeaseInfo.*)
 FROM   lease l JOIN lease_type t ON l.lease_type_id = t.id
 WHERE  t.type = $JujuLeaseKey.type
 AND    l.model_uuid = $JujuLeaseKey.model_uuid`,


### PR DESCRIPTION
This PR changes the syntax of output expressions. For output expressions with columns both sides now need to be unbracketed, or bracketed.

This PR is intended to ensure that the syntax stays consistent. This requirement may be relaxed in the future.

Now allowed:
- `(name, id) AS (&Person.*)`
- `(name) AS (&Person.*)`
- `name AS &Person.*`

Now not allowed:
- `(name, id) AS &Person.*`
- `(name) AS &Person.*`
- `name AS (&Person.*)`