### PR TITLE
Colocate methods with type definitions

### DIFF
--- a/internal/expr/bindinputs.go
+++ b/internal/expr/bindinputs.go
@@ -1,0 +1,110 @@
+package expr
+
+import (
+	"database/sql"
+	"fmt"
+	"reflect"
+	"strconv"
+	"strings"
+
+	"github.com/canonical/sqlair/internal/typeinfo"
+)
+
+// TypedExpr represents a SQLair query bound to concrete Go types. It contains
+// all the type information needed by SQLair.
+type TypedExpr struct {
+	outputs []typeinfo.Member
+	inputs  []typeinfo.Member
+	sql     string
+}
+
+// SQL returns the SQL ready for execution.
+func (te *TypedExpr) SQL() string {
+	return te.sql
+}
+
+const markerPrefix = "_sqlair_"
+
+func markerName(n int) string {
+	return markerPrefix + strconv.Itoa(n)
+}
+
+// markerIndex returns the int X from the string "_sqlair_X".
+func markerIndex(s string) (int, bool) {
+	if strings.HasPrefix(s, markerPrefix) {
+		n, err := strconv.Atoi(s[len(markerPrefix):])
+		if err == nil {
+			return n, true
+		}
+	}
+	return 0, false
+}
+
+func typeMissingError(missingType string, existingTypes []string) error {
+	if len(existingTypes) == 0 {
+		return fmt.Errorf(`parameter with type %q missing`, missingType)
+	}
+	// "%s" is used instead of %q to correctly print double quotes within the joined string.
+	return fmt.Errorf(`parameter with type %q missing (have "%s")`, missingType, strings.Join(existingTypes, `", "`))
+}
+
+// BindInputs takes the SQLair input arguments and returns the PrimedQuery ready
+// for use with the database.
+func (te *TypedExpr) BindInputs(args ...any) (pq *PrimedQuery, err error) {
+	defer func() {
+		if err != nil {
+			err = fmt.Errorf("invalid input parameter: %s", err)
+		}
+	}()
+
+	var inQuery = make(map[reflect.Type]bool)
+	for _, typeMember := range te.inputs {
+		inQuery[typeMember.OuterType()] = true
+	}
+
+	var typeValue = make(map[reflect.Type]reflect.Value)
+	var typeNames []string
+	for _, arg := range args {
+		v := reflect.ValueOf(arg)
+		if v.Kind() == reflect.Invalid || (v.Kind() == reflect.Pointer && v.IsNil()) {
+			return nil, fmt.Errorf("need struct or map, got nil")
+		}
+		v = reflect.Indirect(v)
+		t := v.Type()
+		if v.Kind() != reflect.Struct && v.Kind() != reflect.Map {
+			return nil, fmt.Errorf("need struct or map, got %s", t.Kind())
+		}
+		if _, ok := typeValue[t]; ok {
+			return nil, fmt.Errorf("type %q provided more than once", t.Name())
+		}
+		typeValue[t] = v
+		typeNames = append(typeNames, t.Name())
+		if !inQuery[t] {
+			// Check if we have a type with the same name from a different package.
+			for _, typeMember := range te.inputs {
+				if t.Name() == typeMember.OuterType().Name() {
+					return nil, fmt.Errorf("parameter with type %q missing, have type with same name: %q", typeMember.OuterType().String(), t.String())
+				}
+			}
+			return nil, fmt.Errorf("%s not referenced in query", t.Name())
+		}
+	}
+
+	// Query parameters.
+	var params []any
+	for i, typeMember := range te.inputs {
+		outerType := typeMember.OuterType()
+		v, ok := typeValue[outerType]
+		if !ok {
+			return nil, typeMissingError(outerType.Name(), typeNames)
+		}
+
+		val, err := typeMember.ValueFromOuter(v)
+		if err != nil {
+			return nil, err
+		}
+
+		params = append(params, sql.Named("sqlair_"+strconv.Itoa(i), val.Interface()))
+	}
+	return &PrimedQuery{outputs: te.outputs, sql: te.sql, params: params}, nil
+}

--- a/internal/expr/bindinputs.go
+++ b/internal/expr/bindinputs.go
@@ -23,31 +23,6 @@ func (te *TypedExpr) SQL() string {
 	return te.sql
 }
 
-const markerPrefix = "_sqlair_"
-
-func markerName(n int) string {
-	return markerPrefix + strconv.Itoa(n)
-}
-
-// markerIndex returns the int X from the string "_sqlair_X".
-func markerIndex(s string) (int, bool) {
-	if strings.HasPrefix(s, markerPrefix) {
-		n, err := strconv.Atoi(s[len(markerPrefix):])
-		if err == nil {
-			return n, true
-		}
-	}
-	return 0, false
-}
-
-func typeMissingError(missingType string, existingTypes []string) error {
-	if len(existingTypes) == 0 {
-		return fmt.Errorf(`parameter with type %q missing`, missingType)
-	}
-	// "%s" is used instead of %q to correctly print double quotes within the joined string.
-	return fmt.Errorf(`parameter with type %q missing (have "%s")`, missingType, strings.Join(existingTypes, `", "`))
-}
-
 // BindInputs takes the SQLair input arguments and returns the PrimedQuery ready
 // for use with the database.
 func (te *TypedExpr) BindInputs(args ...any) (pq *PrimedQuery, err error) {
@@ -107,4 +82,21 @@ func (te *TypedExpr) BindInputs(args ...any) (pq *PrimedQuery, err error) {
 		params = append(params, sql.Named("sqlair_"+strconv.Itoa(i), val.Interface()))
 	}
 	return &PrimedQuery{outputs: te.outputs, sql: te.sql, params: params}, nil
+}
+
+const markerPrefix = "_sqlair_"
+
+func markerName(n int) string {
+	return markerPrefix + strconv.Itoa(n)
+}
+
+// markerIndex returns the int X from the string "_sqlair_X".
+func markerIndex(s string) (int, bool) {
+	if strings.HasPrefix(s, markerPrefix) {
+		n, err := strconv.Atoi(s[len(markerPrefix):])
+		if err == nil {
+			return n, true
+		}
+	}
+	return 0, false
 }

--- a/internal/expr/bindtypes.go
+++ b/internal/expr/bindtypes.go
@@ -2,105 +2,33 @@ package expr
 
 import (
 	"bytes"
-	"database/sql"
 	"fmt"
 	"reflect"
 	"sort"
 	"strconv"
-	"strings"
 
 	"github.com/canonical/sqlair/internal/typeinfo"
 )
 
-// TypedExpr represents a SQLair query bound to concrete Go types. It contains
-// all the type information needed by SQLair.
-type TypedExpr struct {
-	outputs []typeinfo.Member
-	inputs  []typeinfo.Member
-	sql     string
+// ParsedExpr is the AST representation of SQLair query. It contains only
+// information encoded in the SQLair query string.
+type ParsedExpr struct {
+	exprs []expression
 }
 
-// SQL returns the SQL ready for execution.
-func (te *TypedExpr) SQL() string {
-	return te.sql
-}
-
-// BindInputs takes the SQLair input arguments and returns the PrimedQuery ready
-// for use with the database.
-func (te *TypedExpr) BindInputs(args ...any) (pq *PrimedQuery, err error) {
-	defer func() {
-		if err != nil {
-			err = fmt.Errorf("invalid input parameter: %s", err)
+// String returns a textual representation of the AST contained in the
+// ParsedExpr for debugging and testing purposes.
+func (pe *ParsedExpr) String() string {
+	var out bytes.Buffer
+	out.WriteString("[")
+	for i, p := range pe.exprs {
+		if i > 0 {
+			out.WriteString(" ")
 		}
-	}()
-
-	var inQuery = make(map[reflect.Type]bool)
-	for _, typeMember := range te.inputs {
-		inQuery[typeMember.OuterType()] = true
+		out.WriteString(p.String())
 	}
-
-	var typeValue = make(map[reflect.Type]reflect.Value)
-	var typeNames []string
-	for _, arg := range args {
-		v := reflect.ValueOf(arg)
-		if v.Kind() == reflect.Invalid || (v.Kind() == reflect.Pointer && v.IsNil()) {
-			return nil, fmt.Errorf("need struct or map, got nil")
-		}
-		v = reflect.Indirect(v)
-		t := v.Type()
-		if v.Kind() != reflect.Struct && v.Kind() != reflect.Map {
-			return nil, fmt.Errorf("need struct or map, got %s", t.Kind())
-		}
-		if _, ok := typeValue[t]; ok {
-			return nil, fmt.Errorf("type %q provided more than once", t.Name())
-		}
-		typeValue[t] = v
-		typeNames = append(typeNames, t.Name())
-		if !inQuery[t] {
-			// Check if we have a type with the same name from a different package.
-			for _, typeMember := range te.inputs {
-				if t.Name() == typeMember.OuterType().Name() {
-					return nil, fmt.Errorf("parameter with type %q missing, have type with same name: %q", typeMember.OuterType().String(), t.String())
-				}
-			}
-			return nil, fmt.Errorf("%s not referenced in query", t.Name())
-		}
-	}
-
-	// Query parameters.
-	var params []any
-	for i, typeMember := range te.inputs {
-		outerType := typeMember.OuterType()
-		v, ok := typeValue[outerType]
-		if !ok {
-			return nil, typeMissingError(outerType.Name(), typeNames)
-		}
-
-		val, err := typeMember.ValueFromOuter(v)
-		if err != nil {
-			return nil, err
-		}
-
-		params = append(params, sql.Named("sqlair_"+strconv.Itoa(i), val.Interface()))
-	}
-	return &PrimedQuery{outputs: te.outputs, sql: te.sql, params: params}, nil
-}
-
-const markerPrefix = "_sqlair_"
-
-func markerName(n int) string {
-	return markerPrefix + strconv.Itoa(n)
-}
-
-// markerIndex returns the int X from the string "_sqlair_X".
-func markerIndex(s string) (int, bool) {
-	if strings.HasPrefix(s, markerPrefix) {
-		n, err := strconv.Atoi(s[len(markerPrefix):])
-		if err == nil {
-			return n, true
-		}
-	}
-	return 0, false
+	out.WriteString("]")
+	return out.String()
 }
 
 // getKeys returns the keys of a string map in a deterministic order.
@@ -135,14 +63,6 @@ func starCountTypes(vs []valueAccessor) int {
 		}
 	}
 	return s
-}
-
-func typeMissingError(missingType string, existingTypes []string) error {
-	if len(existingTypes) == 0 {
-		return fmt.Errorf(`parameter with type %q missing`, missingType)
-	}
-	// "%s" is used instead of %q to correctly print double quotes within the joined string.
-	return fmt.Errorf(`parameter with type %q missing (have "%s")`, missingType, strings.Join(existingTypes, `", "`))
 }
 
 // bindInputTypes binds the input expression to a type and returns the

--- a/internal/expr/doc.go
+++ b/internal/expr/doc.go
@@ -27,11 +27,11 @@ This stage only processes information contained in types. The query should not
 be specialised at this stage to a strict subset of well typed input arguments
 (for example, be only valid for slices arguments of length n).
 
-# Query stage
+# Input Binding and Query stage
 
-The query stage generates the concrete values needed to run the SQLair query on
-a database. This includes the SQL, the query arguments and info for scanning the
-results into SQLair output arguments.
+The Input Binding and Query stage generates the concrete values needed to run
+the SQLair query on a database. This includes the SQL, the query arguments and
+info for scanning the results into SQLair output arguments.
 
 This stage does not analyse the arguments types beyond validating they match
 those seen in the Type Binding stage. Neither does it interact with the actual

--- a/internal/expr/parser.go
+++ b/internal/expr/parser.go
@@ -1,7 +1,6 @@
 package expr
 
 import (
-	"bytes"
 	"fmt"
 	"strings"
 )
@@ -172,27 +171,6 @@ func (cp *checkpoint) restore() {
 	cp.parser.exprs = cp.exprs
 	cp.parser.lineNum = cp.lineNum
 	cp.parser.lineStart = cp.lineStart
-}
-
-// ParsedExpr is the AST representation of SQLair query. It contains only
-// information encoded in the SQLair query string.
-type ParsedExpr struct {
-	exprs []expression
-}
-
-// String returns a textual representation of the AST contained in the
-// ParsedExpr for debugging and testing purposes.
-func (pe *ParsedExpr) String() string {
-	var out bytes.Buffer
-	out.WriteString("[")
-	for i, p := range pe.exprs {
-		if i > 0 {
-			out.WriteString(" ")
-		}
-		out.WriteString(p.String())
-	}
-	out.WriteString("]")
-	return out.String()
 }
 
 // add pushes the parsed expression to the list of expressions along with the

--- a/internal/expr/parser.go
+++ b/internal/expr/parser.go
@@ -5,6 +5,69 @@ import (
 	"strings"
 )
 
+func NewParser() *Parser {
+	return &Parser{}
+}
+
+type Parser struct {
+	input string
+	pos   int
+	// prevExprEnd is the value of pos when we last finished parsing a
+	// expression.
+	prevExprEnd int
+	// currentExprStart is the value of pos just before we started parsing the
+	// expression under pos. We maintain currentExprStart >= prevExprEnd.
+	currentExprStart int
+	exprs            []expression
+	// lineNum is the number of the current line of the input.
+	lineNum int
+	// lineStart is the position of the first byte of the current line in the
+	// input.
+	lineStart int
+}
+
+// Parse takes an SQLair query string and returns a ParsedExpr.
+func (p *Parser) Parse(input string) (pe *ParsedExpr, err error) {
+	defer func() {
+		if err != nil {
+			err = fmt.Errorf("cannot parse expression: %s", err)
+		}
+	}()
+
+	p.init(input)
+
+	for {
+		// Advance the parser to the start of the next expression.
+		if err := p.advance(); err != nil {
+			return nil, err
+		}
+
+		p.currentExprStart = p.pos
+
+		if p.pos == len(p.input) {
+			break
+		}
+
+		if out, ok, err := p.parseOutputExpr(); err != nil {
+			return nil, err
+		} else if ok {
+			p.add(out)
+			continue
+		}
+
+		if in, ok, err := p.parseInputExpr(); err != nil {
+			return nil, err
+		} else if ok {
+			p.add(in)
+			continue
+		}
+	}
+
+	// Add any remaining unparsed string input to the parser.
+	p.add(nil)
+	return &ParsedExpr{exprs: p.exprs}, nil
+}
+
 // expression represents a parsed node of the SQLair query's AST.
 type expression interface {
 	// String returns a text representation for debugging and testing purposes.
@@ -75,27 +138,6 @@ func (p *bypass) String() string {
 }
 
 func (p *bypass) expr() {}
-
-type Parser struct {
-	input string
-	pos   int
-	// prevExprEnd is the value of pos when we last finished parsing a
-	// expression.
-	prevExprEnd int
-	// currentExprStart is the value of pos just before we started parsing the
-	// expression under pos. We maintain currentExprStart >= prevExprEnd.
-	currentExprStart int
-	exprs            []expression
-	// lineNum is the number of the current line of the input.
-	lineNum int
-	// lineStart is the position of the first byte of the current line in the
-	// input.
-	lineStart int
-}
-
-func NewParser() *Parser {
-	return &Parser{}
-}
 
 // init resets the state of the parser and sets the input string.
 func (p *Parser) init(input string) {
@@ -226,48 +268,6 @@ func (p *Parser) skipComment() bool {
 		return false
 	}
 	return false
-}
-
-// Parse takes an SQLair query string and returns a ParsedExpr.
-func (p *Parser) Parse(input string) (pe *ParsedExpr, err error) {
-	defer func() {
-		if err != nil {
-			err = fmt.Errorf("cannot parse expression: %s", err)
-		}
-	}()
-
-	p.init(input)
-
-	for {
-		// Advance the parser to the start of the next expression.
-		if err := p.advance(); err != nil {
-			return nil, err
-		}
-
-		p.currentExprStart = p.pos
-
-		if p.pos == len(p.input) {
-			break
-		}
-
-		if out, ok, err := p.parseOutputExpr(); err != nil {
-			return nil, err
-		} else if ok {
-			p.add(out)
-			continue
-		}
-
-		if in, ok, err := p.parseInputExpr(); err != nil {
-			return nil, err
-		} else if ok {
-			p.add(in)
-			continue
-		}
-	}
-
-	// Add any remaining unparsed string input to the parser.
-	p.add(nil)
-	return &ParsedExpr{exprs: p.exprs}, nil
 }
 
 // advance increments p.pos until it reaches content that might preceed a token


### PR DESCRIPTION
Move major types to separate files along with their methods and helper functions. Also move (internally) public methods on the types to the top of the files.

Before, the files were organised by the stage in the pipeline. This change moves the methods to be colocated with the type definitions rather than ordering them according to the pipeline.

Methods are only moved here, no code is changed. The documentation in `internal/expr/doc.go` is updated to reflect the new file names.