### PR TITLE
Error on missing output columns

### DIFF
--- a/internal/expr/query.go
+++ b/internal/expr/query.go
@@ -199,7 +199,7 @@ func (qe *QueryExpr) ScanArgs(columns []string, outputArgs []any) (scanArgs []an
 
 	for i := 0; i < len(qe.outputs); i++ {
 		if !columnInResult[i] {
-			return nil, nil, fmt.Errorf("column %q for struct %q not found in results", qe.outputs[i].memberName(), qe.outputs[i].outerType().Name())
+			return nil, nil, fmt.Errorf(`query uses "&%s" outside of result context`, qe.outputs[i].outerType().Name())
 		}
 	}
 

--- a/internal/expr/query.go
+++ b/internal/expr/query.go
@@ -151,7 +151,7 @@ func (qe *QueryExpr) ScanArgs(columns []string, outputArgs []any) (scanArgs []an
 
 	// Generate the pointers.
 	var ptrs = []any{}
-	var columnInResult = make(map[int]bool)
+	var columnInResult = make([]bool, len(columns))
 	for _, column := range columns {
 		idx, ok := markerIndex(column)
 		if !ok {

--- a/package_test.go
+++ b/package_test.go
@@ -334,17 +334,12 @@ func (s *PackageSuite) TestIterGetErrors(c *C) {
 		err:     `cannot get result: type "M" provided more than once, rename one of them`,
 	}, {
 		summary: "output expr in a with clause",
-		query: `WITH averageID(avgid) AS
-		        (SELECT &Person.id
-		        FROM person)
-		        SELECT id
-		        FROM person, averageID
-		        WHERE id > averageID.avgid
-				LIMIT 1`,
+		query: `WITH averageID(avgid) AS (SELECT &Person.id FROM person)
+		        SELECT id FROM person, averageID WHERE id > averageID.avgid LIMIT 1`,
 		types:   []any{Person{}},
 		inputs:  []any{},
 		outputs: []any{&Person{}},
-		err:     `cannot get result: column "id" for struct "Person" not found in results`,
+		err:     `cannot get result: query uses "&Person" outside of result context`,
 	}}
 
 	dropTables, sqldb, err := personAndAddressDB()

--- a/package_test.go
+++ b/package_test.go
@@ -274,64 +274,77 @@ func (s *PackageSuite) TestIterGetErrors(c *C) {
 		query   string
 		types   []any
 		inputs  []any
-		outputs [][]any
+		outputs []any
 		err     string
 	}{{
 		summary: "nil parameter",
 		query:   "SELECT * AS &Person.* FROM person",
 		types:   []any{Person{}},
 		inputs:  []any{},
-		outputs: [][]any{{nil}},
+		outputs: []any{nil},
 		err:     "cannot get result: need map or pointer to struct, got nil",
 	}, {
 		summary: "nil pointer parameter",
 		query:   "SELECT * AS &Person.* FROM person",
 		types:   []any{Person{}},
 		inputs:  []any{},
-		outputs: [][]any{{(*Person)(nil)}},
+		outputs: []any{(*Person)(nil)},
 		err:     "cannot get result: got nil pointer",
 	}, {
 		summary: "non pointer parameter",
 		query:   "SELECT * AS &Person.* FROM person",
 		types:   []any{Person{}},
 		inputs:  []any{},
-		outputs: [][]any{{Person{}}},
+		outputs: []any{Person{}},
 		err:     "cannot get result: need map or pointer to struct, got struct",
 	}, {
 		summary: "wrong struct",
 		query:   "SELECT * AS &Person.* FROM person",
 		types:   []any{Person{}},
 		inputs:  []any{},
-		outputs: [][]any{{&Address{}}},
+		outputs: []any{&Address{}},
 		err:     `cannot get result: type "Address" does not appear in query, have: Person`,
 	}, {
 		summary: "not a struct",
 		query:   "SELECT * AS &Person.* FROM person",
 		types:   []any{Person{}},
 		inputs:  []any{},
-		outputs: [][]any{{&[]any{}}},
+		outputs: []any{&[]any{}},
 		err:     "cannot get result: need map or pointer to struct, got pointer to slice",
 	}, {
 		summary: "missing get value",
 		query:   "SELECT * AS &Person.* FROM person",
 		types:   []any{Person{}},
 		inputs:  []any{},
-		outputs: [][]any{{}},
+		outputs: []any{},
 		err:     `cannot get result: type "Person" found in query but not passed to get`,
 	}, {
 		summary: "multiple of the same type",
 		query:   "SELECT * AS &Person.* FROM person",
 		types:   []any{Person{}},
 		inputs:  []any{},
-		outputs: [][]any{{&Person{}, &Person{}}},
+		outputs: []any{&Person{}, &Person{}},
 		err:     `cannot get result: type "Person" provided more than once, rename one of them`,
 	}, {
 		summary: "multiple of the same type",
 		query:   "SELECT name AS &M.* FROM person",
 		types:   []any{sqlair.M{}},
 		inputs:  []any{},
-		outputs: [][]any{{&sqlair.M{}, sqlair.M{}}},
+		outputs: []any{&sqlair.M{}, sqlair.M{}},
 		err:     `cannot get result: type "M" provided more than once, rename one of them`,
+	}, {
+		summary: "output expr in a with clause",
+		query: `WITH averageID(avgid) AS
+		        (SELECT &Person.id
+		        FROM person)
+		        SELECT id
+		        FROM person, averageID
+		        WHERE id > averageID.avgid
+				LIMIT 1`,
+		types:   []any{Person{}},
+		inputs:  []any{},
+		outputs: []any{&Person{}},
+		err:     `cannot get result: column "id" for struct "Person" not found in results`,
 	}}
 
 	dropTables, sqldb, err := personAndAddressDB()
@@ -350,20 +363,12 @@ func (s *PackageSuite) TestIterGetErrors(c *C) {
 
 		iter := db.Query(nil, stmt, t.inputs...).Iter()
 		defer iter.Close()
-		i := 0
-		for iter.Next() {
-			if i >= len(t.outputs) {
-				c.Errorf("\ntest %q failed (Next):\ninput: %s\nerr: more rows that expected (%d > %d)\n", t.summary, t.query, i+1, len(t.outputs))
-				break
-			}
-			if err := iter.Get(t.outputs[i]...); err != nil {
-				c.Assert(err, ErrorMatches, t.err,
-					Commentf("\ntest %q failed:\ninput: %s\noutputs: %s", t.summary, t.query, t.outputs))
-				iter.Close()
-				break
-			}
-			i++
+		if !iter.Next() {
+			c.Fatalf("\ntest %q failed (Get):\ninput: %s\nerr: no rows returned\n", t.summary, t.query)
 		}
+		err = iter.Get(t.outputs...)
+		c.Assert(err, ErrorMatches, t.err,
+			Commentf("\ntest %q failed:\ninput: %s\noutputs: %s\n", t.summary, t.query, t.outputs))
 		err = iter.Close()
 		if err != nil {
 			c.Errorf("\ntest %q failed (Close):\ninput: %s\nerr: %s\n", t.summary, t.query, err)


### PR DESCRIPTION
Add an error triggered when columns from output expressions do not appear in query results. This could happen when a output expressions is within a `WITH` clause of a query.

Also refactor `TestIterGetErrors` to be more concise and reliable. Before, if no error was thrown by `iter.Get` the test could still pass.