### PR TITLE
Add latest Go verison to CI

### DIFF
--- a/.github/workflows/go-test.yml
+++ b/.github/workflows/go-test.yml
@@ -4,7 +4,7 @@ jobs:
   build:
     strategy:
       matrix:
-        go-version: [1.18.x, 1.19.x, 1.20.x, 1.21.x]
+        go-version: [1.18.x, 1.x]
     runs-on: ubuntu-latest
     steps:
       - name: Checkout code

--- a/.github/workflows/go-test.yml
+++ b/.github/workflows/go-test.yml
@@ -4,7 +4,7 @@ jobs:
   build:
     strategy:
       matrix:
-        go-version: [1.18.x, 1.19.x, 1.20.x]
+        go-version: [1.18.x, 1.19.x, 1.20.x, 1.21.x]
     runs-on: ubuntu-latest
     steps:
       - name: Checkout code


### PR DESCRIPTION
Change CI to run tests on Go 1.18 and the latest version.