### PR TITLE
Include expression in prepare errors

### DIFF
--- a/internal/expr/expr_test.go
+++ b/internal/expr/expr_test.go
@@ -543,17 +543,17 @@ func (s *ExprSuite) TestPrepareMapError(c *C) {
 		"all output into map star",
 		"SELECT &M.* FROM person WHERE name = 'Fred'",
 		[]any{sqlair.M{}},
-		"cannot prepare statement: output expression: &M.*: asterisk cannot be used with maps when no column names are specified",
+		"cannot prepare statement: output expression: &M.*: asterisk cannot be used with map when no column names are specified",
 	}, {
 		"all output into map star from table star",
 		"SELECT p.* AS &M.* FROM person WHERE name = 'Fred'",
 		[]any{sqlair.M{}},
-		"cannot prepare statement: output expression: p.* AS &M.*: asterisk cannot be used with maps when no column names are specified",
+		"cannot prepare statement: output expression: p.* AS &M.*: asterisk cannot be used with map when no column names are specified",
 	}, {
 		"all output into map star from lone star",
 		"SELECT * AS &CustomMap.* FROM person WHERE name = 'Fred'",
 		[]any{CustomMap{}},
-		"cannot prepare statement: output expression: * AS &CustomMap.*: asterisk cannot be used with maps when no column names are specified",
+		"cannot prepare statement: output expression: * AS &CustomMap.*: asterisk cannot be used with map when no column names are specified",
 	}, {
 		"invalid map",
 		"SELECT * AS &InvalidMap.* FROM person WHERE name = 'Fred'",

--- a/internal/expr/expr_test.go
+++ b/internal/expr/expr_test.go
@@ -421,95 +421,95 @@ func (s *ExprSuite) TestPrepareErrors(c *C) {
 	}{{
 		query:       "SELECT (p.name, t.id) AS (&Address.id) FROM t",
 		prepareArgs: []any{Address{}},
-		err:         `cannot prepare query: output expression: (p.name, t.id) AS (&Address.id): mismatched number of columns and target types`,
+		err:         `cannot prepare statement: output expression: (p.name, t.id) AS (&Address.id): mismatched number of columns and target types`,
 	}, {
 		query:       "SELECT (p.name) AS (&Address.district, &Address.street) FROM t",
 		prepareArgs: []any{Address{}},
-		err:         "cannot prepare query: output expression: (p.name) AS (&Address.district, &Address.street): mismatched number of columns and target types",
+		err:         "cannot prepare statement: output expression: (p.name) AS (&Address.district, &Address.street): mismatched number of columns and target types",
 	}, {
 		query:       "SELECT (&Address.*, &Address.id) FROM t",
 		prepareArgs: []any{Address{}, Person{}},
-		err:         `cannot prepare query: member "id" of type "Address" appears more than once`,
+		err:         `cannot prepare statement: member "id" of type "Address" appears more than once`,
 	}, {
 		query:       "SELECT (p.*, t.name) AS (&Address.*) FROM t",
 		prepareArgs: []any{Address{}},
-		err:         "cannot prepare query: output expression: (p.*, t.name) AS (&Address.*): invalid asterisk in expression columns",
+		err:         "cannot prepare statement: output expression: (p.*, t.name) AS (&Address.*): invalid asterisk in expression columns",
 	}, {
 		query:       "SELECT (name, p.*) AS (&Person.id, &Person.*) FROM t",
 		prepareArgs: []any{Address{}, Person{}},
-		err:         "cannot prepare query: output expression: (name, p.*) AS (&Person.id, &Person.*): invalid asterisk in expression columns",
+		err:         "cannot prepare statement: output expression: (name, p.*) AS (&Person.id, &Person.*): invalid asterisk in expression columns",
 	}, {
 		query:       "SELECT (&Person.*, &Person.*) FROM t",
 		prepareArgs: []any{Address{}, Person{}},
-		err:         `cannot prepare query: member "address_id" of type "Person" appears more than once`,
+		err:         `cannot prepare statement: member "address_id" of type "Person" appears more than once`,
 	}, {
 		query:       "SELECT (p.*, t.*) AS (&Address.*) FROM t",
 		prepareArgs: []any{Address{}},
-		err:         "cannot prepare query: output expression: (p.*, t.*) AS (&Address.*): invalid asterisk in expression columns",
+		err:         "cannot prepare statement: output expression: (p.*, t.*) AS (&Address.*): invalid asterisk in expression columns",
 	}, {
 		query:       "SELECT (id, name) AS (&Person.id, &Address.*) FROM t",
 		prepareArgs: []any{Address{}, Person{}},
-		err:         "cannot prepare query: output expression: (id, name) AS (&Person.id, &Address.*): invalid asterisk in expression types",
+		err:         "cannot prepare statement: output expression: (id, name) AS (&Person.id, &Address.*): invalid asterisk in expression types",
 	}, {
 		query:       "SELECT (name, id) AS (&Person.*, &Address.id) FROM t",
 		prepareArgs: []any{Address{}, Person{}},
-		err:         "cannot prepare query: output expression: (name, id) AS (&Person.*, &Address.id): invalid asterisk in expression types",
+		err:         "cannot prepare statement: output expression: (name, id) AS (&Person.*, &Address.id): invalid asterisk in expression types",
 	}, {
 		query:       "SELECT (name, id) AS (&Person.*, &Address.*) FROM t",
 		prepareArgs: []any{Address{}, Person{}},
-		err:         "cannot prepare query: output expression: (name, id) AS (&Person.*, &Address.*): invalid asterisk in expression types",
+		err:         "cannot prepare statement: output expression: (name, id) AS (&Person.*, &Address.*): invalid asterisk in expression types",
 	}, {
 		query:       "SELECT street FROM t WHERE x = $Address.number",
 		prepareArgs: []any{Address{}},
-		err:         `cannot prepare query: input expression: $Address.number: type "Address" has no "number" db tag`,
+		err:         `cannot prepare statement: input expression: $Address.number: type "Address" has no "number" db tag`,
 	}, {
 		query:       "SELECT (street, road) AS (&Address.*) FROM t",
 		prepareArgs: []any{Address{}},
-		err:         `cannot prepare query: output expression: (street, road) AS (&Address.*): type "Address" has no "road" db tag`,
+		err:         `cannot prepare statement: output expression: (street, road) AS (&Address.*): type "Address" has no "road" db tag`,
 	}, {
 		query:       "SELECT &Address.road FROM t",
 		prepareArgs: []any{Address{}},
-		err:         `cannot prepare query: output expression: &Address.road: type "Address" has no "road" db tag`,
+		err:         `cannot prepare statement: output expression: &Address.road: type "Address" has no "road" db tag`,
 	}, {
 		query:       "SELECT street FROM t WHERE x = $Address.street",
 		prepareArgs: []any{Person{}},
-		err:         `cannot prepare query: input expression: $Address.street: type "Address" not passed as a parameter, have: Person`,
+		err:         `cannot prepare statement: input expression: $Address.street: type "Address" not passed as a parameter, have: Person`,
 	}, {
 		query:       "SELECT street AS &Address.street FROM t",
 		prepareArgs: []any{},
-		err:         `cannot prepare query: output expression: street AS &Address.street: type "Address" not passed as a parameter`,
+		err:         `cannot prepare statement: output expression: street AS &Address.street: type "Address" not passed as a parameter`,
 	}, {
 		query:       "SELECT street AS &Address.id FROM t",
 		prepareArgs: []any{Person{}},
-		err:         `cannot prepare query: output expression: street AS &Address.id: type "Address" not passed as a parameter, have: Person`,
+		err:         `cannot prepare statement: output expression: street AS &Address.id: type "Address" not passed as a parameter, have: Person`,
 	}, {
 		query:       "SELECT * AS &Person.* FROM t",
 		prepareArgs: []any{[]any{Person{}}},
-		err:         `cannot prepare query: need struct or map, got slice`,
+		err:         `cannot prepare statement: need struct or map, got slice`,
 	}, {
 		query:       "SELECT * AS &Person.* FROM t",
 		prepareArgs: []any{&Person{}},
-		err:         `cannot prepare query: need struct or map, got pointer to struct`,
+		err:         `cannot prepare statement: need struct or map, got pointer to struct`,
 	}, {
 		query:       "SELECT * AS &Person.* FROM t",
 		prepareArgs: []any{(*Person)(nil)},
-		err:         `cannot prepare query: need struct or map, got pointer to struct`,
+		err:         `cannot prepare statement: need struct or map, got pointer to struct`,
 	}, {
 		query:       "SELECT * AS &Person.* FROM t",
 		prepareArgs: []any{map[string]any{}},
-		err:         `cannot prepare query: cannot use anonymous map`,
+		err:         `cannot prepare statement: cannot use anonymous map`,
 	}, {
 		query:       "SELECT * AS &Person.* FROM t",
 		prepareArgs: []any{nil},
-		err:         `cannot prepare query: need struct or map, got nil`,
+		err:         `cannot prepare statement: need struct or map, got nil`,
 	}, {
 		query:       "SELECT * AS &.* FROM t",
 		prepareArgs: []any{struct{ f int }{f: 1}},
-		err:         `cannot prepare query: cannot use anonymous struct`,
+		err:         `cannot prepare statement: cannot use anonymous struct`,
 	}, {
 		query:       "SELECT &NoTags.* FROM t",
 		prepareArgs: []any{NoTags{}},
-		err:         `cannot prepare query: output expression: &NoTags.*: type "NoTags" does not have any db tags`,
+		err:         `cannot prepare statement: output expression: &NoTags.*: type "NoTags" does not have any db tags`,
 	}}
 
 	for i, test := range tests {
@@ -543,27 +543,27 @@ func (s *ExprSuite) TestPrepareMapError(c *C) {
 		"all output into map star",
 		"SELECT &M.* FROM person WHERE name = 'Fred'",
 		[]any{sqlair.M{}},
-		"cannot prepare query: output expression: &M.*: asterisk cannot be used with maps when no column names are specified",
+		"cannot prepare statement: output expression: &M.*: asterisk cannot be used with maps when no column names are specified",
 	}, {
 		"all output into map star from table star",
 		"SELECT p.* AS &M.* FROM person WHERE name = 'Fred'",
 		[]any{sqlair.M{}},
-		"cannot prepare query: output expression: p.* AS &M.*: asterisk cannot be used with maps when no column names are specified",
+		"cannot prepare statement: output expression: p.* AS &M.*: asterisk cannot be used with maps when no column names are specified",
 	}, {
 		"all output into map star from lone star",
 		"SELECT * AS &CustomMap.* FROM person WHERE name = 'Fred'",
 		[]any{CustomMap{}},
-		"cannot prepare query: output expression: * AS &CustomMap.*: asterisk cannot be used with maps when no column names are specified",
+		"cannot prepare statement: output expression: * AS &CustomMap.*: asterisk cannot be used with maps when no column names are specified",
 	}, {
 		"invalid map",
 		"SELECT * AS &InvalidMap.* FROM person WHERE name = 'Fred'",
 		[]any{InvalidMap{}},
-		"cannot prepare query: map type InvalidMap must have key type string, found type int",
+		"cannot prepare statement: map type InvalidMap must have key type string, found type int",
 	}, {
 		"clashing map and struct names",
 		"SELECT * AS &M.* FROM person WHERE name = $M.id",
 		[]any{M{}, sqlair.M{}},
-		`cannot prepare query: two types found with name "M": "expr_test.M" and "sqlair.M"`,
+		`cannot prepare statement: two types found with name "M": "expr_test.M" and "sqlair.M"`,
 	},
 	}
 	for _, test := range tests {

--- a/internal/expr/expr_test.go
+++ b/internal/expr/expr_test.go
@@ -473,7 +473,7 @@ func (s *ExprSuite) TestPrepareErrors(c *C) {
 	}, {
 		query:       "SELECT street FROM t WHERE x = $Address.street",
 		prepareArgs: []any{Person{}, Manager{}},
-		err:         `cannot prepare statement: input expression: type "Address" not passed as a parameter, have "Manager", "Person": $Address.street`,
+		err:         `cannot prepare statement: input expression: type "Address" not passed as a parameter (have "Manager", "Person"): $Address.street`,
 	}, {
 		query:       "SELECT street AS &Address.street FROM t",
 		prepareArgs: []any{},
@@ -481,7 +481,7 @@ func (s *ExprSuite) TestPrepareErrors(c *C) {
 	}, {
 		query:       "SELECT street AS &Address.id FROM t",
 		prepareArgs: []any{Person{}},
-		err:         `cannot prepare statement: output expression: type "Address" not passed as a parameter, have Person: street AS &Address.id`,
+		err:         `cannot prepare statement: output expression: type "Address" not passed as a parameter (have "Person"): street AS &Address.id`,
 	}, {
 		query:       "SELECT * AS &Person.* FROM t",
 		prepareArgs: []any{[]any{Person{}}},

--- a/internal/expr/expr_test.go
+++ b/internal/expr/expr_test.go
@@ -421,7 +421,7 @@ func (s *ExprSuite) TestPrepareErrors(c *C) {
 	}{{
 		query:       "SELECT (p.name, t.id) AS (&Address.id) FROM t",
 		prepareArgs: []any{Address{}},
-		err:         `cannot prepare statement: output expression: mismatched number of columns and target types: (p.name, t.id) AS (&Address.id)`,
+		err:         "cannot prepare statement: output expression: mismatched number of columns and target types: (p.name, t.id) AS (&Address.id)",
 	}, {
 		query:       "SELECT (p.name) AS (&Address.district, &Address.street) FROM t",
 		prepareArgs: []any{Address{}},
@@ -543,17 +543,17 @@ func (s *ExprSuite) TestPrepareMapError(c *C) {
 		"all output into map star",
 		"SELECT &M.* FROM person WHERE name = 'Fred'",
 		[]any{sqlair.M{}},
-		"cannot prepare statement: output expression: columns must be specified for asterisk map: &M.*",
+		"cannot prepare statement: output expression: columns must be specified for map with star: &M.*",
 	}, {
 		"all output into map star from table star",
 		"SELECT p.* AS &M.* FROM person WHERE name = 'Fred'",
 		[]any{sqlair.M{}},
-		"cannot prepare statement: output expression: columns must be specified for asterisk map: p.* AS &M.*",
+		"cannot prepare statement: output expression: columns must be specified for map with star: p.* AS &M.*",
 	}, {
 		"all output into map star from lone star",
 		"SELECT * AS &CustomMap.* FROM person WHERE name = 'Fred'",
 		[]any{CustomMap{}},
-		"cannot prepare statement: output expression: columns must be specified for asterisk map: * AS &CustomMap.*",
+		"cannot prepare statement: output expression: columns must be specified for map with star: * AS &CustomMap.*",
 	}, {
 		"invalid map",
 		"SELECT * AS &InvalidMap.* FROM person WHERE name = 'Fred'",

--- a/internal/expr/expr_test.go
+++ b/internal/expr/expr_test.go
@@ -421,95 +421,95 @@ func (s *ExprSuite) TestPrepareErrors(c *C) {
 	}{{
 		query:       "SELECT (p.name, t.id) AS (&Address.id) FROM t",
 		prepareArgs: []any{Address{}},
-		err:         "cannot prepare expression: mismatched number of columns and targets in output expression: (p.name, t.id) AS (&Address.id)",
+		err:         `cannot prepare query: output expression: (p.name, t.id) AS (&Address.id): mismatched number of columns and target types`,
 	}, {
 		query:       "SELECT (p.name) AS (&Address.district, &Address.street) FROM t",
 		prepareArgs: []any{Address{}},
-		err:         "cannot prepare expression: mismatched number of columns and targets in output expression: (p.name) AS (&Address.district, &Address.street)",
+		err:         "cannot prepare query: output expression: (p.name) AS (&Address.district, &Address.street): mismatched number of columns and target types",
 	}, {
 		query:       "SELECT (&Address.*, &Address.id) FROM t",
 		prepareArgs: []any{Address{}, Person{}},
-		err:         `cannot prepare expression: member "id" of type "Address" appears more than once`,
+		err:         `cannot prepare query: member "id" of type "Address" appears more than once`,
 	}, {
 		query:       "SELECT (p.*, t.name) AS (&Address.*) FROM t",
 		prepareArgs: []any{Address{}},
-		err:         "cannot prepare expression: invalid asterisk in output expression columns: (p.*, t.name) AS (&Address.*)",
+		err:         "cannot prepare query: output expression: (p.*, t.name) AS (&Address.*): invalid asterisk in expression columns",
 	}, {
 		query:       "SELECT (name, p.*) AS (&Person.id, &Person.*) FROM t",
 		prepareArgs: []any{Address{}, Person{}},
-		err:         "cannot prepare expression: invalid asterisk in output expression columns: (name, p.*) AS (&Person.id, &Person.*)",
+		err:         "cannot prepare query: output expression: (name, p.*) AS (&Person.id, &Person.*): invalid asterisk in expression columns",
 	}, {
 		query:       "SELECT (&Person.*, &Person.*) FROM t",
 		prepareArgs: []any{Address{}, Person{}},
-		err:         `cannot prepare expression: member "address_id" of type "Person" appears more than once`,
+		err:         `cannot prepare query: member "address_id" of type "Person" appears more than once`,
 	}, {
 		query:       "SELECT (p.*, t.*) AS (&Address.*) FROM t",
 		prepareArgs: []any{Address{}},
-		err:         "cannot prepare expression: invalid asterisk in output expression columns: (p.*, t.*) AS (&Address.*)",
+		err:         "cannot prepare query: output expression: (p.*, t.*) AS (&Address.*): invalid asterisk in expression columns",
 	}, {
 		query:       "SELECT (id, name) AS (&Person.id, &Address.*) FROM t",
 		prepareArgs: []any{Address{}, Person{}},
-		err:         "cannot prepare expression: invalid asterisk in output expression types: (id, name) AS (&Person.id, &Address.*)",
+		err:         "cannot prepare query: output expression: (id, name) AS (&Person.id, &Address.*): invalid asterisk in expression types",
 	}, {
 		query:       "SELECT (name, id) AS (&Person.*, &Address.id) FROM t",
 		prepareArgs: []any{Address{}, Person{}},
-		err:         "cannot prepare expression: invalid asterisk in output expression types: (name, id) AS (&Person.*, &Address.id)",
+		err:         "cannot prepare query: output expression: (name, id) AS (&Person.*, &Address.id): invalid asterisk in expression types",
 	}, {
 		query:       "SELECT (name, id) AS (&Person.*, &Address.*) FROM t",
 		prepareArgs: []any{Address{}, Person{}},
-		err:         "cannot prepare expression: invalid asterisk in output expression types: (name, id) AS (&Person.*, &Address.*)",
+		err:         "cannot prepare query: output expression: (name, id) AS (&Person.*, &Address.*): invalid asterisk in expression types",
 	}, {
 		query:       "SELECT street FROM t WHERE x = $Address.number",
 		prepareArgs: []any{Address{}},
-		err:         `cannot prepare expression: type "Address" has no "number" db tag`,
+		err:         `cannot prepare query: input expression: $Address.number: type "Address" has no "number" db tag`,
 	}, {
 		query:       "SELECT (street, road) AS (&Address.*) FROM t",
 		prepareArgs: []any{Address{}},
-		err:         `cannot prepare expression: type "Address" has no "road" db tag`,
+		err:         `cannot prepare query: output expression: (street, road) AS (&Address.*): type "Address" has no "road" db tag`,
 	}, {
 		query:       "SELECT &Address.road FROM t",
 		prepareArgs: []any{Address{}},
-		err:         `cannot prepare expression: type "Address" has no "road" db tag`,
+		err:         `cannot prepare query: output expression: &Address.road: type "Address" has no "road" db tag`,
 	}, {
 		query:       "SELECT street FROM t WHERE x = $Address.street",
 		prepareArgs: []any{Person{}},
-		err:         `cannot prepare expression: type "Address" not passed as a parameter, have: Person`,
+		err:         `cannot prepare query: input expression: $Address.street: type "Address" not passed as a parameter, have: Person`,
 	}, {
 		query:       "SELECT street AS &Address.street FROM t",
 		prepareArgs: []any{},
-		err:         `cannot prepare expression: type "Address" not passed as a parameter`,
+		err:         `cannot prepare query: output expression: street AS &Address.street: type "Address" not passed as a parameter`,
 	}, {
 		query:       "SELECT street AS &Address.id FROM t",
 		prepareArgs: []any{Person{}},
-		err:         `cannot prepare expression: type "Address" not passed as a parameter, have: Person`,
+		err:         `cannot prepare query: output expression: street AS &Address.id: type "Address" not passed as a parameter, have: Person`,
 	}, {
 		query:       "SELECT * AS &Person.* FROM t",
 		prepareArgs: []any{[]any{Person{}}},
-		err:         `cannot prepare expression: need struct or map, got slice`,
+		err:         `cannot prepare query: need struct or map, got slice`,
 	}, {
 		query:       "SELECT * AS &Person.* FROM t",
 		prepareArgs: []any{&Person{}},
-		err:         `cannot prepare expression: need struct or map, got pointer to struct`,
+		err:         `cannot prepare query: need struct or map, got pointer to struct`,
 	}, {
 		query:       "SELECT * AS &Person.* FROM t",
 		prepareArgs: []any{(*Person)(nil)},
-		err:         `cannot prepare expression: need struct or map, got pointer to struct`,
+		err:         `cannot prepare query: need struct or map, got pointer to struct`,
 	}, {
 		query:       "SELECT * AS &Person.* FROM t",
 		prepareArgs: []any{map[string]any{}},
-		err:         `cannot prepare expression: cannot use anonymous map`,
+		err:         `cannot prepare query: cannot use anonymous map`,
 	}, {
 		query:       "SELECT * AS &Person.* FROM t",
 		prepareArgs: []any{nil},
-		err:         `cannot prepare expression: need struct or map, got nil`,
+		err:         `cannot prepare query: need struct or map, got nil`,
 	}, {
 		query:       "SELECT * AS &.* FROM t",
 		prepareArgs: []any{struct{ f int }{f: 1}},
-		err:         `cannot prepare expression: cannot use anonymous struct`,
+		err:         `cannot prepare query: cannot use anonymous struct`,
 	}, {
 		query:       "SELECT &NoTags.* FROM t",
 		prepareArgs: []any{NoTags{}},
-		err:         `cannot prepare expression: type "NoTags" in "&NoTags.*" does not have any db tags`,
+		err:         `cannot prepare query: output expression: &NoTags.*: type "NoTags" does not have any db tags`,
 	}}
 
 	for i, test := range tests {
@@ -543,27 +543,27 @@ func (s *ExprSuite) TestPrepareMapError(c *C) {
 		"all output into map star",
 		"SELECT &M.* FROM person WHERE name = 'Fred'",
 		[]any{sqlair.M{}},
-		"cannot prepare expression: &M.* cannot be used for maps when no column names are specified",
+		"cannot prepare query: output expression: &M.*: asterisk cannot be used with maps when no column names are specified",
 	}, {
 		"all output into map star from table star",
 		"SELECT p.* AS &M.* FROM person WHERE name = 'Fred'",
 		[]any{sqlair.M{}},
-		"cannot prepare expression: &M.* cannot be used for maps when no column names are specified",
+		"cannot prepare query: output expression: p.* AS &M.*: asterisk cannot be used with maps when no column names are specified",
 	}, {
 		"all output into map star from lone star",
 		"SELECT * AS &CustomMap.* FROM person WHERE name = 'Fred'",
 		[]any{CustomMap{}},
-		"cannot prepare expression: &CustomMap.* cannot be used for maps when no column names are specified",
+		"cannot prepare query: output expression: * AS &CustomMap.*: asterisk cannot be used with maps when no column names are specified",
 	}, {
 		"invalid map",
 		"SELECT * AS &InvalidMap.* FROM person WHERE name = 'Fred'",
 		[]any{InvalidMap{}},
-		"cannot prepare expression: map type InvalidMap must have key type string, found type int",
+		"cannot prepare query: map type InvalidMap must have key type string, found type int",
 	}, {
 		"clashing map and struct names",
 		"SELECT * AS &M.* FROM person WHERE name = $M.id",
 		[]any{M{}, sqlair.M{}},
-		`cannot prepare expression: two types found with name "M": "expr_test.M" and "sqlair.M"`,
+		`cannot prepare query: two types found with name "M": "expr_test.M" and "sqlair.M"`,
 	},
 	}
 	for _, test := range tests {

--- a/internal/expr/expr_test.go
+++ b/internal/expr/expr_test.go
@@ -421,67 +421,67 @@ func (s *ExprSuite) TestPrepareErrors(c *C) {
 	}{{
 		query:       "SELECT (p.name, t.id) AS (&Address.id) FROM t",
 		prepareArgs: []any{Address{}},
-		err:         `cannot prepare statement: output expression: (p.name, t.id) AS (&Address.id): mismatched number of columns and target types`,
+		err:         `cannot prepare statement: mismatched number of columns and target types in output expression: (p.name, t.id) AS (&Address.id)`,
 	}, {
 		query:       "SELECT (p.name) AS (&Address.district, &Address.street) FROM t",
 		prepareArgs: []any{Address{}},
-		err:         "cannot prepare statement: output expression: (p.name) AS (&Address.district, &Address.street): mismatched number of columns and target types",
+		err:         "cannot prepare statement: mismatched number of columns and target types in output expression: (p.name) AS (&Address.district, &Address.street)",
 	}, {
 		query:       "SELECT (&Address.*, &Address.id) FROM t",
 		prepareArgs: []any{Address{}, Person{}},
-		err:         `cannot prepare statement: member "id" of type "Address" appears more than once`,
+		err:         `cannot prepare statement: member "id" of type "Address" appears more than once in output expressions`,
 	}, {
 		query:       "SELECT (p.*, t.name) AS (&Address.*) FROM t",
 		prepareArgs: []any{Address{}},
-		err:         "cannot prepare statement: output expression: (p.*, t.name) AS (&Address.*): invalid asterisk in expression columns",
+		err:         "cannot prepare statement: invalid asterisk in columns in output expression: (p.*, t.name) AS (&Address.*)",
 	}, {
 		query:       "SELECT (name, p.*) AS (&Person.id, &Person.*) FROM t",
 		prepareArgs: []any{Address{}, Person{}},
-		err:         "cannot prepare statement: output expression: (name, p.*) AS (&Person.id, &Person.*): invalid asterisk in expression columns",
+		err:         "cannot prepare statement: invalid asterisk in columns in output expression: (name, p.*) AS (&Person.id, &Person.*)",
 	}, {
 		query:       "SELECT (&Person.*, &Person.*) FROM t",
 		prepareArgs: []any{Address{}, Person{}},
-		err:         `cannot prepare statement: member "address_id" of type "Person" appears more than once`,
+		err:         `cannot prepare statement: member "address_id" of type "Person" appears more than once in output expressions`,
 	}, {
 		query:       "SELECT (p.*, t.*) AS (&Address.*) FROM t",
 		prepareArgs: []any{Address{}},
-		err:         "cannot prepare statement: output expression: (p.*, t.*) AS (&Address.*): invalid asterisk in expression columns",
+		err:         "cannot prepare statement: invalid asterisk in columns in output expression: (p.*, t.*) AS (&Address.*)",
 	}, {
 		query:       "SELECT (id, name) AS (&Person.id, &Address.*) FROM t",
 		prepareArgs: []any{Address{}, Person{}},
-		err:         "cannot prepare statement: output expression: (id, name) AS (&Person.id, &Address.*): invalid asterisk in expression types",
+		err:         "cannot prepare statement: invalid asterisk in types in output expression: (id, name) AS (&Person.id, &Address.*)",
 	}, {
 		query:       "SELECT (name, id) AS (&Person.*, &Address.id) FROM t",
 		prepareArgs: []any{Address{}, Person{}},
-		err:         "cannot prepare statement: output expression: (name, id) AS (&Person.*, &Address.id): invalid asterisk in expression types",
+		err:         "cannot prepare statement: invalid asterisk in types in output expression: (name, id) AS (&Person.*, &Address.id)",
 	}, {
 		query:       "SELECT (name, id) AS (&Person.*, &Address.*) FROM t",
 		prepareArgs: []any{Address{}, Person{}},
-		err:         "cannot prepare statement: output expression: (name, id) AS (&Person.*, &Address.*): invalid asterisk in expression types",
+		err:         "cannot prepare statement: invalid asterisk in types in output expression: (name, id) AS (&Person.*, &Address.*)",
 	}, {
 		query:       "SELECT street FROM t WHERE x = $Address.number",
 		prepareArgs: []any{Address{}},
-		err:         `cannot prepare statement: input expression: $Address.number: type "Address" has no "number" db tag`,
+		err:         `cannot prepare statement: type "Address" has no "number" db tag in input expression: $Address.number`,
 	}, {
 		query:       "SELECT (street, road) AS (&Address.*) FROM t",
 		prepareArgs: []any{Address{}},
-		err:         `cannot prepare statement: output expression: (street, road) AS (&Address.*): type "Address" has no "road" db tag`,
+		err:         `cannot prepare statement: type "Address" has no "road" db tag in output expression: (street, road) AS (&Address.*)`,
 	}, {
 		query:       "SELECT &Address.road FROM t",
 		prepareArgs: []any{Address{}},
-		err:         `cannot prepare statement: output expression: &Address.road: type "Address" has no "road" db tag`,
+		err:         `cannot prepare statement: type "Address" has no "road" db tag in output expression: &Address.road`,
 	}, {
 		query:       "SELECT street FROM t WHERE x = $Address.street",
 		prepareArgs: []any{Person{}},
-		err:         `cannot prepare statement: input expression: $Address.street: type "Address" not passed as a parameter, have: Person`,
+		err:         `cannot prepare statement: type "Address" not passed as a parameter, have: Person. Type mentioned in input expression: $Address.street`,
 	}, {
 		query:       "SELECT street AS &Address.street FROM t",
 		prepareArgs: []any{},
-		err:         `cannot prepare statement: output expression: street AS &Address.street: type "Address" not passed as a parameter`,
+		err:         `cannot prepare statement: type "Address" not passed as a parameter. Type mentioned in output expression: street AS &Address.street`,
 	}, {
 		query:       "SELECT street AS &Address.id FROM t",
 		prepareArgs: []any{Person{}},
-		err:         `cannot prepare statement: output expression: street AS &Address.id: type "Address" not passed as a parameter, have: Person`,
+		err:         `cannot prepare statement: type "Address" not passed as a parameter, have: Person. Type mentioned in output expression: street AS &Address.id`,
 	}, {
 		query:       "SELECT * AS &Person.* FROM t",
 		prepareArgs: []any{[]any{Person{}}},
@@ -509,7 +509,7 @@ func (s *ExprSuite) TestPrepareErrors(c *C) {
 	}, {
 		query:       "SELECT &NoTags.* FROM t",
 		prepareArgs: []any{NoTags{}},
-		err:         `cannot prepare statement: output expression: &NoTags.*: type "NoTags" does not have any db tags`,
+		err:         `cannot prepare statement: no db tags found for type "NoTags" in output expression: &NoTags.*`,
 	}}
 
 	for i, test := range tests {
@@ -543,17 +543,17 @@ func (s *ExprSuite) TestPrepareMapError(c *C) {
 		"all output into map star",
 		"SELECT &M.* FROM person WHERE name = 'Fred'",
 		[]any{sqlair.M{}},
-		"cannot prepare statement: output expression: &M.*: asterisk cannot be used with map when no column names are specified",
+		"cannot prepare statement: columns must be specified for asterisk map in output expression: &M.*",
 	}, {
 		"all output into map star from table star",
 		"SELECT p.* AS &M.* FROM person WHERE name = 'Fred'",
 		[]any{sqlair.M{}},
-		"cannot prepare statement: output expression: p.* AS &M.*: asterisk cannot be used with map when no column names are specified",
+		"cannot prepare statement: columns must be specified for asterisk map in output expression: p.* AS &M.*",
 	}, {
 		"all output into map star from lone star",
 		"SELECT * AS &CustomMap.* FROM person WHERE name = 'Fred'",
 		[]any{CustomMap{}},
-		"cannot prepare statement: output expression: * AS &CustomMap.*: asterisk cannot be used with map when no column names are specified",
+		"cannot prepare statement: columns must be specified for asterisk map in output expression: * AS &CustomMap.*",
 	}, {
 		"invalid map",
 		"SELECT * AS &InvalidMap.* FROM person WHERE name = 'Fred'",

--- a/internal/expr/expr_test.go
+++ b/internal/expr/expr_test.go
@@ -472,8 +472,8 @@ func (s *ExprSuite) TestPrepareErrors(c *C) {
 		err:         `cannot prepare statement: output expression: type "Address" has no "road" db tag: &Address.road`,
 	}, {
 		query:       "SELECT street FROM t WHERE x = $Address.street",
-		prepareArgs: []any{Person{}},
-		err:         `cannot prepare statement: input expression: type "Address" not passed as a parameter, have Person: $Address.street`,
+		prepareArgs: []any{Person{}, Manager{}},
+		err:         `cannot prepare statement: input expression: type "Address" not passed as a parameter, have "Manager", "Person": $Address.street`,
 	}, {
 		query:       "SELECT street AS &Address.street FROM t",
 		prepareArgs: []any{},

--- a/internal/expr/expr_test.go
+++ b/internal/expr/expr_test.go
@@ -509,7 +509,7 @@ func (s *ExprSuite) TestPrepareErrors(c *C) {
 	}, {
 		query:       "SELECT &NoTags.* FROM t",
 		prepareArgs: []any{NoTags{}},
-		err:         `cannot prepare statement: output expression: no db tags found for type "NoTags": &NoTags.*`,
+		err:         `cannot prepare statement: output expression: no "db" tags found in struct "NoTags": &NoTags.*`,
 	}}
 
 	for i, test := range tests {

--- a/internal/expr/expr_test.go
+++ b/internal/expr/expr_test.go
@@ -421,11 +421,11 @@ func (s *ExprSuite) TestPrepareErrors(c *C) {
 	}{{
 		query:       "SELECT (p.name, t.id) AS (&Address.id) FROM t",
 		prepareArgs: []any{Address{}},
-		err:         `cannot prepare statement: mismatched number of columns and target types in output expression: (p.name, t.id) AS (&Address.id)`,
+		err:         `cannot prepare statement: output expression: mismatched number of columns and target types: (p.name, t.id) AS (&Address.id)`,
 	}, {
 		query:       "SELECT (p.name) AS (&Address.district, &Address.street) FROM t",
 		prepareArgs: []any{Address{}},
-		err:         "cannot prepare statement: mismatched number of columns and target types in output expression: (p.name) AS (&Address.district, &Address.street)",
+		err:         "cannot prepare statement: output expression: mismatched number of columns and target types: (p.name) AS (&Address.district, &Address.street)",
 	}, {
 		query:       "SELECT (&Address.*, &Address.id) FROM t",
 		prepareArgs: []any{Address{}, Person{}},
@@ -433,11 +433,11 @@ func (s *ExprSuite) TestPrepareErrors(c *C) {
 	}, {
 		query:       "SELECT (p.*, t.name) AS (&Address.*) FROM t",
 		prepareArgs: []any{Address{}},
-		err:         "cannot prepare statement: invalid asterisk in columns in output expression: (p.*, t.name) AS (&Address.*)",
+		err:         "cannot prepare statement: output expression: invalid asterisk in columns: (p.*, t.name) AS (&Address.*)",
 	}, {
 		query:       "SELECT (name, p.*) AS (&Person.id, &Person.*) FROM t",
 		prepareArgs: []any{Address{}, Person{}},
-		err:         "cannot prepare statement: invalid asterisk in columns in output expression: (name, p.*) AS (&Person.id, &Person.*)",
+		err:         "cannot prepare statement: output expression: invalid asterisk in columns: (name, p.*) AS (&Person.id, &Person.*)",
 	}, {
 		query:       "SELECT (&Person.*, &Person.*) FROM t",
 		prepareArgs: []any{Address{}, Person{}},
@@ -445,43 +445,43 @@ func (s *ExprSuite) TestPrepareErrors(c *C) {
 	}, {
 		query:       "SELECT (p.*, t.*) AS (&Address.*) FROM t",
 		prepareArgs: []any{Address{}},
-		err:         "cannot prepare statement: invalid asterisk in columns in output expression: (p.*, t.*) AS (&Address.*)",
+		err:         "cannot prepare statement: output expression: invalid asterisk in columns: (p.*, t.*) AS (&Address.*)",
 	}, {
 		query:       "SELECT (id, name) AS (&Person.id, &Address.*) FROM t",
 		prepareArgs: []any{Address{}, Person{}},
-		err:         "cannot prepare statement: invalid asterisk in types in output expression: (id, name) AS (&Person.id, &Address.*)",
+		err:         "cannot prepare statement: output expression: invalid asterisk in types: (id, name) AS (&Person.id, &Address.*)",
 	}, {
 		query:       "SELECT (name, id) AS (&Person.*, &Address.id) FROM t",
 		prepareArgs: []any{Address{}, Person{}},
-		err:         "cannot prepare statement: invalid asterisk in types in output expression: (name, id) AS (&Person.*, &Address.id)",
+		err:         "cannot prepare statement: output expression: invalid asterisk in types: (name, id) AS (&Person.*, &Address.id)",
 	}, {
 		query:       "SELECT (name, id) AS (&Person.*, &Address.*) FROM t",
 		prepareArgs: []any{Address{}, Person{}},
-		err:         "cannot prepare statement: invalid asterisk in types in output expression: (name, id) AS (&Person.*, &Address.*)",
+		err:         "cannot prepare statement: output expression: invalid asterisk in types: (name, id) AS (&Person.*, &Address.*)",
 	}, {
 		query:       "SELECT street FROM t WHERE x = $Address.number",
 		prepareArgs: []any{Address{}},
-		err:         `cannot prepare statement: type "Address" has no "number" db tag in input expression: $Address.number`,
+		err:         `cannot prepare statement: input expression: type "Address" has no "number" db tag: $Address.number`,
 	}, {
 		query:       "SELECT (street, road) AS (&Address.*) FROM t",
 		prepareArgs: []any{Address{}},
-		err:         `cannot prepare statement: type "Address" has no "road" db tag in output expression: (street, road) AS (&Address.*)`,
+		err:         `cannot prepare statement: output expression: type "Address" has no "road" db tag: (street, road) AS (&Address.*)`,
 	}, {
 		query:       "SELECT &Address.road FROM t",
 		prepareArgs: []any{Address{}},
-		err:         `cannot prepare statement: type "Address" has no "road" db tag in output expression: &Address.road`,
+		err:         `cannot prepare statement: output expression: type "Address" has no "road" db tag: &Address.road`,
 	}, {
 		query:       "SELECT street FROM t WHERE x = $Address.street",
 		prepareArgs: []any{Person{}},
-		err:         `cannot prepare statement: type "Address" not passed as a parameter, have: Person. Type mentioned in input expression: $Address.street`,
+		err:         `cannot prepare statement: input expression: type "Address" not passed as a parameter, have Person: $Address.street`,
 	}, {
 		query:       "SELECT street AS &Address.street FROM t",
 		prepareArgs: []any{},
-		err:         `cannot prepare statement: type "Address" not passed as a parameter. Type mentioned in output expression: street AS &Address.street`,
+		err:         `cannot prepare statement: output expression: type "Address" not passed as a parameter: street AS &Address.street`,
 	}, {
 		query:       "SELECT street AS &Address.id FROM t",
 		prepareArgs: []any{Person{}},
-		err:         `cannot prepare statement: type "Address" not passed as a parameter, have: Person. Type mentioned in output expression: street AS &Address.id`,
+		err:         `cannot prepare statement: output expression: type "Address" not passed as a parameter, have Person: street AS &Address.id`,
 	}, {
 		query:       "SELECT * AS &Person.* FROM t",
 		prepareArgs: []any{[]any{Person{}}},
@@ -509,7 +509,7 @@ func (s *ExprSuite) TestPrepareErrors(c *C) {
 	}, {
 		query:       "SELECT &NoTags.* FROM t",
 		prepareArgs: []any{NoTags{}},
-		err:         `cannot prepare statement: no db tags found for type "NoTags" in output expression: &NoTags.*`,
+		err:         `cannot prepare statement: output expression: no db tags found for type "NoTags": &NoTags.*`,
 	}}
 
 	for i, test := range tests {
@@ -543,17 +543,17 @@ func (s *ExprSuite) TestPrepareMapError(c *C) {
 		"all output into map star",
 		"SELECT &M.* FROM person WHERE name = 'Fred'",
 		[]any{sqlair.M{}},
-		"cannot prepare statement: columns must be specified for asterisk map in output expression: &M.*",
+		"cannot prepare statement: output expression: columns must be specified for asterisk map: &M.*",
 	}, {
 		"all output into map star from table star",
 		"SELECT p.* AS &M.* FROM person WHERE name = 'Fred'",
 		[]any{sqlair.M{}},
-		"cannot prepare statement: columns must be specified for asterisk map in output expression: p.* AS &M.*",
+		"cannot prepare statement: output expression: columns must be specified for asterisk map: p.* AS &M.*",
 	}, {
 		"all output into map star from lone star",
 		"SELECT * AS &CustomMap.* FROM person WHERE name = 'Fred'",
 		[]any{CustomMap{}},
-		"cannot prepare statement: columns must be specified for asterisk map in output expression: * AS &CustomMap.*",
+		"cannot prepare statement: output expression: columns must be specified for asterisk map: * AS &CustomMap.*",
 	}, {
 		"invalid map",
 		"SELECT * AS &InvalidMap.* FROM person WHERE name = 'Fred'",

--- a/internal/expr/prepare.go
+++ b/internal/expr/prepare.go
@@ -92,14 +92,12 @@ func prepareInput(ti typeNameToInfo, p *inputPart) (tm typeMember, err error) {
 
 // prepareOutput checks that the output expressions correspond to known types.
 // It then checks they are formatted correctly and finally generates the columns for the query.
-func prepareOutput(ti typeNameToInfo, p *outputPart) (fns []fullName, tms []typeMember, err error) {
+func prepareOutput(ti typeNameToInfo, p *outputPart) (outCols []fullName, typeMembers []typeMember, err error) {
 	defer func() {
 		if err != nil {
 			err = fmt.Errorf("output expression: %s: %s", p.raw, err)
 		}
 	}()
-	var outCols = make([]fullName, 0)
-	var typeMembers = make([]typeMember, 0)
 
 	numTypes := len(p.targetTypes)
 	numColumns := len(p.sourceColumns)

--- a/internal/expr/prepare.go
+++ b/internal/expr/prepare.go
@@ -61,7 +61,12 @@ func starCount(fns []fullName) int {
 }
 
 // prepareInput checks that the input expression corresponds to a known type.
-func prepareInput(ti typeNameToInfo, p *inputPart) (typeMember, error) {
+func prepareInput(ti typeNameToInfo, p *inputPart) (tm typeMember, err error) {
+	defer func() {
+		if err != nil {
+			err = fmt.Errorf("input expression: %s: %s", p.raw, err)
+		}
+	}()
 	info, ok := ti[p.sourceType.prefix]
 	if !ok {
 		ts := getKeys(ti)
@@ -87,7 +92,12 @@ func prepareInput(ti typeNameToInfo, p *inputPart) (typeMember, error) {
 
 // prepareOutput checks that the output expressions correspond to known types.
 // It then checks they are formatted correctly and finally generates the columns for the query.
-func prepareOutput(ti typeNameToInfo, p *outputPart) ([]fullName, []typeMember, error) {
+func prepareOutput(ti typeNameToInfo, p *outputPart) (fns []fullName, tms []typeMember, err error) {
+	defer func() {
+		if err != nil {
+			err = fmt.Errorf("output expression: %s: %s", p.raw, err)
+		}
+	}()
 	var outCols = make([]fullName, 0)
 	var typeMembers = make([]typeMember, 0)
 
@@ -99,7 +109,6 @@ func prepareOutput(ti typeNameToInfo, p *outputPart) ([]fullName, []typeMember, 
 	// Check target struct type and its tags are valid.
 	var info typeInfo
 	var ok bool
-	var err error
 
 	fetchInfo := func(typeName string) (typeInfo, error) {
 		info, ok := ti[typeName]
@@ -146,10 +155,10 @@ func prepareOutput(ti typeNameToInfo, p *outputPart) ([]fullName, []typeMember, 
 			if t.name == "*" {
 				switch info := info.(type) {
 				case *mapInfo:
-					return nil, nil, fmt.Errorf(`&%s.* cannot be used for maps when no column names are specified`, info.typ().Name())
+					return nil, nil, fmt.Errorf(`asterisk cannot be used with maps when no column names are specified`)
 				case *structInfo:
 					if len(info.tags) == 0 {
-						return nil, nil, fmt.Errorf("type %q in %q does not have any db tags", info.typ().Name(), p.raw)
+						return nil, nil, fmt.Errorf("type %q does not have any db tags", info.typ().Name())
 					}
 					for _, tag := range info.tags {
 						outCols = append(outCols, fullName{pref, tag})
@@ -165,7 +174,7 @@ func prepareOutput(ti typeNameToInfo, p *outputPart) ([]fullName, []typeMember, 
 		}
 		return outCols, typeMembers, nil
 	} else if numColumns > 1 && starColumns > 0 {
-		return nil, nil, fmt.Errorf("invalid asterisk in output expression columns: %s", p.raw)
+		return nil, nil, fmt.Errorf("invalid asterisk in expression columns")
 	}
 
 	// Case 2: Explicit columns, single asterisk type e.g. "(col1, t.col2) AS &P.*".
@@ -180,7 +189,7 @@ func prepareOutput(ti typeNameToInfo, p *outputPart) ([]fullName, []typeMember, 
 		}
 		return outCols, typeMembers, nil
 	} else if starTypes > 0 && numTypes > 1 {
-		return nil, nil, fmt.Errorf("invalid asterisk in output expression types: %s", p.raw)
+		return nil, nil, fmt.Errorf("invalid asterisk in expression types")
 	}
 
 	// Case 3: Explicit columns and types e.g. "(col1, col2) AS (&P.name, &P.id)".
@@ -196,7 +205,7 @@ func prepareOutput(ti typeNameToInfo, p *outputPart) ([]fullName, []typeMember, 
 			}
 		}
 	} else {
-		return nil, nil, fmt.Errorf("mismatched number of columns and targets in output expression: %s", p.raw)
+		return nil, nil, fmt.Errorf("mismatched number of columns and target types")
 	}
 
 	return outCols, typeMembers, nil
@@ -211,7 +220,7 @@ type typeNameToInfo map[string]typeInfo
 func (pe *ParsedExpr) Prepare(args ...any) (expr *PreparedExpr, err error) {
 	defer func() {
 		if err != nil {
-			err = fmt.Errorf("cannot prepare expression: %s", err)
+			err = fmt.Errorf("cannot prepare query: %s", err)
 		}
 	}()
 

--- a/internal/expr/prepare.go
+++ b/internal/expr/prepare.go
@@ -153,7 +153,7 @@ func prepareOutput(ti typeNameToInfo, p *outputPart) (outCols []fullName, typeMe
 			if t.name == "*" {
 				switch info := info.(type) {
 				case *mapInfo:
-					return nil, nil, fmt.Errorf(`asterisk cannot be used with maps when no column names are specified`)
+					return nil, nil, fmt.Errorf(`asterisk cannot be used with map when no column names are specified`)
 				case *structInfo:
 					if len(info.tags) == 0 {
 						return nil, nil, fmt.Errorf("type %q does not have any db tags", info.typ().Name())

--- a/internal/expr/prepare.go
+++ b/internal/expr/prepare.go
@@ -73,7 +73,7 @@ func prepareInput(ti typeNameToInfo, p *inputPart) (tm typeMember, err error) {
 		if len(ts) == 0 {
 			return nil, fmt.Errorf(`type %q not passed as a parameter`, p.sourceType.prefix)
 		} else {
-			return nil, fmt.Errorf(`type %q not passed as a parameter, have %s`, p.sourceType.prefix, strings.Join(ts, ", "))
+			return nil, fmt.Errorf(`type %q not passed as a parameter, have "%s"`, p.sourceType.prefix, strings.Join(ts, `", "`))
 		}
 	}
 	switch info := info.(type) {

--- a/internal/expr/prepare.go
+++ b/internal/expr/prepare.go
@@ -73,6 +73,8 @@ func prepareInput(ti typeNameToInfo, p *inputPart) (tm typeMember, err error) {
 		if len(ts) == 0 {
 			return nil, fmt.Errorf(`type %q not passed as a parameter`, p.sourceType.prefix)
 		} else {
+			// "%s" is used instead of %q to print double quotes within the
+			// joined string correctly.
 			return nil, fmt.Errorf(`type %q not passed as a parameter, have "%s"`, p.sourceType.prefix, strings.Join(ts, `", "`))
 		}
 	}

--- a/internal/expr/prepare.go
+++ b/internal/expr/prepare.go
@@ -64,16 +64,16 @@ func starCount(fns []fullName) int {
 func prepareInput(ti typeNameToInfo, p *inputPart) (tm typeMember, err error) {
 	defer func() {
 		if err != nil {
-			err = fmt.Errorf("input expression: %s: %s", p.raw, err)
+			err = fmt.Errorf("%s in input expression: %s", err, p.raw)
 		}
 	}()
 	info, ok := ti[p.sourceType.prefix]
 	if !ok {
 		ts := getKeys(ti)
 		if len(ts) == 0 {
-			return nil, fmt.Errorf(`type %q not passed as a parameter`, p.sourceType.prefix)
+			return nil, fmt.Errorf(`type %q not passed as a parameter. Type mentioned`, p.sourceType.prefix)
 		} else {
-			return nil, fmt.Errorf(`type %q not passed as a parameter, have: %s`, p.sourceType.prefix, strings.Join(ts, ", "))
+			return nil, fmt.Errorf(`type %q not passed as a parameter, have: %s. Type mentioned`, p.sourceType.prefix, strings.Join(ts, ", "))
 		}
 	}
 	switch info := info.(type) {
@@ -95,7 +95,7 @@ func prepareInput(ti typeNameToInfo, p *inputPart) (tm typeMember, err error) {
 func prepareOutput(ti typeNameToInfo, p *outputPart) (outCols []fullName, typeMembers []typeMember, err error) {
 	defer func() {
 		if err != nil {
-			err = fmt.Errorf("output expression: %s: %s", p.raw, err)
+			err = fmt.Errorf("%s in output expression: %s", err, p.raw)
 		}
 	}()
 
@@ -113,9 +113,9 @@ func prepareOutput(ti typeNameToInfo, p *outputPart) (outCols []fullName, typeMe
 		if !ok {
 			ts := getKeys(ti)
 			if len(ts) == 0 {
-				return nil, fmt.Errorf(`type %q not passed as a parameter`, typeName)
+				return nil, fmt.Errorf(`type %q not passed as a parameter. Type mentioned`, typeName)
 			} else {
-				return nil, fmt.Errorf(`type %q not passed as a parameter, have: %s`, typeName, strings.Join(ts, ", "))
+				return nil, fmt.Errorf(`type %q not passed as a parameter, have: %s. Type mentioned`, typeName, strings.Join(ts, ", "))
 			}
 		}
 		return info, nil
@@ -153,10 +153,10 @@ func prepareOutput(ti typeNameToInfo, p *outputPart) (outCols []fullName, typeMe
 			if t.name == "*" {
 				switch info := info.(type) {
 				case *mapInfo:
-					return nil, nil, fmt.Errorf(`asterisk cannot be used with map when no column names are specified`)
+					return nil, nil, fmt.Errorf(`columns must be specified for asterisk map`)
 				case *structInfo:
 					if len(info.tags) == 0 {
-						return nil, nil, fmt.Errorf("type %q does not have any db tags", info.typ().Name())
+						return nil, nil, fmt.Errorf("no db tags found for type %q", info.typ().Name())
 					}
 					for _, tag := range info.tags {
 						outCols = append(outCols, fullName{pref, tag})
@@ -172,7 +172,7 @@ func prepareOutput(ti typeNameToInfo, p *outputPart) (outCols []fullName, typeMe
 		}
 		return outCols, typeMembers, nil
 	} else if numColumns > 1 && starColumns > 0 {
-		return nil, nil, fmt.Errorf("invalid asterisk in expression columns")
+		return nil, nil, fmt.Errorf("invalid asterisk in columns")
 	}
 
 	// Case 2: Explicit columns, single asterisk type e.g. "(col1, t.col2) AS &P.*".
@@ -187,7 +187,7 @@ func prepareOutput(ti typeNameToInfo, p *outputPart) (outCols []fullName, typeMe
 		}
 		return outCols, typeMembers, nil
 	} else if starTypes > 0 && numTypes > 1 {
-		return nil, nil, fmt.Errorf("invalid asterisk in expression types")
+		return nil, nil, fmt.Errorf("invalid asterisk in types")
 	}
 
 	// Case 3: Explicit columns and types e.g. "(col1, col2) AS (&P.name, &P.id)".
@@ -282,7 +282,7 @@ func (pe *ParsedExpr) Prepare(args ...any) (expr *PreparedExpr, err error) {
 
 			for _, tm := range typeMembers {
 				if ok := typeMemberPresent[tm]; ok {
-					return nil, fmt.Errorf("member %q of type %q appears more than once", tm.memberName(), tm.outerType().Name())
+					return nil, fmt.Errorf("member %q of type %q appears more than once in output expressions", tm.memberName(), tm.outerType().Name())
 				}
 				typeMemberPresent[tm] = true
 			}

--- a/internal/expr/prepare.go
+++ b/internal/expr/prepare.go
@@ -156,7 +156,7 @@ func prepareOutput(ti typeNameToInfo, p *outputPart) (outCols []fullName, typeMe
 					return nil, nil, fmt.Errorf(`columns must be specified for asterisk map`)
 				case *structInfo:
 					if len(info.tags) == 0 {
-						return nil, nil, fmt.Errorf("no db tags found for type %q", info.typ().Name())
+						return nil, nil, fmt.Errorf(`no "db" tags found in struct %q`, info.typ().Name())
 					}
 					for _, tag := range info.tags {
 						outCols = append(outCols, fullName{pref, tag})

--- a/internal/expr/prepare.go
+++ b/internal/expr/prepare.go
@@ -73,8 +73,7 @@ func prepareInput(ti typeNameToInfo, p *inputPart) (tm typeMember, err error) {
 		if len(ts) == 0 {
 			return nil, fmt.Errorf(`type %q not passed as a parameter`, p.sourceType.prefix)
 		} else {
-			// "%s" is used instead of %q to print double quotes within the
-			// joined string correctly.
+			// "%s" is used instead of %q to correctly print double quotes within the joined string.
 			return nil, fmt.Errorf(`type %q not passed as a parameter (have "%s")`, p.sourceType.prefix, strings.Join(ts, `", "`))
 		}
 	}
@@ -117,8 +116,7 @@ func prepareOutput(ti typeNameToInfo, p *outputPart) (outCols []fullName, typeMe
 			if len(ts) == 0 {
 				return nil, fmt.Errorf(`type %q not passed as a parameter`, typeName)
 			} else {
-				// "%s" is used instead of %q to print double quotes within the
-				// joined string correctly.
+				// "%s" is used instead of %q to correctly print double quotes within the joined string.
 				return nil, fmt.Errorf(`type %q not passed as a parameter (have "%s")`, typeName, strings.Join(ts, `", "`))
 			}
 		}

--- a/internal/expr/prepare.go
+++ b/internal/expr/prepare.go
@@ -220,7 +220,7 @@ type typeNameToInfo map[string]typeInfo
 func (pe *ParsedExpr) Prepare(args ...any) (expr *PreparedExpr, err error) {
 	defer func() {
 		if err != nil {
-			err = fmt.Errorf("cannot prepare query: %s", err)
+			err = fmt.Errorf("cannot prepare statement: %s", err)
 		}
 	}()
 

--- a/internal/expr/prepare.go
+++ b/internal/expr/prepare.go
@@ -75,7 +75,7 @@ func prepareInput(ti typeNameToInfo, p *inputPart) (tm typeMember, err error) {
 		} else {
 			// "%s" is used instead of %q to print double quotes within the
 			// joined string correctly.
-			return nil, fmt.Errorf(`type %q not passed as a parameter, have "%s"`, p.sourceType.prefix, strings.Join(ts, `", "`))
+			return nil, fmt.Errorf(`type %q not passed as a parameter (have "%s")`, p.sourceType.prefix, strings.Join(ts, `", "`))
 		}
 	}
 	switch info := info.(type) {
@@ -117,7 +117,9 @@ func prepareOutput(ti typeNameToInfo, p *outputPart) (outCols []fullName, typeMe
 			if len(ts) == 0 {
 				return nil, fmt.Errorf(`type %q not passed as a parameter`, typeName)
 			} else {
-				return nil, fmt.Errorf(`type %q not passed as a parameter, have %s`, typeName, strings.Join(ts, ", "))
+				// "%s" is used instead of %q to print double quotes within the
+				// joined string correctly.
+				return nil, fmt.Errorf(`type %q not passed as a parameter (have "%s")`, typeName, strings.Join(ts, `", "`))
 			}
 		}
 		return info, nil

--- a/internal/expr/prepare.go
+++ b/internal/expr/prepare.go
@@ -64,16 +64,16 @@ func starCount(fns []fullName) int {
 func prepareInput(ti typeNameToInfo, p *inputPart) (tm typeMember, err error) {
 	defer func() {
 		if err != nil {
-			err = fmt.Errorf("%s in input expression: %s", err, p.raw)
+			err = fmt.Errorf("input expression: %s: %s", err, p.raw)
 		}
 	}()
 	info, ok := ti[p.sourceType.prefix]
 	if !ok {
 		ts := getKeys(ti)
 		if len(ts) == 0 {
-			return nil, fmt.Errorf(`type %q not passed as a parameter. Type mentioned`, p.sourceType.prefix)
+			return nil, fmt.Errorf(`type %q not passed as a parameter`, p.sourceType.prefix)
 		} else {
-			return nil, fmt.Errorf(`type %q not passed as a parameter, have: %s. Type mentioned`, p.sourceType.prefix, strings.Join(ts, ", "))
+			return nil, fmt.Errorf(`type %q not passed as a parameter, have %s`, p.sourceType.prefix, strings.Join(ts, ", "))
 		}
 	}
 	switch info := info.(type) {
@@ -95,7 +95,7 @@ func prepareInput(ti typeNameToInfo, p *inputPart) (tm typeMember, err error) {
 func prepareOutput(ti typeNameToInfo, p *outputPart) (outCols []fullName, typeMembers []typeMember, err error) {
 	defer func() {
 		if err != nil {
-			err = fmt.Errorf("%s in output expression: %s", err, p.raw)
+			err = fmt.Errorf("output expression: %s: %s", err, p.raw)
 		}
 	}()
 
@@ -113,9 +113,9 @@ func prepareOutput(ti typeNameToInfo, p *outputPart) (outCols []fullName, typeMe
 		if !ok {
 			ts := getKeys(ti)
 			if len(ts) == 0 {
-				return nil, fmt.Errorf(`type %q not passed as a parameter. Type mentioned`, typeName)
+				return nil, fmt.Errorf(`type %q not passed as a parameter`, typeName)
 			} else {
-				return nil, fmt.Errorf(`type %q not passed as a parameter, have: %s. Type mentioned`, typeName, strings.Join(ts, ", "))
+				return nil, fmt.Errorf(`type %q not passed as a parameter, have %s`, typeName, strings.Join(ts, ", "))
 			}
 		}
 		return info, nil

--- a/internal/expr/prepare.go
+++ b/internal/expr/prepare.go
@@ -153,7 +153,7 @@ func prepareOutput(ti typeNameToInfo, p *outputPart) (outCols []fullName, typeMe
 			if t.name == "*" {
 				switch info := info.(type) {
 				case *mapInfo:
-					return nil, nil, fmt.Errorf(`columns must be specified for asterisk map`)
+					return nil, nil, fmt.Errorf(`columns must be specified for map with star`)
 				case *structInfo:
 					if len(info.tags) == 0 {
 						return nil, nil, fmt.Errorf(`no "db" tags found in struct %q`, info.typ().Name())


### PR DESCRIPTION
In `prepare.go`, include the I/O expression in which the error was found where possible. The errors are changed to reflect that the full expression is now included in the error message. The phrase "cannot prepare expression" is changed to "cannot prepare statement" to reflect that expression is used to refer only to the I/O expression. 