### PR TITLE
bugfix: Iter.Get check number of args to prevent panic

### DIFF
--- a/package_test.go
+++ b/package_test.go
@@ -877,6 +877,11 @@ func (s *PackageSuite) TestOutcome(c *C) {
 	err = q2.GetAll(&outcome, &jims)
 	c.Assert(err, IsNil)
 	c.Assert(outcome.Result(), IsNil)
+	// Test Iter.Get with zero args and without Outcome
+	selectStmt = sqlair.MustPrepare(`SELECT 'hello'`)
+	iter = db.Query(nil, selectStmt).Iter()
+	err = iter.Get()
+	c.Assert(err, ErrorMatches, "cannot get result: cannot call Get before Next unless getting outcome")
 }
 
 func (s *PackageSuite) TestQueryMultipleRuns(c *C) {

--- a/sqlair.go
+++ b/sqlair.go
@@ -329,9 +329,11 @@ func (iter *Iterator) Get(outputArgs ...any) (err error) {
 	}()
 
 	if !iter.started {
-		if oc, ok := outputArgs[0].(*Outcome); ok && len(outputArgs) == 1 {
-			oc.result = iter.result
-			return nil
+		if len(outputArgs) == 1 {
+			if oc, ok := outputArgs[0].(*Outcome); ok {
+				oc.result = iter.result
+				return nil
+			}
 		}
 		return fmt.Errorf("cannot call Get before Next unless getting outcome")
 	}


### PR DESCRIPTION
In `Iter.Get` we need to explicitly check the length of args before a check at the zero-index in order to prevent a panic.