### PR TITLE
Replace typeName and columnName

### DIFF
--- a/internal/expr/parser.go
+++ b/internal/expr/parser.go
@@ -18,8 +18,8 @@ type queryPart interface {
 }
 
 // valueAccessor stores information for accessing a Go value. It consists of a
-// type name and a part of it to access, for example a field of a struct or key
-// of a map.
+// type name and some value within it to be accessed. For example: a field of a
+// struct, or a key of a map.
 type valueAccessor struct {
 	typeName, memberName string
 }

--- a/internal/expr/parser.go
+++ b/internal/expr/parser.go
@@ -17,31 +17,33 @@ type queryPart interface {
 	part()
 }
 
-// typeName stores a Go type and a member of it.
-type typeName struct {
-	name, member string
+// valueAccessor stores information for accessing a Go value. It consists of a
+// type name and a part of it to access, for example a field of a struct or key
+// of a map.
+type valueAccessor struct {
+	typeName, memberName string
 }
 
-func (tn typeName) String() string {
-	return tn.name + "." + tn.member
+func (va valueAccessor) String() string {
+	return va.typeName + "." + va.memberName
 }
 
-// columnName stores a SQL column and optionally its table.
-type columnName struct {
-	table, name string
+// columnAccessor stores a SQL column name and optionally its table name.
+type columnAccessor struct {
+	tableName, columnName string
 }
 
-func (cn columnName) String() string {
-	if cn.table == "" {
-		return cn.name
+func (ca columnAccessor) String() string {
+	if ca.tableName == "" {
+		return ca.columnName
 	}
-	return cn.table + "." + cn.name
+	return ca.tableName + "." + ca.columnName
 }
 
 // inputPart represents a named parameter that will be sent to the database
 // while performing the query.
 type inputPart struct {
-	sourceType typeName
+	sourceType valueAccessor
 	raw        string
 }
 
@@ -54,8 +56,8 @@ func (p *inputPart) part() {}
 // outputPart represents a named target output variable in the SQL expression,
 // as well as the source table and column where it will be read from.
 type outputPart struct {
-	sourceColumns []columnName
-	targetTypes   []typeName
+	sourceColumns []columnAccessor
+	targetTypes   []valueAccessor
 	raw           string
 }
 
@@ -483,53 +485,52 @@ func (p *Parser) parseIdentifier() (string, bool) {
 // parseColumn parses a column made up of name bytes, optionally dot-prefixed by
 // its table name.
 // parseColumn returns an error so that it can be used with parseList.
-func (p *Parser) parseColumn() (columnName, bool, error) {
+func (p *Parser) parseColumn() (columnAccessor, bool, error) {
 	cp := p.save()
 
 	if id, ok := p.parseIdentifierAsterisk(); ok {
 		if id != "*" && p.skipByte('.') {
 			if idCol, ok := p.parseIdentifierAsterisk(); ok {
-				return columnName{table: id, name: idCol}, true, nil
+				return columnAccessor{tableName: id, columnName: idCol}, true, nil
 			}
 		} else {
-			// A column name specified without a table prefix should be in name.
-			return columnName{name: id}, true, nil
+			return columnAccessor{columnName: id}, true, nil
 		}
 	}
 
 	cp.restore()
-	return columnName{}, false, nil
+	return columnAccessor{}, false, nil
 }
 
-func (p *Parser) parseTargetType() (typeName, bool, error) {
+func (p *Parser) parseTargetType() (valueAccessor, bool, error) {
 	if p.skipByte('&') {
 		return p.parseTypeName()
 	}
 
-	return typeName{}, false, nil
+	return valueAccessor{}, false, nil
 }
 
 // parseTypeName parses a Go type name qualified by a tag name (or asterisk)
 // of the form "TypeName.col_name".
-func (p *Parser) parseTypeName() (typeName, bool, error) {
+func (p *Parser) parseTypeName() (valueAccessor, bool, error) {
 	cp := p.save()
 
 	// The error points to the skipped & or $.
 	identifierCol := p.colNum() - 1
 	if id, ok := p.parseIdentifier(); ok {
 		if !p.skipByte('.') {
-			return typeName{}, false, errorAt(fmt.Errorf("unqualified type, expected %s.* or %s.<db tag>", id, id), p.lineNum, identifierCol, p.input)
+			return valueAccessor{}, false, errorAt(fmt.Errorf("unqualified type, expected %s.* or %s.<db tag>", id, id), p.lineNum, identifierCol, p.input)
 		}
 
 		idField, ok := p.parseIdentifierAsterisk()
 		if !ok {
-			return typeName{}, false, errorAt(fmt.Errorf("invalid identifier suffix following %q", id), p.lineNum, p.colNum(), p.input)
+			return valueAccessor{}, false, errorAt(fmt.Errorf("invalid identifier suffix following %q", id), p.lineNum, p.colNum(), p.input)
 		}
-		return typeName{name: id, member: idField}, true, nil
+		return valueAccessor{typeName: id, memberName: idField}, true, nil
 	}
 
 	cp.restore()
-	return typeName{}, false, nil
+	return valueAccessor{}, false, nil
 }
 
 // parseList takes a parsing function that returns a T and parses a
@@ -572,10 +573,10 @@ func parseList[T any](p *Parser, parseFn func(p *Parser) (T, bool, error)) ([]T,
 
 // parseColumns parses a single column or a list of columns. Lists must be
 // enclosed in parentheses.
-func (p *Parser) parseColumns() (cols []columnName, parentheses bool, ok bool) {
+func (p *Parser) parseColumns() (cols []columnAccessor, parentheses bool, ok bool) {
 	// Case 1: A single column e.g. "p.name".
 	if col, ok, _ := p.parseColumn(); ok {
-		return []columnName{col}, false, true
+		return []columnAccessor{col}, false, true
 	}
 
 	// Case 2: Multiple columns e.g. "(p.name, p.id)".
@@ -588,12 +589,12 @@ func (p *Parser) parseColumns() (cols []columnName, parentheses bool, ok bool) {
 
 // parseTargetTypes parses a single output type or a list of output types.
 // Lists of types must be enclosed in parentheses.
-func (p *Parser) parseTargetTypes() (types []typeName, parentheses bool, ok bool, err error) {
+func (p *Parser) parseTargetTypes() (types []valueAccessor, parentheses bool, ok bool, err error) {
 	// Case 1: A single target e.g. "&Person.name".
 	if targetTypes, ok, err := p.parseTargetType(); err != nil {
 		return nil, false, false, err
 	} else if ok {
-		return []typeName{targetTypes}, false, true, nil
+		return []valueAccessor{targetTypes}, false, true, nil
 	}
 
 	// Case 2: Multiple types e.g. "(&Person.name, &Person.id)".
@@ -616,8 +617,8 @@ func (p *Parser) parseOutputExpression() (*outputPart, bool, error) {
 		return nil, false, err
 	} else if ok {
 		return &outputPart{
-			sourceColumns: []columnName{},
-			targetTypes:   []typeName{targetType},
+			sourceColumns: []columnAccessor{},
+			targetTypes:   []valueAccessor{targetType},
 			raw:           p.input[start:p.pos],
 		}, true, nil
 	}
@@ -660,7 +661,7 @@ func (p *Parser) parseInputExpression() (*inputPart, bool, error) {
 		// Error points to the $ sign skipped above.
 		nameCol := p.colNum() - 1
 		if tn, ok, err := p.parseTypeName(); ok {
-			if tn.member == "*" {
+			if tn.memberName == "*" {
 				return nil, false, errorAt(fmt.Errorf(`asterisk not allowed in input expression "$%s"`, tn), p.lineNum, nameCol, p.input)
 			}
 			return &inputPart{sourceType: tn, raw: p.input[cp.pos:p.pos]}, true, nil

--- a/internal/expr/prepare.go
+++ b/internal/expr/prepare.go
@@ -51,10 +51,10 @@ func getKeys[T any](m map[string]T) []string {
 }
 
 // starCountColumns counts the number of asterisks in a list of columns.
-func starCountColumns(columns []columnName) int {
+func starCountColumns(cs []columnAccessor) int {
 	s := 0
-	for _, column := range columns {
-		if column.name == "*" {
+	for _, c := range cs {
+		if c.columnName == "*" {
 			s++
 		}
 	}
@@ -62,10 +62,10 @@ func starCountColumns(columns []columnName) int {
 }
 
 // starCountTypes counts the number of asterisks in a list of types.
-func starCountTypes(types []typeName) int {
+func starCountTypes(vs []valueAccessor) int {
 	s := 0
-	for _, t := range types {
-		if t.member == "*" {
+	for _, v := range vs {
+		if v.memberName == "*" {
 			s++
 		}
 	}
@@ -88,12 +88,12 @@ func prepareInput(ti typeNameToInfo, p *inputPart) (tm typeMember, err error) {
 		}
 	}()
 
-	info, ok := ti[p.sourceType.name]
+	info, ok := ti[p.sourceType.typeName]
 	if !ok {
-		return nil, typeMissingError(p.sourceType.name, getKeys(ti))
+		return nil, typeMissingError(p.sourceType.typeName, getKeys(ti))
 	}
 
-	tm, err = info.typeMember(p.sourceType.member)
+	tm, err = info.typeMember(p.sourceType.memberName)
 	if err != nil {
 		return nil, err
 	}
@@ -102,7 +102,7 @@ func prepareInput(ti typeNameToInfo, p *inputPart) (tm typeMember, err error) {
 
 // prepareOutput checks that the output expressions correspond to known types.
 // It then checks they are formatted correctly and finally generates the columns for the query.
-func prepareOutput(ti typeNameToInfo, p *outputPart) (outCols []columnName, typeMembers []typeMember, err error) {
+func prepareOutput(ti typeNameToInfo, p *outputPart) (outCols []columnAccessor, typeMembers []typeMember, err error) {
 	defer func() {
 		if err != nil {
 			err = fmt.Errorf("output expression: %s: %s", err, p.raw)
@@ -119,15 +119,15 @@ func prepareOutput(ti typeNameToInfo, p *outputPart) (outCols []columnName, type
 		pref := ""
 		// Prepend table name. E.g. "t" in "t.* AS &P.*".
 		if numColumns > 0 {
-			pref = p.sourceColumns[0].table
+			pref = p.sourceColumns[0].tableName
 		}
 
 		for _, t := range p.targetTypes {
-			info, ok := ti[t.name]
+			info, ok := ti[t.typeName]
 			if !ok {
-				return nil, nil, typeMissingError(t.name, getKeys(ti))
+				return nil, nil, typeMissingError(t.typeName, getKeys(ti))
 			}
-			if t.member == "*" {
+			if t.memberName == "*" {
 				// Generate asterisk columns.
 				allMembers, err := info.getAllMembers()
 				if err != nil {
@@ -135,16 +135,16 @@ func prepareOutput(ti typeNameToInfo, p *outputPart) (outCols []columnName, type
 				}
 				typeMembers = append(typeMembers, allMembers...)
 				for _, tm := range allMembers {
-					outCols = append(outCols, columnName{pref, tm.memberName()})
+					outCols = append(outCols, columnAccessor{pref, tm.memberName()})
 				}
 			} else {
 				// Generate explicit columns.
-				tm, err := info.typeMember(t.member)
+				tm, err := info.typeMember(t.memberName)
 				if err != nil {
 					return nil, nil, err
 				}
 				typeMembers = append(typeMembers, tm)
-				outCols = append(outCols, columnName{pref, t.member})
+				outCols = append(outCols, columnAccessor{pref, t.memberName})
 			}
 		}
 		return outCols, typeMembers, nil
@@ -154,12 +154,12 @@ func prepareOutput(ti typeNameToInfo, p *outputPart) (outCols []columnName, type
 
 	// Case 2: Explicit columns, single asterisk type e.g. "(col1, t.col2) AS &P.*".
 	if starTypes == 1 && numTypes == 1 {
-		info, ok := ti[p.targetTypes[0].name]
+		info, ok := ti[p.targetTypes[0].typeName]
 		if !ok {
-			return nil, nil, typeMissingError(p.targetTypes[0].name, getKeys(ti))
+			return nil, nil, typeMissingError(p.targetTypes[0].typeName, getKeys(ti))
 		}
 		for _, c := range p.sourceColumns {
-			tm, err := info.typeMember(c.name)
+			tm, err := info.typeMember(c.columnName)
 			if err != nil {
 				return nil, nil, err
 			}
@@ -175,11 +175,11 @@ func prepareOutput(ti typeNameToInfo, p *outputPart) (outCols []columnName, type
 	if numColumns == numTypes {
 		for i, c := range p.sourceColumns {
 			t := p.targetTypes[i]
-			info, ok := ti[t.name]
+			info, ok := ti[t.typeName]
 			if !ok {
-				return nil, nil, typeMissingError(t.name, getKeys(ti))
+				return nil, nil, typeMissingError(t.typeName, getKeys(ti))
 			}
-			tm, err := info.typeMember(t.member)
+			tm, err := info.typeMember(t.memberName)
 			if err != nil {
 				return nil, nil, err
 			}


### PR DESCRIPTION
Change `typeName` to `valueAccessor` and `columnName` to `columnAccessor`. This change reduces the ambiguity introduced in #101 where both `typeName` and `columnName` had a `name` field that represented a very different thing. The names of the structs and their fields are changed here to reflect more what the values represent in the context of the program rather than what they literally are.