### PR TITLE
Seperate cache operations from SQLair logic

### DIFF
--- a/cache.go
+++ b/cache.go
@@ -1,0 +1,147 @@
+package sqlair
+
+import (
+	"context"
+	"database/sql"
+	"runtime"
+	"sync"
+	"sync/atomic"
+
+	"github.com/canonical/sqlair/internal/expr"
+)
+
+// A SQLair Statement is prepared on a database when a Query method is run on a
+// DB/TX. The prepared statement is then stored in the stmtDBCache and a flag
+// is set in dbStmtCache.
+// A finalizer function is set on the Statement when it is placed in the cache.
+// On garbage collection, the finalizer cycles through the open databases in
+// the cache and closes each matching sql.Stmt. The finalizer then removes the
+// stmtID from stmtDBCache and dbStmtCache.
+// Similarly, a finalizer is set on the SQLair DB which closes all statements
+// prepared on the DB and then the sql.DB itself. It removes the dbID from
+// dbStmtCache and stmtDBCache.
+var stmtIDCount int64
+var dbIDCount int64
+
+type dbID = int64
+type stmtID = int64
+
+// statementCache caches the sql.Stmt values assosiated with each
+// sqlair.Statement. sqlair.Statement values can correspond to multiple
+// sql.Stmt values on different databases. The cache is indexed by the
+// sqlair.Statement ID and the sqlair.DB ID.
+//
+// The mutex must be locked when accessing either the stmtDBCache or the
+// dbStmtCache.
+type statementCache struct {
+	stmtDBCache map[stmtID]map[dbID]*sql.Stmt
+	dbStmtCache map[dbID]map[stmtID]bool
+	mutex       sync.RWMutex
+}
+
+func newStatementCache() *statementCache {
+	//Once something
+	return &statementCache{
+		stmtDBCache: map[stmtID]map[dbID]*sql.Stmt{},
+		dbStmtCache: map[dbID]map[stmtID]bool{},
+	}
+}
+
+// newStatement returns a new sqlair.Statement and allocates it in the cache. A
+// finalizer is set on the sqlair.Statement to remove all sql.Stmt values
+// assosiated with it from the cache and then run Close on the sql.Stmt values.
+// The finalizer is run after the sqlair.Statment is garbage collected.
+func (sc *statementCache) newStatement(te *expr.TypedExpr) *Statement {
+	cacheID := atomic.AddInt64(&stmtIDCount, 1)
+	s := &Statement{te: te, cacheID: cacheID}
+	sc.mutex.Lock()
+	sc.stmtDBCache[cacheID] = map[dbID]*sql.Stmt{}
+	sc.mutex.Unlock()
+	runtime.SetFinalizer(s, sc.getStmtFinalizer(s))
+	return s
+}
+
+// newDB returns a new sqlair.DB and allocates it in the cache. A finalizer is
+// set on the sqlair.DB which removes it from the cache, closes all sql.Stmt
+// values prepared upon it and then closes the DB. The finalizer is run after
+// the sqlair.DB is garbage collected.
+func (sc *statementCache) newDB(sqldb *sql.DB) *DB {
+	cacheID := atomic.AddInt64(&dbIDCount, 1)
+	sc.mutex.Lock()
+	sc.dbStmtCache[cacheID] = map[stmtID]bool{}
+	sc.mutex.Unlock()
+	db := &DB{sqldb: sqldb, cacheID: cacheID}
+	runtime.SetFinalizer(db, sc.getDBFinalizer(db))
+	return db
+}
+
+// prepareSubstrate is an object that queries can be prepared on, e.g. a sql.DB
+// or sql.Conn. It is used in prepareStmt.
+type prepareSubstrate interface {
+	PrepareContext(context.Context, string) (*sql.Stmt, error)
+}
+
+// prepareStmt prepares a Statement on a prepareSubstrate. It first checks in
+// the cache to see if it has already been prepared on the DB.
+// The prepareSubstrate must be assosiated with the same DB that prepareStmt is
+// a method of.
+func (sc *statementCache) prepareStmt(ctx context.Context, dbID dbID, ps prepareSubstrate, s *Statement) (*sql.Stmt, error) {
+	var err error
+	sc.mutex.RLock()
+	// The statement ID is only removed from the cache when the finalizer is
+	// run, so it is always in stmtDBCache.
+	sqlstmt, ok := sc.stmtDBCache[s.cacheID][dbID]
+	sc.mutex.RUnlock()
+	if !ok {
+		sqlstmt, err = ps.PrepareContext(ctx, s.te.SQL())
+		if err != nil {
+			return nil, err
+		}
+		sc.mutex.Lock()
+		// Check if a statement has been inserted by someone else since we last
+		// checked.
+		sqlstmtAlt, ok := sc.stmtDBCache[s.cacheID][dbID]
+		if ok {
+			sqlstmt.Close()
+			sqlstmt = sqlstmtAlt
+		} else {
+			sc.stmtDBCache[s.cacheID][dbID] = sqlstmt
+			sc.dbStmtCache[dbID][s.cacheID] = true
+		}
+		sc.mutex.Unlock()
+	}
+	return sqlstmt, nil
+}
+
+// getStmtFinalizer returns a finalizer that removes a Statement from the
+// statement caches and closes it.
+func (sc *statementCache) getStmtFinalizer(s *Statement) func(*Statement) {
+	return func(s *Statement) {
+		sc.mutex.Lock()
+		defer sc.mutex.Unlock()
+		dbCache := sc.stmtDBCache[s.cacheID]
+		for dbCacheID, sqlstmt := range dbCache {
+			sqlstmt.Close()
+			delete(sc.dbStmtCache[dbCacheID], s.cacheID)
+		}
+		delete(sc.stmtDBCache, s.cacheID)
+	}
+}
+
+// getDBFinalizer returns a finalizer that closes and removes from the cache
+// all sql.Stmt values prepared on the database, removes the database from then
+// cache, then closes the sql.DB.
+func (sc *statementCache) getDBFinalizer(db *DB) func(*DB) {
+	return func(db *DB) {
+		sc.mutex.Lock()
+		defer sc.mutex.Unlock()
+		statementCache := sc.dbStmtCache[db.cacheID]
+		for statementCacheID, _ := range statementCache {
+			dbCache := sc.stmtDBCache[statementCacheID]
+			dbCache[db.cacheID].Close()
+			delete(dbCache, db.cacheID)
+		}
+		delete(sc.dbStmtCache, db.cacheID)
+		db.sqldb.Close()
+	}
+}

--- a/cache.go
+++ b/cache.go
@@ -30,7 +30,8 @@ type statementCache struct {
 	// dbStmtCache indicates when a sqlair.Statement has been prepared on a particular sqlair.DB.
 	dbStmtCache map[uint64]map[uint64]bool
 
-	// stmtIDCount and dbIDCount used to generate unique cache IDs.
+	// stmtIDCount and dbIDCount are monotonically increasing counters used to
+	// generate unique new cache IDs.
 	stmtIDCount uint64
 	dbIDCount   uint64
 
@@ -93,8 +94,9 @@ func (sc *statementCache) prepareStmt(ctx context.Context, dbID uint64, ps prepa
 	var err error
 	sc.mutex.RLock()
 	// The Statement cache ID is only removed from stmtDBCache when the
-	// finalizer is run. The cache ID must be present as we have a reference to
-	// the Statement.
+	// finalizer is run. The Statements cache ID must be in the stmtDBCache
+	// since we hold a reference to the Statement. It is therefore safe to
+	// access in it in the map without first checking it exists.
 	sqlstmt, ok := sc.stmtDBCache[s.cacheID][dbID]
 	sc.mutex.RUnlock()
 	if !ok {

--- a/export_test.go
+++ b/export_test.go
@@ -5,14 +5,14 @@ import (
 	"sync"
 )
 
-func (s *Statement) CacheID() int64 {
+func (s *Statement) CacheID() uint64 {
 	return s.cacheID
 }
 
-func (db *DB) CacheID() int64 {
+func (db *DB) CacheID() uint64 {
 	return db.cacheID
 }
 
-func Cache() (map[int64]map[int64]*sql.Stmt, map[int64]map[int64]bool, *sync.RWMutex) {
+func Cache() (map[uint64]map[uint64]*sql.Stmt, map[uint64]map[uint64]bool, *sync.RWMutex) {
 	return stmtCache.stmtDBCache, stmtCache.dbStmtCache, &stmtCache.mutex
 }

--- a/export_test.go
+++ b/export_test.go
@@ -14,5 +14,5 @@ func (db *DB) CacheID() int64 {
 }
 
 func Cache() (map[int64]map[int64]*sql.Stmt, map[int64]map[int64]bool, *sync.RWMutex) {
-	return stmtDBCache, dbStmtCache, &cacheMutex
+	return stmtCache.stmtDBCache, stmtCache.dbStmtCache, &stmtCache.mutex
 }

--- a/package_test.go
+++ b/package_test.go
@@ -1079,7 +1079,7 @@ func (s *PackageSuite) TestPreparedStmtCaching(c *C) {
 
 	// checkStmtCache is a helper function to check if a prepared statement is
 	// cached or not.
-	checkStmtCache := func(dbID int64, sID int64, inCache bool) {
+	checkStmtCache := func(dbID uint64, sID uint64, inCache bool) {
 		cacheMutex.RLock()
 		defer cacheMutex.RUnlock()
 		dbCache, ok1 := stmtDBCache[sID]
@@ -1094,7 +1094,7 @@ func (s *PackageSuite) TestPreparedStmtCaching(c *C) {
 
 	// checkDBNotInCache is a helper function to check a db is not mentioned in
 	// the cache.
-	checkDBNotInCache := func(dbID int64) {
+	checkDBNotInCache := func(dbID uint64) {
 		cacheMutex.RLock()
 		defer cacheMutex.RUnlock()
 		for _, dbCache := range stmtDBCache {
@@ -1122,7 +1122,7 @@ func (s *PackageSuite) TestPreparedStmtCaching(c *C) {
 	p := Person{}
 
 	// createAndCacheStmt takes a db and prepares a statement on it.
-	createAndCacheStmt := func(db *sqlair.DB) (stmtID int64) {
+	createAndCacheStmt := func(db *sqlair.DB) (stmtID uint64) {
 		// Create stmt.
 		stmt, err := sqlair.Prepare(q1, Person{})
 		c.Assert(err, IsNil)
@@ -1153,7 +1153,7 @@ func (s *PackageSuite) TestPreparedStmtCaching(c *C) {
 	}
 
 	// createDBAndTestStmt opens a new database and runs testStmtsOnDB on it.
-	createDBAndTestStmt := func(stmt *sqlair.Statement) (dbID int64) {
+	createDBAndTestStmt := func(stmt *sqlair.Statement) (dbID uint64) {
 		// Create db.
 		tables, sqldb, err := personAndAddressDB(c)
 		c.Assert(err, IsNil)

--- a/sqlair.go
+++ b/sqlair.go
@@ -29,7 +29,7 @@ var stmtCache = newStatementCache()
 // Statement represents a SQL statement with valid SQLair expressions.
 // It is ready to be run on a SQLair DB.
 type Statement struct {
-	cacheID stmtID
+	cacheID uint64
 	// te is the type bound SQLair query. It contains information used to
 	// generate query values from the input arguments when the Statement is run
 	// on a database.
@@ -65,7 +65,7 @@ func MustPrepare(query string, typeSamples ...any) *Statement {
 }
 
 type DB struct {
-	cacheID dbID
+	cacheID uint64
 	sqldb   *sql.DB
 }
 

--- a/sqlair.go
+++ b/sqlair.go
@@ -51,7 +51,7 @@ func Prepare(query string, typeSamples ...any) (*Statement, error) {
 		return nil, err
 	}
 
-	s := stmtCache.newStmt(typedExpr)
+	s := stmtCache.newStatement(typedExpr)
 	return s, nil
 }
 


### PR DESCRIPTION
Move the cache to a separate file and move operations on it to functions. The cache remains in the `sqlair` rather than being moved to a separate package because it needs access to the types in `sqlair` to set finalizers on new instantiations of them.

The singleton pattern is used in `newStmtCache` to allow only a single copy of the cache to be created. 