### PR TITLE
Separate concerns relating to reflection and type information

### DIFF
--- a/internal/expr/parser_helper_test.go
+++ b/internal/expr/parser_helper_test.go
@@ -4,6 +4,10 @@ import (
 	. "gopkg.in/check.v1"
 )
 
+type parseSuite struct{}
+
+var _ = Suite(&parseSuite{})
+
 type parseHelperTest struct {
 	bytef    func(byte) bool
 	stringf  func(string) bool
@@ -13,7 +17,7 @@ type parseHelperTest struct {
 	data     []string
 }
 
-func (s *ExprInternalSuite) TestRunTable(c *C) {
+func (s parseSuite) TestRunTable(c *C) {
 	var p = NewParser()
 	var parseTests = []parseHelperTest{
 
@@ -70,7 +74,7 @@ func (s *ExprInternalSuite) TestRunTable(c *C) {
 	}
 }
 
-func (s *ExprInternalSuite) TestValidQuotes(c *C) {
+func (s parseSuite) TestValidQuotes(c *C) {
 	var p = NewParser()
 
 	validQuotes := []string{
@@ -94,7 +98,7 @@ func (s *ExprInternalSuite) TestValidQuotes(c *C) {
 	}
 }
 
-func (s *ExprInternalSuite) TestInvalidQuote(c *C) {
+func (s parseSuite) TestInvalidQuote(c *C) {
 	var p = NewParser()
 
 	invalidQuote := []string{
@@ -111,7 +115,7 @@ func (s *ExprInternalSuite) TestInvalidQuote(c *C) {
 	}
 }
 
-func (s *ExprInternalSuite) TestUnfinishedQuote(c *C) {
+func (s parseSuite) TestUnfinishedQuote(c *C) {
 	var p = NewParser()
 
 	unfinishedQuotes := []string{
@@ -133,7 +137,7 @@ func (s *ExprInternalSuite) TestUnfinishedQuote(c *C) {
 	}
 }
 
-func (s *ExprInternalSuite) TestRemoveComments(c *C) {
+func (s parseSuite) TestRemoveComments(c *C) {
 	validComments := []string{
 		`-- Single line comment`,
 		`-- Single line comment with line break

--- a/internal/expr/query.go
+++ b/internal/expr/query.go
@@ -97,8 +97,14 @@ func (pq *PrimedQuery) ScanArgs(columnNames []string, outputArgs []any) (scanArg
 			return nil, nil, fmt.Errorf("type %q found in query but not passed to get", typeMember.OuterType().Name())
 		}
 
-		if ptrs, scanProxies, err = typeMember.AddScanTarget(outputVal, ptrs, scanProxies); err != nil {
+		ptr, scanProxy, err := typeMember.GetScanTarget(outputVal)
+		if err != nil {
 			return nil, nil, err
+		}
+
+		ptrs = append(ptrs, ptr)
+		if scanProxy != nil {
+			scanProxies = append(scanProxies, *scanProxy)
 		}
 	}
 

--- a/internal/expr/query.go
+++ b/internal/expr/query.go
@@ -1,10 +1,11 @@
 package expr
 
 import (
-	"database/sql"
 	"fmt"
 	"reflect"
 	"strings"
+
+	"github.com/canonical/sqlair/internal/typeinfo"
 )
 
 // PrimedQuery contains all concrete values needed to run a SQLair query on a
@@ -14,7 +15,7 @@ type PrimedQuery struct {
 	// params are the query parameters to pass to the database.
 	params []any
 	// outputs specifies where to scan the query results.
-	outputs []typeMember
+	outputs []typeinfo.Member
 }
 
 // Params returns the query parameters to pass with the SQL to a database.
@@ -28,32 +29,23 @@ func (pq *PrimedQuery) HasOutputs() bool {
 	return len(pq.outputs) > 0
 }
 
-var scannerInterface = reflect.TypeOf((*sql.Scanner)(nil)).Elem()
-
 // ScanArgs produces a list of pointers to be passed to rows.Scan. After a
 // successful call, the onSuccess function must be invoked. The outputArgs will
 // be populated with the query results. All the structs/maps/slices mentioned in
 // the query must be in outputArgs.
 func (pq *PrimedQuery) ScanArgs(columnNames []string, outputArgs []any) (scanArgs []any, onSuccess func(), err error) {
-	var typesInQuery = []string{}
+	var typesInQuery []string
 	var inQuery = make(map[reflect.Type]bool)
 	for _, typeMember := range pq.outputs {
-		outerType := typeMember.outerType()
+		outerType := typeMember.OuterType()
 		if ok := inQuery[outerType]; !ok {
 			inQuery[outerType] = true
 			typesInQuery = append(typesInQuery, outerType.Name())
 		}
 	}
 
-	type scanProxy struct {
-		original reflect.Value
-		scan     reflect.Value
-		key      reflect.Value
-	}
-	var scanProxies []scanProxy
-
 	var typeDest = make(map[reflect.Type]reflect.Value)
-	outputVals := []reflect.Value{}
+	var outputVals []reflect.Value
 	for _, outputArg := range outputArgs {
 		if outputArg == nil {
 			return nil, nil, fmt.Errorf("need map or pointer to struct, got nil")
@@ -84,7 +76,8 @@ func (pq *PrimedQuery) ScanArgs(columnNames []string, outputArgs []any) (scanArg
 	}
 
 	// Generate the pointers.
-	var ptrs = []any{}
+	var ptrs []any
+	var scanProxies []typeinfo.ScanProxy
 	var columnInResult = make([]bool, len(columnNames))
 	for _, column := range columnNames {
 		idx, ok := markerIndex(column)
@@ -99,53 +92,25 @@ func (pq *PrimedQuery) ScanArgs(columnNames []string, outputArgs []any) (scanArg
 		}
 		columnInResult[idx] = true
 		typeMember := pq.outputs[idx]
-		outputVal, ok := typeDest[typeMember.outerType()]
+		outputVal, ok := typeDest[typeMember.OuterType()]
 		if !ok {
-			return nil, nil, fmt.Errorf("type %q found in query but not passed to get", typeMember.outerType().Name())
+			return nil, nil, fmt.Errorf("type %q found in query but not passed to get", typeMember.OuterType().Name())
 		}
-		switch tm := typeMember.(type) {
-		case *structField:
-			val := outputVal.Field(tm.index)
-			if !val.CanSet() {
-				return nil, nil, fmt.Errorf("internal error: cannot set field %s of struct %s", tm.name, tm.structType.Name())
-			}
-			pt := reflect.PointerTo(val.Type())
-			if val.Type().Kind() != reflect.Pointer && !pt.Implements(scannerInterface) {
-				// Rows.Scan will return an error if it tries to scan NULL into a type that cannot be set to nil.
-				// For types that are not a pointer and do not implement sql.Scanner a pointer to them is generated
-				// and passed to Rows.Scan. If Scan has set this pointer to nil the value is zeroed.
-				scanVal := reflect.New(pt).Elem()
-				ptrs = append(ptrs, scanVal.Addr().Interface())
-				scanProxies = append(scanProxies, scanProxy{original: val, scan: scanVal})
-			} else {
-				ptrs = append(ptrs, val.Addr().Interface())
-			}
-		case *mapKey:
-			scanVal := reflect.New(tm.mapType.Elem()).Elem()
-			ptrs = append(ptrs, scanVal.Addr().Interface())
-			scanProxies = append(scanProxies, scanProxy{original: outputVal, scan: scanVal, key: reflect.ValueOf(tm.name)})
+
+		if ptrs, scanProxies, err = typeMember.AddScanTarget(outputVal, ptrs, scanProxies); err != nil {
+			return nil, nil, err
 		}
 	}
 
 	for i := 0; i < len(pq.outputs); i++ {
 		if !columnInResult[i] {
-			return nil, nil, fmt.Errorf(`query uses "&%s" outside of result context`, pq.outputs[i].outerType().Name())
+			return nil, nil, fmt.Errorf(`query uses "&%s" outside of result context`, pq.outputs[i].OuterType().Name())
 		}
 	}
 
 	onSuccess = func() {
 		for _, sp := range scanProxies {
-			if sp.key.IsValid() {
-				sp.original.SetMapIndex(sp.key, sp.scan)
-			} else {
-				var val reflect.Value
-				if !sp.scan.IsNil() {
-					val = sp.scan.Elem()
-				} else {
-					val = reflect.Zero(sp.original.Type())
-				}
-				sp.original.Set(val)
-			}
+			sp.OnSuccess()
 		}
 	}
 

--- a/internal/expr/typebind.go
+++ b/internal/expr/typebind.go
@@ -76,7 +76,7 @@ func (te *TypedExpr) BindInputs(args ...any) (pq *PrimedQuery, err error) {
 			return nil, typeMissingError(outerType.Name(), typeNames)
 		}
 
-		val, err := typeMember.ValueForOuter(v)
+		val, err := typeMember.ValueFromOuter(v)
 		if err != nil {
 			return nil, err
 		}

--- a/internal/typeinfo/info.go
+++ b/internal/typeinfo/info.go
@@ -1,4 +1,4 @@
-package expr
+package typeinfo
 
 import (
 	"fmt"
@@ -9,59 +9,19 @@ import (
 	"sync"
 )
 
-type typeMember interface {
-	outerType() reflect.Type
-	memberName() string
-}
+// This expression should be aligned with the bytes we allow in isNameByte in
+// the parser.
+var validColNameRx = regexp.MustCompile(`^([a-zA-Z_])+([a-zA-Z_0-9])*$`)
 
-type mapKey struct {
-	name    string
-	mapType reflect.Type
-}
+// Info exposes useful information about types used in SQLair queries.
+type Info interface {
+	Typ() reflect.Type
 
-func (mk *mapKey) outerType() reflect.Type {
-	return mk.mapType
-}
+	// TypeMember returns the type member associated with a given column name.
+	TypeMember(member string) (Member, error)
 
-func (mk mapKey) memberName() string {
-	return mk.name
-}
-
-// structField represents reflection information about a field from some struct type.
-type structField struct {
-	name string
-
-	// The type of the containing struct.
-	structType reflect.Type
-
-	// Index for Type.Field.
-	index int
-
-	// The tag assosiated with this field
-	tag string
-
-	// OmitEmpty is true when "omitempty" is
-	// a property of the field's "db" tag.
-	omitEmpty bool
-}
-
-func (f *structField) outerType() reflect.Type {
-	return f.structType
-}
-
-func (f structField) memberName() string {
-	return f.tag
-}
-
-// typeInfo exposes useful information about types used in SQLair queries.
-type typeInfo interface {
-	typ() reflect.Type
-
-	// typeMember returns the type member associated with a given column name.
-	typeMember(member string) (typeMember, error)
-
-	// getAllMembers returns all members a type associated with column names.
-	getAllMembers() ([]typeMember, error)
+	// GetAllMembers returns all members a type associated with column names.
+	GetAllMembers() ([]Member, error)
 }
 
 type structInfo struct {
@@ -73,11 +33,11 @@ type structInfo struct {
 	tagToField map[string]*structField
 }
 
-func (si *structInfo) typ() reflect.Type {
+func (si *structInfo) Typ() reflect.Type {
 	return si.structType
 }
 
-func (si *structInfo) typeMember(member string) (typeMember, error) {
+func (si *structInfo) TypeMember(member string) (Member, error) {
 	tm, ok := si.tagToField[member]
 	if !ok {
 		return nil, fmt.Errorf(`type %q has no %q db tag`, si.structType.Name(), member)
@@ -85,44 +45,40 @@ func (si *structInfo) typeMember(member string) (typeMember, error) {
 	return tm, nil
 }
 
-func (si *structInfo) getAllMembers() ([]typeMember, error) {
+func (si *structInfo) GetAllMembers() ([]Member, error) {
 	if len(si.tags) == 0 {
 		return nil, fmt.Errorf(`no "db" tags found in struct %q`, si.structType.Name())
 	}
 
-	tms := []typeMember{}
+	var tms []Member
 	for _, tag := range si.tags {
 		tms = append(tms, si.tagToField[tag])
 	}
 	return tms, nil
 }
 
-var _ typeInfo = &structInfo{}
-
 type mapInfo struct {
 	mapType reflect.Type
 }
 
-func (mi *mapInfo) typ() reflect.Type {
+func (mi *mapInfo) Typ() reflect.Type {
 	return mi.mapType
 }
 
-func (mi *mapInfo) typeMember(member string) (typeMember, error) {
+func (mi *mapInfo) TypeMember(member string) (Member, error) {
 	return &mapKey{name: member, mapType: mi.mapType}, nil
 }
 
-func (mi *mapInfo) getAllMembers() ([]typeMember, error) {
+func (mi *mapInfo) GetAllMembers() ([]Member, error) {
 	return nil, fmt.Errorf(`columns must be specified for map with star`)
 }
 
-var _ typeInfo = &mapInfo{}
-
 var cacheMutex sync.RWMutex
-var cache = make(map[reflect.Type]typeInfo)
+var cache = make(map[reflect.Type]Info)
 
 // Reflect will return the typeInfo of a given type,
 // generating and caching as required.
-func getTypeInfo(value any) (typeInfo, error) {
+func GetTypeInfo(value any) (Info, error) {
 	if value == (any)(nil) {
 		return nil, fmt.Errorf("cannot reflect nil value")
 	}
@@ -150,7 +106,7 @@ func getTypeInfo(value any) (typeInfo, error) {
 
 // generate produces and returns reflection information for the input
 // reflect.Value that is specifically required for SQLair operation.
-func generateTypeInfo(t reflect.Type) (typeInfo, error) {
+func generateTypeInfo(t reflect.Type) (Info, error) {
 	switch t.Kind() {
 	case reflect.Map:
 		if t.Key().Kind() != reflect.String {
@@ -194,13 +150,9 @@ func generateTypeInfo(t reflect.Type) (typeInfo, error) {
 
 		return &info, nil
 	default:
-		return nil, fmt.Errorf("internal error: cannot obtain type information for type that is not map or struct: %s.", t)
+		return nil, fmt.Errorf("internal error: cannot obtain type information for type that is not map or struct: %s", t)
 	}
 }
-
-// This expression should be aligned with the bytes we allow in isNameByte in
-// the parser.
-var validColNameRx = regexp.MustCompile(`^([a-zA-Z_])+([a-zA-Z_0-9])*$`)
 
 // parseTag parses the input tag string and returns its
 // name and whether it contains the "omitempty" option.

--- a/internal/typeinfo/member.go
+++ b/internal/typeinfo/member.go
@@ -1,0 +1,99 @@
+package typeinfo
+
+import (
+	"database/sql"
+	"fmt"
+	"reflect"
+)
+
+var scannerInterface = reflect.TypeOf((*sql.Scanner)(nil)).Elem()
+
+// Member describes a type that is a child
+// of some other encapsulating type.
+type Member interface {
+	// OuterType returns the outer type in which this member is present.
+	OuterType() reflect.Type
+
+	// MemberName returns this member's name.
+	MemberName() string
+
+	// ValueForOuter returns the value represented by this
+	// type member within the input outer value.
+	ValueForOuter(reflect.Value) (reflect.Value, error)
+
+	AddScanTarget(reflect.Value, []any, []ScanProxy) ([]any, []ScanProxy, error)
+}
+
+type mapKey struct {
+	name    string
+	mapType reflect.Type
+}
+
+func (mk *mapKey) OuterType() reflect.Type {
+	return mk.mapType
+}
+
+func (mk *mapKey) MemberName() string {
+	return mk.name
+}
+
+func (mk *mapKey) ValueForOuter(v reflect.Value) (reflect.Value, error) {
+	val := v.MapIndex(reflect.ValueOf(mk.name))
+	if val.Kind() == reflect.Invalid {
+		return val, fmt.Errorf("map %q does not contain key %q", mk.OuterType().Name(), mk.name)
+	}
+	return val, nil
+}
+
+func (mk *mapKey) AddScanTarget(outVal reflect.Value, ptrs []any, proxies []ScanProxy) ([]any, []ScanProxy, error) {
+	scanVal := reflect.New(mk.mapType.Elem()).Elem()
+	return append(ptrs, scanVal.Addr().Interface()),
+		append(proxies, ScanProxy{original: outVal, scan: scanVal, key: reflect.ValueOf(mk.name)}), nil
+}
+
+// structField represents reflection information about a field from some struct type.
+type structField struct {
+	name string
+
+	// The type of the containing struct.
+	structType reflect.Type
+
+	// Index for Type.Field.
+	index int
+
+	// The tag associated with this field
+	tag string
+
+	// OmitEmpty is true when "omitempty" is
+	// a property of the field's "db" tag.
+	omitEmpty bool
+}
+
+func (f *structField) OuterType() reflect.Type {
+	return f.structType
+}
+
+func (f *structField) MemberName() string {
+	return f.tag
+}
+
+func (f *structField) ValueForOuter(v reflect.Value) (reflect.Value, error) {
+	return v.Field(f.index), nil
+}
+
+func (f *structField) AddScanTarget(outVal reflect.Value, ptrs []any, proxies []ScanProxy) ([]any, []ScanProxy, error) {
+	val := outVal.Field(f.index)
+	if !val.CanSet() {
+		return nil, nil, fmt.Errorf("internal error: cannot set field %s of struct %s", f.name, f.structType.Name())
+	}
+
+	pt := reflect.PointerTo(val.Type())
+	if val.Type().Kind() != reflect.Pointer && !pt.Implements(scannerInterface) {
+		// Rows.Scan will return an error if it tries to scan NULL into a type that cannot be set to nil.
+		// For types that are not a pointer and do not implement sql.Scanner a pointer to them is generated
+		// and passed to Rows.Scan. If Scan has set this pointer to nil the value is zeroed.
+		scanVal := reflect.New(pt).Elem()
+		return append(ptrs, scanVal.Addr().Interface()), append(proxies, ScanProxy{original: val, scan: scanVal}), nil
+	}
+	return append(ptrs, val.Addr().Interface()), proxies, nil
+}

--- a/internal/typeinfo/scan.go
+++ b/internal/typeinfo/scan.go
@@ -1,0 +1,25 @@
+package typeinfo
+
+import "reflect"
+
+// ScanProxy is a shim for scanning query results
+// into types for which we have information.
+type ScanProxy struct {
+	original reflect.Value
+	scan     reflect.Value
+	key      reflect.Value
+}
+
+func (sp ScanProxy) OnSuccess() {
+	if sp.key.IsValid() {
+		sp.original.SetMapIndex(sp.key, sp.scan)
+	} else {
+		var val reflect.Value
+		if !sp.scan.IsNil() {
+			val = sp.scan.Elem()
+		} else {
+			val = reflect.Zero(sp.original.Type())
+		}
+		sp.original.Set(val)
+	}
+}

--- a/internal/typeinfo/scan.go
+++ b/internal/typeinfo/scan.go
@@ -3,13 +3,24 @@ package typeinfo
 import "reflect"
 
 // ScanProxy is a shim for scanning query results
-// into types for which we have information.
+// into struct fields or map keys.
 type ScanProxy struct {
+	// original is the reflected value of a map or struct field
+	// into which we want to scan SQL query results.
 	original reflect.Value
-	scan     reflect.Value
-	key      reflect.Value
+
+	// scan is the reflected value that we populated by rows.Scan
+	scan reflect.Value
+
+	// key when valid indicates that this proxy is
+	// for a key in the map indicated by original.
+	key reflect.Value
 }
 
+// OnSuccess is run after using rows.Scan to read a single query column
+// return into the variable referenced by the scan member.
+// When the ScanProxy is for a map key, we set the map's value for the key.
+// When the proxy is for a struct field, we set that field.
 func (sp ScanProxy) OnSuccess() {
 	if sp.key.IsValid() {
 		sp.original.SetMapIndex(sp.key, sp.scan)


### PR DESCRIPTION
SQLair has an `internal` package, but under that a single `expr` package into which everything is lumped. 

This has allowed accretion of logic with no clear delineation of concerns, lack of encapsulation, no principle of least knowledge et al.

Here we create a new package `typeinfo` into which logic around reflection and type information is relocated. In particular:
- The exposed API surface of this logic is now apparent.
- `typeinfo.Member` (previously `typeMember`) implementations assume responsibility for returning their corresponding values within parents, and for generating scan targets. This fixes query and prepare logic so that we can rely on the indirection and eschew type switching, which violates responsibility bounds.

