### PR TITLE
Include raw expression in `Query` errors

### DIFF
--- a/internal/expr/expr_test.go
+++ b/internal/expr/expr_test.go
@@ -557,11 +557,11 @@ func (s *ExprSuite) TestBindTypesErrors(c *C) {
 	}, {
 		query:       "SELECT (&Address.*, &Address.id) FROM t",
 		typeSamples: []any{Address{}, Person{}},
-		err:         `cannot prepare statement: tag "id" of struct "Address" appears in: &Address.* and in: &Address.id`,
+		err:         `cannot prepare statement: tag "id" of struct "Address" appears in "&Address.*" and in "&Address.id"`,
 	}, {
 		query:       "SELECT (&M.id, &M.id) FROM t",
 		typeSamples: []any{sqlair.M{}},
-		err:         `cannot prepare statement: key "id" of map "M" appears more than once in output expressions`,
+		err:         `cannot prepare statement: key "id" of map "M" appears more than once in "&M.id" and "&M.id"`,
 	}, {
 		query:       "SELECT (p.*, t.name) AS (&Address.*) FROM t",
 		typeSamples: []any{Address{}},
@@ -573,11 +573,7 @@ func (s *ExprSuite) TestBindTypesErrors(c *C) {
 	}, {
 		query:       "SELECT (&Person.*, &Person.*) FROM t",
 		typeSamples: []any{Address{}, Person{}},
-		err:         `cannot prepare statement: tag "address_id" of struct "Person" appears in: &Person.* and in: &Person.*`,
-	}, {
-		query:       "SELECT (p.*, t.*) AS (&Address.*) FROM t",
-		typeSamples: []any{Address{}},
-		err:         "cannot prepare statement: output expression: invalid asterisk in columns: (p.*, t.*) AS (&Address.*)",
+		err:         `cannot prepare statement: tag "address_id" of struct "Person" appears in "&Person.*" and in "&Person.*"`,
 	}, {
 		query:       "SELECT (id, name) AS (&Person.id, &Address.*) FROM t",
 		typeSamples: []any{Address{}, Person{}},

--- a/internal/expr/expr_test.go
+++ b/internal/expr/expr_test.go
@@ -557,11 +557,11 @@ func (s *ExprSuite) TestBindTypesErrors(c *C) {
 	}, {
 		query:       "SELECT (&Address.*, &Address.id) FROM t",
 		typeSamples: []any{Address{}, Person{}},
-		err:         `cannot prepare statement: tag "id" of struct "Address" appears in "&Address.*" and in "&Address.id"`,
+		err:         `cannot prepare statement: tag "id" of struct "Address" appears in "&Address.id" and in "&Address.*"`,
 	}, {
 		query:       "SELECT (&M.id, &M.id) FROM t",
 		typeSamples: []any{sqlair.M{}},
-		err:         `cannot prepare statement: key "id" of map "M" appears more than once in "&M.id" and "&M.id"`,
+		err:         `cannot prepare statement: key "id" of map "M" appears in "&M.id" and in "&M.id"`,
 	}, {
 		query:       "SELECT (p.*, t.name) AS (&Address.*) FROM t",
 		typeSamples: []any{Address{}},
@@ -782,7 +782,7 @@ func (s *ExprSuite) TestBindInputsError(c *C) {
 		query:       "SELECT street FROM t WHERE y = $Person.name",
 		typeSamples: []any{outerP},
 		inputArgs:   []any{shadowedP},
-		err:         `invalid input parameter: parameter with type "expr_test.Person" missing, have type with same name: "expr_test.Person"`,
+		err:         `invalid input parameter: parameter with type "expr_test.Person" missing, have type with same name: "expr_test.Person": $Person.name`,
 	}}
 
 	tests = append(tests, testsShadowed...)

--- a/internal/expr/expr_test.go
+++ b/internal/expr/expr_test.go
@@ -557,7 +557,7 @@ func (s *ExprSuite) TestBindTypesErrors(c *C) {
 	}, {
 		query:       "SELECT (&Address.*, &Address.id) FROM t",
 		typeSamples: []any{Address{}, Person{}},
-		err:         `cannot prepare statement: tag "id" of struct "Address" appears more than once in output expressions`,
+		err:         `cannot prepare statement: tag "id" of struct "Address" appears in: &Address.* and in: &Address.id`,
 	}, {
 		query:       "SELECT (&M.id, &M.id) FROM t",
 		typeSamples: []any{sqlair.M{}},
@@ -573,7 +573,7 @@ func (s *ExprSuite) TestBindTypesErrors(c *C) {
 	}, {
 		query:       "SELECT (&Person.*, &Person.*) FROM t",
 		typeSamples: []any{Address{}, Person{}},
-		err:         `cannot prepare statement: tag "address_id" of struct "Person" appears more than once in output expressions`,
+		err:         `cannot prepare statement: tag "address_id" of struct "Person" appears in: &Person.* and in: &Person.*`,
 	}, {
 		query:       "SELECT (p.*, t.*) AS (&Address.*) FROM t",
 		typeSamples: []any{Address{}},
@@ -715,7 +715,7 @@ func (s *ExprSuite) TestBindInputsError(c *C) {
 		query:       "SELECT street FROM t WHERE x = $Address.street, y = $Person.name",
 		typeSamples: []any{Address{}, Person{}},
 		inputArgs:   []any{Address{Street: "Dead end road"}},
-		err:         `invalid input parameter: parameter with type "Person" missing (have "Address")`,
+		err:         `invalid input parameter: parameter with type "Person" missing (have "Address"): $Person.name`,
 	}, {
 		query:       "SELECT street FROM t WHERE x = $Address.street, y = $Person.name",
 		typeSamples: []any{Address{}, Person{}},
@@ -750,17 +750,17 @@ func (s *ExprSuite) TestBindInputsError(c *C) {
 		query:       "SELECT * AS &Address.* FROM t WHERE x = $M.Fullname",
 		typeSamples: []any{Address{}, sqlair.M{}},
 		inputArgs:   []any{sqlair.M{"fullname": "Jimany Johnson"}},
-		err:         `invalid input parameter: map "M" does not contain key "Fullname"`,
+		err:         `invalid input parameter: map "M" does not contain key "Fullname": $M.Fullname`,
 	}, {
 		query:       "SELECT foo FROM t WHERE x = $M.street, y = $Person.id",
 		typeSamples: []any{Person{}, sqlair.M{}},
 		inputArgs:   []any{Person{ID: 666}, sqlair.M{"Street": "Highway to Hell"}},
-		err:         `invalid input parameter: map "M" does not contain key "street"`,
+		err:         `invalid input parameter: map "M" does not contain key "street": $M.street`,
 	}, {
 		query:       "SELECT street FROM t WHERE x = $Address.street, y = $Person.name",
 		typeSamples: []any{Address{}, Person{}},
 		inputArgs:   []any{},
-		err:         `invalid input parameter: parameter with type "Address" missing`,
+		err:         `invalid input parameter: parameter with type "Address" missing: $Address.street`,
 	}, {
 		query:       "SELECT street FROM t WHERE x = $Person.id, y = $Person.name",
 		typeSamples: []any{Person{}},

--- a/internal/expr/parser.go
+++ b/internal/expr/parser.go
@@ -198,6 +198,10 @@ func (p *bypass) String() string {
 
 func (p *bypass) expr() {}
 
+func (p *bypass) raw() string {
+	return p.chunk
+}
+
 // init resets the state of the parser and sets the input string.
 func (p *Parser) init(input string) {
 	p.input = input

--- a/package_test.go
+++ b/package_test.go
@@ -573,7 +573,7 @@ func (s *PackageSuite) TestGetErrors(c *C) {
 		types:   []any{sqlair.M{}},
 		inputs:  []any{sqlair.M{}},
 		outputs: []any{sqlair.M{}},
-		err:     `invalid input parameter: map "M" does not contain key "p1"`,
+		err:     `invalid input parameter: map "M" does not contain key "p1": $M.p1`,
 	}}
 
 	tables, sqldb, err := personAndAddressDB(c)
@@ -588,8 +588,12 @@ func (s *PackageSuite) TestGetErrors(c *C) {
 			Commentf("\ntest %q failed (Prepare):\ninput: %s\n", t.summary, t.query))
 
 		err = db.Query(nil, stmt, t.inputs...).Get(t.outputs...)
-		c.Assert(err, ErrorMatches, t.err,
-			Commentf("\ntest %q failed:\ninput: %s\noutputs: %s", t.summary, t.query, t.outputs))
+		if err != nil {
+			c.Assert(err.Error(), Equals, t.err,
+				Commentf("\ntest %q failed:\ninput: %s\noutputs: %s", t.summary, t.query, t.outputs))
+		} else {
+			c.Errorf("\ntest %q failed:\nexpected err: %q but got nil\ninput: %s\noutputs: %s", t.summary, t.err, t.query, t.outputs)
+		}
 	}
 }
 func (s *PackageSuite) TestErrNoRows(c *C) {


### PR DESCRIPTION
Add information to errors in `query.go` about the expression in the query that the error pertains to. Extra information is also added to the error that reports duplicate type members in the query, it now includes the expressions in which the two instances occur.

In the `PreparedExpr` a list of typeMembers was used to store the query input and outputs . This is replaced by a list of `typeLocations`. The `typeLocation` struct contains the `typeMember` and the raw string. `typeMember` structs are reused across statements so it would be strange to include information specific to the statement inside them. The `typeLocation` struct can also be used in the future to retain other contextual information about where the `typeMember` occurs in the query.