### PR TITLE
bugfix: race condition, statement was closed early

### DIFF
--- a/package_test.go
+++ b/package_test.go
@@ -1358,6 +1358,9 @@ AND    l.model_uuid = $JujuLeaseKey.model_uuid`,
 	}
 }
 
+// Because the Query struct did not contain references to either Statement or
+// DB, if either of those would go out of scope the underlying sql.Stmt would
+// be closed.
 func (s *PackageSuite) TestRaceConditionFinalizer(c *C) {
 	var q *sqlair.Query
 	// Drop all the values except the query itself.
@@ -1377,9 +1380,9 @@ func (s *PackageSuite) TestRaceConditionFinalizer(c *C) {
 		time.Sleep(0)
 	}
 
+	// Assert that sql.Stmt was not closed early.
 	c.Assert(q.Run(), IsNil)
 }
-
 func (s *PackageSuite) TestRaceConditionFinalizerTX(c *C) {
 	var q *sqlair.Query
 	// Drop all the values except the query itself.
@@ -1401,5 +1404,6 @@ func (s *PackageSuite) TestRaceConditionFinalizerTX(c *C) {
 		time.Sleep(0)
 	}
 
+	// Assert that sql.Stmt was not closed early.
 	c.Assert(q.Run(), IsNil)
 }

--- a/sqlair.go
+++ b/sqlair.go
@@ -141,6 +141,10 @@ type Query struct {
 	ctx     context.Context
 	err     error
 	tx      *TX // tx is only set for queries in transactions.
+	// Persist statement so it is not closed until the Query is dropped.
+	stmt *Statement
+	// Persist db so it is not closed until the Query is dropped.
+	db *DB
 }
 
 // Iterator is used to iterate over the results of the query.
@@ -171,7 +175,7 @@ func (db *DB) Query(ctx context.Context, s *Statement, inputArgs ...any) *Query 
 		return &Query{ctx: ctx, err: err}
 	}
 
-	return &Query{sqlstmt: sqlstmt, qe: qe, ctx: ctx, err: nil}
+	return &Query{sqlstmt: sqlstmt, stmt: s, db: db, qe: qe, ctx: ctx, err: nil}
 }
 
 // prepareSubstrate is an object that queries can be prepared on, e.g. a sql.DB
@@ -565,5 +569,5 @@ func (tx *TX) Query(ctx context.Context, s *Statement, inputArgs ...any) *Query 
 		return &Query{ctx: ctx, err: err}
 	}
 
-	return &Query{sqlstmt: sqlstmt, qe: qe, tx: tx, ctx: ctx, err: nil}
+	return &Query{sqlstmt: sqlstmt, stmt: s, db: tx.db, qe: qe, tx: tx, ctx: ctx, err: nil}
 }

--- a/sqlair.go
+++ b/sqlair.go
@@ -141,10 +141,9 @@ type Query struct {
 	ctx     context.Context
 	err     error
 	tx      *TX // tx is only set for queries in transactions.
-	// Persist statement so it is not closed until the Query is dropped.
+	// Persist statement and db so the sql.Stmt is not closed until the Query is dropped.
 	stmt *Statement
-	// Persist db so it is not closed until the Query is dropped.
-	db *DB
+	db   *DB
 }
 
 // Iterator is used to iterate over the results of the query.


### PR DESCRIPTION
Because the Query struct did not contain references to either Statement or DB, if either of those goes out of scope the underlying sql.Stmt was closed. If the user then proceeds to use the Query struct, the result will be an error.