### PR TITLE
Move marker methods from prepare.go to query.go

### DIFF
--- a/internal/expr/prepare.go
+++ b/internal/expr/prepare.go
@@ -21,23 +21,6 @@ func (pe *PreparedExpr) SQL() string {
 	return pe.sql
 }
 
-const markerPrefix = "_sqlair_"
-
-func markerName(n int) string {
-	return markerPrefix + strconv.Itoa(n)
-}
-
-// markerIndex returns the int X from the string "_sqlair_X".
-func markerIndex(s string) (int, bool) {
-	if strings.HasPrefix(s, markerPrefix) {
-		n, err := strconv.Atoi(s[len(markerPrefix):])
-		if err == nil {
-			return n, true
-		}
-	}
-	return 0, false
-}
-
 // getKeys returns the keys of a string map in a deterministic order.
 func getKeys[T any](m map[string]T) []string {
 	i := 0

--- a/internal/expr/query.go
+++ b/internal/expr/query.go
@@ -22,6 +22,23 @@ type QueryExpr struct {
 	outputs []typeMember
 }
 
+const markerPrefix = "_sqlair_"
+
+func markerName(n int) string {
+	return markerPrefix + strconv.Itoa(n)
+}
+
+// markerIndex returns the int X from the string "_sqlair_X".
+func markerIndex(s string) (int, bool) {
+	if strings.HasPrefix(s, markerPrefix) {
+		n, err := strconv.Atoi(s[len(markerPrefix):])
+		if err == nil {
+			return n, true
+		}
+	}
+	return 0, false
+}
+
 // Query returns a query expression ready for execution, using the provided values to
 // substitute the input placeholders in the prepared expression. These placeholders use
 // the syntax "$Person.fullname", where Person would be a type such as:


### PR DESCRIPTION
Move the const `markerPrefix` and the methods `markerName` and `markerIndex` to `query.go`.

This change is motivated by PR #112. In it, the SQL will be generated in `query.go` so all calls to these functions will come from `query.go`.