### PR TITLE
Improve Go Report Card score

### DIFF
--- a/internal/expr/parser.go
+++ b/internal/expr/parser.go
@@ -611,7 +611,7 @@ func (p *Parser) parseTypeAndMember() (memberAccessor, bool, error) {
 }
 
 // parseList takes a parsing function that returns a T and parses a
-// bracketed, comma seperated, list.
+// bracketed, comma separated, list.
 func parseList[T any](p *Parser, parseFn func(p *Parser) (T, bool, error)) ([]T, bool, error) {
 	cp := p.save()
 	if !p.skipByte('(') {

--- a/internal/expr/parser_helper_test.go
+++ b/internal/expr/parser_helper_test.go
@@ -76,7 +76,7 @@ func (s parseSuite) TestRunTable(c *C) {
 	for _, v := range parseTests {
 		// Reset the input.
 		p.init(v.input)
-		for i, _ := range v.result {
+		for i := range v.result {
 			var result bool
 			var err error
 			if v.bytef != nil {

--- a/internal/typeinfo/arginfo.go
+++ b/internal/typeinfo/arginfo.go
@@ -291,12 +291,12 @@ func nameNotFoundError(argInfo ArgInfo, missingTypeName string) error {
 	for argName := range argInfo {
 		argNames = append(argNames, argName)
 	}
-	// Sort for consistant error messages.
+	// Sort for consistent error messages.
 	sort.Strings(argNames)
 	return typeMissingError(missingTypeName, argNames)
 }
 
-// typeMissingError returns an error specificing the missing type and types
+// typeMissingError returns an error specifying the missing type and types
 // that are present.
 func typeMissingError(missingType string, existingTypes []string) error {
 	if len(existingTypes) == 0 {

--- a/internal/typeinfo/valuelocator.go
+++ b/internal/typeinfo/valuelocator.go
@@ -63,7 +63,7 @@ func (mk *mapKey) ArgType() reflect.Type {
 	return mk.mapType
 }
 
-// LocateParams locates the map in typeToValue and then gets value assosiated
+// LocateParams locates the map in typeToValue and then gets value associated
 // with the key specified in mapKey. An error is returned if the map does not
 // contain this key. A slice with a single entry is returned to fit the Input
 // interface.
@@ -222,7 +222,7 @@ func valueNotFoundError(typeToValue TypeToValue, missingType reflect.Type) error
 		}
 		argNames = append(argNames, argType.Name())
 	}
-	// Sort for consistant error messages.
+	// Sort for consistent error messages.
 	sort.Strings(argNames)
 	return typeMissingError(missingType.Name(), argNames)
 }

--- a/package_test.go
+++ b/package_test.go
@@ -639,21 +639,21 @@ func (s *PackageSuite) TestValidGetAll(c *C) {
 		types:    []any{Person{}, Address{}},
 		inputs:   []any{},
 		slices:   []any{&[]*Person{}, &[]*Address{}},
-		expected: []any{&[]*Person{&Person{ID: 30}, &Person{ID: 30}, &Person{ID: 30}, &Person{ID: 20}, &Person{ID: 20}, &Person{ID: 20}, &Person{ID: 40}, &Person{ID: 40}, &Person{ID: 40}, &Person{ID: 35}, &Person{ID: 35}, &Person{ID: 35}}, &[]*Address{&Address{ID: 1000}, &Address{ID: 1500}, &Address{ID: 3500}, &Address{ID: 1000}, &Address{ID: 1500}, &Address{ID: 3500}, &Address{ID: 1000}, &Address{ID: 1500}, &Address{ID: 3500}, &Address{ID: 1000}, &Address{ID: 1500}, &Address{ID: 3500}}},
+		expected: []any{&[]*Person{{ID: 30}, {ID: 30}, {ID: 30}, {ID: 20}, {ID: 20}, {ID: 20}, {ID: 40}, {ID: 40}, {ID: 40}, {ID: 35}, {ID: 35}, {ID: 35}}, &[]*Address{{ID: 1000}, {ID: 1500}, {ID: 3500}, {ID: 1000}, {ID: 1500}, {ID: 3500}, {ID: 1000}, {ID: 1500}, {ID: 3500}, {ID: 1000}, {ID: 1500}, {ID: 3500}}},
 	}, {
 		summary:  "select all columns into person",
 		query:    "SELECT * AS &Person.* FROM person",
 		types:    []any{Person{}},
 		inputs:   []any{},
 		slices:   []any{&[]*Person{}},
-		expected: []any{&[]*Person{&Person{30, "Fred", 1000}, &Person{20, "Mark", 1500}, &Person{40, "Mary", 3500}, &Person{35, "James", 4500}}},
+		expected: []any{&[]*Person{{30, "Fred", 1000}, {20, "Mark", 1500}, {40, "Mary", 3500}, {35, "James", 4500}}},
 	}, {
 		summary:  "select all columns into person with no pointers",
 		query:    "SELECT * AS &Person.* FROM person",
 		types:    []any{Person{}},
 		inputs:   []any{},
 		slices:   []any{&[]Person{}},
-		expected: []any{&[]Person{Person{30, "Fred", 1000}, Person{20, "Mark", 1500}, Person{40, "Mary", 3500}, Person{35, "James", 4500}}},
+		expected: []any{&[]Person{{30, "Fred", 1000}, {20, "Mark", 1500}, {40, "Mary", 3500}, {35, "James", 4500}}},
 	}, {
 		summary:  "single line of query with inputs",
 		query:    "SELECT p.* AS &Person.*, a.* AS &Address.*, p.* AS &Manager.* FROM person AS p, address AS a WHERE p.id = $Person.id AND a.id = $Address.id ",
@@ -902,7 +902,7 @@ func (s *PackageSuite) TestQueryMultipleRuns(c *C) {
 	// Note: Query structs are not designed to be reused (hence why they store a context as a struct field).
 	//       It is, however, possible.
 	allOutput := &[]*Person{}
-	allExpected := &[]*Person{&Person{30, "Fred", 1000}, &Person{20, "Mark", 1500}, &Person{40, "Mary", 3500}, &Person{35, "James", 4500}}
+	allExpected := &[]*Person{{30, "Fred", 1000}, {20, "Mark", 1500}, {40, "Mary", 3500}, {35, "James", 4500}}
 
 	iterOutputs := []any{&Person{}, &Person{}, &Person{}, &Person{}}
 	iterExpected := []any{&Person{30, "Fred", 1000}, &Person{20, "Mark", 1500}, &Person{40, "Mary", 3500}, &Person{35, "James", 4500}}

--- a/package_test.go
+++ b/package_test.go
@@ -1125,7 +1125,7 @@ func (s *PackageSuite) TestIterMethodOrder(c *C) {
 	var p = Person{}
 	stmt := sqlair.MustPrepare("SELECT &Person.* FROM person", Person{})
 
-	// Check immidiate Get.
+	// Check immediate Get.
 	iter := db.Query(nil, stmt).Iter()
 	err = iter.Get(&p)
 	c.Assert(err, ErrorMatches, "cannot get result: cannot call Get before Next unless getting outcome")


### PR DESCRIPTION
Fix a few spellings and runs `gofmt -s` on the codebase. This brings the score on [go report](https://goreportcard.com/report/github.com/canonical/sqlair) to 100% in all categories.