### PR TITLE
Test for prepared statement leaks

### DIFF
--- a/driver_test.go
+++ b/driver_test.go
@@ -72,14 +72,18 @@ func (c *Conn) Prepare(query string) (driver.Stmt, error) {
 	return c.PrepareContext(context.Background(), query)
 }
 
-var testNameTag = "testName"
+const testNameTag = "testName"
 
 func (d *Driver) Open(name string) (driver.Conn, error) {
 	var testName string
-	for _, p := range strings.Split(name, "&") {
+	parameters := strings.Split(name, "?")[1]
+	for _, p := range strings.Split(parameters, "&") {
 		if strings.HasPrefix(p, testNameTag) {
 			testName = strings.Split(p, "=")[1]
 		}
+	}
+	if testName == "" {
+		panic("internal error: testName is not found in the db DSN")
 	}
 
 	baseConn, err := d.Driver.Open(name)

--- a/driver_test.go
+++ b/driver_test.go
@@ -11,10 +11,10 @@ import (
 	"github.com/mattn/go-sqlite3"
 )
 
-// This file contains a wrapper sql.Driver over the SQLite driver. On top of
-// it, it monitors the creation and closing of prepared statements and stores
-// the references to said statements. We can later use that information to
-// check for statement leaks.
+// This file contains a wrapper sql.Driver over the SQLite driver which
+// monitors the creation and closing of prepared statements and stores the
+// references to said statements. We can later use that information to check
+// for statement leaks.
 
 // The stmt registry keeps the pointers for the open and closed statements to
 // detect resource leaks. It uses unsafe pointers instead of references to the

--- a/driver_test.go
+++ b/driver_test.go
@@ -1,0 +1,80 @@
+package sqlair_test
+
+import (
+	"context"
+	"database/sql"
+	"database/sql/driver"
+	"sync"
+	"unsafe"
+
+	"github.com/mattn/go-sqlite3"
+)
+
+// This file contains a wrapper sql.Driver over the SQLite driver which does
+// the real work behind the scenes. On top of it, it monitors the creation and
+// closing of prepared statements and stores the references to said statements.
+// We can later use that information to check for leaks.
+
+// The stmt registry keeps the pointers for the open and closed statements to
+// detect resource leaks. It uses pointers instead of references to the object
+// because if we stored a reference the runtime.Finalizer would not be able to
+// run.
+var openStmts map[uintptr]string = map[uintptr]string{}
+var closedStmts map[uintptr]bool = map[uintptr]bool{}
+var stmtRegistryMutex sync.RWMutex
+
+// Structs used for wrapping the underlying SQLite driver.
+type Driver struct {
+	driver.Driver
+}
+type Conn struct {
+	*sqlite3.SQLiteConn
+}
+type Stmt struct {
+	*sqlite3.SQLiteStmt
+}
+
+func (s *Stmt) Close() error {
+	stmtRegistryMutex.Lock()
+	closedStmts[uintptr(unsafe.Pointer(s))] = true
+	stmtRegistryMutex.Unlock()
+
+	return s.SQLiteStmt.Close()
+}
+
+func (c *Conn) PrepareContext(ctx context.Context, query string) (driver.Stmt, error) {
+	s, err := c.SQLiteConn.PrepareContext(ctx, query)
+	if s, ok := s.(*sqlite3.SQLiteStmt); ok {
+		sPtr := &Stmt{s}
+
+		stmtRegistryMutex.Lock()
+		openStmts[uintptr(unsafe.Pointer(sPtr))] = query
+		stmtRegistryMutex.Unlock()
+
+		return sPtr, err
+	} else {
+		panic("internal error: base driver is not SQLite")
+	}
+}
+
+func (c *Conn) Prepare(query string) (driver.Stmt, error) {
+	return c.PrepareContext(context.Background(), query)
+}
+
+func (d *Driver) Open(name string) (driver.Conn, error) {
+	baseConn, err := d.Driver.Open(name)
+	if err != nil {
+		return nil, err
+	}
+	if baseConn, ok := baseConn.(*sqlite3.SQLiteConn); ok {
+		return &Conn{baseConn}, err
+	} else {
+		panic("internal error: base driver is not SQLite")
+	}
+}
+
+func init() {
+	sql.Register("sqlite3_stmtChecked", &Driver{
+		&sqlite3.SQLiteDriver{},
+	})
+}

--- a/package_test.go
+++ b/package_test.go
@@ -33,14 +33,14 @@ func (s *PackageSuite) TearDownTest(c *C) {
 	defer stmtRegistryMutex.Unlock()
 
 	// Asssert that all the open statements were closed.
-	for sPtr, query := range openStmts[c.TestName()] {
+	for sPtr, query := range openedStmts[c.TestName()] {
 		c.Check(closedStmts[c.TestName()][sPtr], Equals, true,
 			Commentf("%s: failed to close statement: %s", c.TestName(), query))
 	}
 
 	// Reset state for next test.
 	closedStmts = map[string]map[uintptr]bool{}
-	openStmts = map[string]map[uintptr]string{}
+	openedStmts = map[string]map[uintptr]string{}
 }
 
 func setupDB(testName string) (*sql.DB, error) {

--- a/package_test.go
+++ b/package_test.go
@@ -37,8 +37,13 @@ func (s *PackageSuite) TearDownTest(c *C) {
 		c.Check(closedStmts[c.TestName()][sPtr], Equals, true,
 			Commentf("%s: failed to close statement: %s", c.TestName(), query))
 	}
+}
 
-	// Reset state for next test.
+func (s *PackageSuite) TearDownSuite(c *C) {
+	stmtRegistryMutex.Lock()
+	defer stmtRegistryMutex.Unlock()
+
+	// Reset state of stmt registry.
 	closedStmts = map[string]map[uintptr]bool{}
 	openedStmts = map[string]map[uintptr]string{}
 }

--- a/package_test.go
+++ b/package_test.go
@@ -43,7 +43,7 @@ func (s *PackageSuite) TearDownSuite(c *C) {
 	stmtRegistryMutex.Lock()
 	defer stmtRegistryMutex.Unlock()
 
-	// Reset state of stmt registry.
+	// Reset state.
 	closedStmts = map[string]map[uintptr]bool{}
 	openedStmts = map[string]map[uintptr]string{}
 }


### PR DESCRIPTION
Created wrapper driver to monitor statement creation and deletion while calling SQLite behind the scenes.

Before this change the tests did not flag when statements were not closed properly, for example if you commented [the following line](https://github.com/canonical/sqlair/blob/main/sqlair.go#L279) no tests would have failed. After this change, the tests are more robust and they can now verify that the cache and finalizers are working correctly. This is especially important now that we want to overhaul the cache implementation and we want to verify it is still correct.