### PR TITLE
Error on struct with no tags

### DIFF
--- a/internal/expr/prepare.go
+++ b/internal/expr/prepare.go
@@ -143,6 +143,9 @@ func prepareOutput(ti typeNameToInfo, p *outputPart) ([]fullName, []typeMember, 
 				case *mapInfo:
 					return nil, nil, fmt.Errorf(`&%s.* cannot be used for maps when no column names are specified`, info.typ().Name())
 				case *structInfo:
+					if len(info.tags) == 0 {
+						return nil, nil, fmt.Errorf("type %q in %q does not have any db tags", info.typ().Name(), p.raw)
+					}
 					for _, tag := range info.tags {
 						outCols = append(outCols, fullName{pref, tag})
 						typeMembers = append(typeMembers, info.tagToField[tag])


### PR DESCRIPTION
This PR adds in a check for output expressions that use an asterisk, e.g. `&MyStruct.*`. If the struct has no `db` tags then an error will be thrown. Currently, the statement `SELECT &MyStruct.* FROM t` would result in the SQL `SELECT  FROM t` which would trigger a parsing error from the database.