### PR TITLE
Change switch/case in Prepare methods of typeInfo

### DIFF
--- a/internal/expr/expr_test.go
+++ b/internal/expr/expr_test.go
@@ -509,7 +509,7 @@ func (s *ExprSuite) TestPrepareErrors(c *C) {
 	}, {
 		query:       "SELECT &NoTags.* FROM t",
 		prepareArgs: []any{NoTags{}},
-		err:         `cannot prepare expression: type "NoTags" in "&NoTags.*" does not have any db tags`,
+		err:         `cannot prepare expression: type "NoTags" does not have any db tags`,
 	}}
 
 	for i, test := range tests {
@@ -543,17 +543,17 @@ func (s *ExprSuite) TestPrepareMapError(c *C) {
 		"all output into map star",
 		"SELECT &M.* FROM person WHERE name = 'Fred'",
 		[]any{sqlair.M{}},
-		"cannot prepare expression: &M.* cannot be used for maps when no column names are specified",
+		`cannot prepare expression: map type "M" cannot be used with asterisk`,
 	}, {
 		"all output into map star from table star",
 		"SELECT p.* AS &M.* FROM person WHERE name = 'Fred'",
 		[]any{sqlair.M{}},
-		"cannot prepare expression: &M.* cannot be used for maps when no column names are specified",
+		`cannot prepare expression: map type "M" cannot be used with asterisk`,
 	}, {
 		"all output into map star from lone star",
 		"SELECT * AS &CustomMap.* FROM person WHERE name = 'Fred'",
 		[]any{CustomMap{}},
-		"cannot prepare expression: &CustomMap.* cannot be used for maps when no column names are specified",
+		`cannot prepare expression: map type "CustomMap" cannot be used with asterisk`,
 	}, {
 		"invalid map",
 		"SELECT * AS &InvalidMap.* FROM person WHERE name = 'Fred'",

--- a/internal/expr/typeinfo.go
+++ b/internal/expr/typeinfo.go
@@ -58,7 +58,7 @@ type typeInfo interface {
 	typ() reflect.Type
 
 	// typeMember returns the type member associated with a given column name.
-	typeMember(string) (typeMember, error)
+	typeMember(member string) (typeMember, error)
 
 	// getAllMembers returns all members a type associated with column names.
 	getAllMembers() ([]typeMember, error)

--- a/internal/expr/typeinfo.go
+++ b/internal/expr/typeinfo.go
@@ -53,8 +53,15 @@ func (f structField) memberName() string {
 	return f.tag
 }
 
+// typeInfo exposes useful information about types used in SQLair queries.
 type typeInfo interface {
 	typ() reflect.Type
+
+	// typeMember returns the type member associated with a given column name.
+	typeMember(string) (typeMember, error)
+
+	// getAllMembers returns all members a type associated with column names.
+	getAllMembers() ([]typeMember, error)
 }
 
 type structInfo struct {
@@ -70,6 +77,28 @@ func (si *structInfo) typ() reflect.Type {
 	return si.structType
 }
 
+func (si *structInfo) typeMember(member string) (typeMember, error) {
+	tm, ok := si.tagToField[member]
+	if !ok {
+		return nil, fmt.Errorf(`type %q has no %q db tag`, si.structType.Name(), member)
+	}
+	return tm, nil
+}
+
+func (si *structInfo) getAllMembers() ([]typeMember, error) {
+	if len(si.tags) == 0 {
+		return nil, fmt.Errorf("type %q does not have any db tags", si.structType.Name())
+	}
+
+	tms := []typeMember{}
+	for _, tag := range si.tags {
+		tms = append(tms, si.tagToField[tag])
+	}
+	return tms, nil
+}
+
+var _ typeInfo = &structInfo{}
+
 type mapInfo struct {
 	mapType reflect.Type
 }
@@ -77,6 +106,16 @@ type mapInfo struct {
 func (mi *mapInfo) typ() reflect.Type {
 	return mi.mapType
 }
+
+func (mi *mapInfo) typeMember(member string) (typeMember, error) {
+	return &mapKey{name: member, mapType: mi.mapType}, nil
+}
+
+func (mi *mapInfo) getAllMembers() ([]typeMember, error) {
+	return nil, fmt.Errorf(`map type %q cannot be used with asterisk`, mi.mapType.Name())
+}
+
+var _ typeInfo = &mapInfo{}
 
 var cacheMutex sync.RWMutex
 var cache = make(map[reflect.Type]typeInfo)


### PR DESCRIPTION
The switch/case statements in `prepareInput` and `prepareOutput` contain repeated code and repeated error message that can be factored out into methods on `typeInfo`.
- `typeMember(string) (typeMember, error)` is added to get a specific member of a struct or map
- `getAllMembers() ([]typeMember, error)` is added for when asterisk expressions need all members of a type

The local function `addColumns` in `prepareOutput` is removed and calls are replaced with the explicit code since with these changes it only added cognitive overhead.

This means that the error messages change slightly but any context lost here will be added back with PR #99 where we add the relevant raw SQL to the error.