### PR TITLE
Improve comments in `query.go`

### DIFF
--- a/internal/expr/query.go
+++ b/internal/expr/query.go
@@ -19,8 +19,8 @@ func (qe *QueryExpr) HasOutputs() bool {
 	return len(qe.outputs) > 0
 }
 
-// QueryExpr represents a SQLair query that is ready for execution and then
-// scanning of query results.
+// QueryExpr represents a SQL statement and its arguements. It is is ready for
+// execution on a database and then the scanning of the query results.
 type QueryExpr struct {
 	sql     string
 	args    []any

--- a/internal/expr/query.go
+++ b/internal/expr/query.go
@@ -78,7 +78,7 @@ func (pe *PreparedExpr) Query(args ...any) (ce *QueryExpr, err error) {
 		}
 	}
 
-	// Extract query parameteres from arguments.
+	// Extract query parameters from arguments.
 	qargs := []any{}
 	for i, typeMember := range pe.inputs {
 		outerType := typeMember.outerType()
@@ -213,12 +213,12 @@ func (qe *QueryExpr) ScanArgs(columns []string, outputArgs []any) (scanArgs []an
 				ptrs = append(ptrs, val.Addr().Interface())
 			}
 		case *mapKey:
-			// If a result column is to be scanned into a map at a specfic key
+			// If a result column is to be scanned into a map at a specific key
 			// then a pointer to a new proxy variable of type any is added to
 			// ptrs.
 			// The onSuccess function will then populate the target map with
 			// the values in these proxies.
-			// Proxy values are used for map values becuase it is not possible
+			// Proxy values are used for map values because it is not possible
 			// to generate a pointer to a value in a map.
 			scanVal := reflect.New(tm.mapType.Elem()).Elem()
 			ptrs = append(ptrs, scanVal.Addr().Interface())

--- a/internal/expr/query.go
+++ b/internal/expr/query.go
@@ -19,7 +19,7 @@ func (qe *QueryExpr) HasOutputs() bool {
 	return len(qe.outputs) > 0
 }
 
-// QueryExpr represents a SQL statement and its arguements. It is is ready for
+// QueryExpr represents a SQL statement and its arguments. It is is ready for
 // execution on a database and then the scanning of the query results.
 type QueryExpr struct {
 	sql     string


### PR DESCRIPTION
Correct and improve on the content of some of the comments in `query.go`. Also limit the line width to 80 columns in the comments (assuming you have tabs set to 4 spaces).

There is some very minor refactoring of the code to help with line length.
