### PR TITLE
Redistribute Type Bind responsibility 

### DIFF
--- a/cache.go
+++ b/cache.go
@@ -54,7 +54,7 @@ func newStatementCache() *statementCache {
 // newStatement returns a new sqlair.Statement and adds it to the cache. A
 // finalizer is set on the sqlair.Statement to remove its ID from the cache and
 // close all associated sql.Stmt objects.
-func (sc *statementCache) newStatement(te *expr.TypedExpr) *Statement {
+func (sc *statementCache) newStatement(te *expr.TypeBoundExpr) *Statement {
 	cacheID := atomic.AddUint64(&sc.stmtIDCount, 1)
 	sc.mutex.Lock()
 	sc.stmtDBCache[cacheID] = map[uint64]*sql.Stmt{}

--- a/internal/expr/bindinputs.go
+++ b/internal/expr/bindinputs.go
@@ -76,8 +76,6 @@ func (tbe *TypeBoundExpr) BindInputs(args ...any) (pq *PrimedQuery, err error) {
 			}
 		case *bypass:
 			sqlStr.WriteString(te.chunk)
-		default:
-			return nil, fmt.Errorf("internal error: unknown type %T", te)
 		}
 	}
 

--- a/internal/expr/bindinputs.go
+++ b/internal/expr/bindinputs.go
@@ -1,6 +1,7 @@
 package expr
 
 import (
+	"bytes"
 	"database/sql"
 	"fmt"
 	"reflect"
@@ -10,32 +11,19 @@ import (
 	"github.com/canonical/sqlair/internal/typeinfo"
 )
 
-// TypedExpr represents a SQLair query bound to concrete Go types. It contains
-// all the type information needed by SQLair.
-type TypedExpr struct {
-	outputs []typeinfo.Output
-	inputs  []typeinfo.Input
-	sql     string
-}
-
-// SQL returns the SQL ready for execution.
-func (te *TypedExpr) SQL() string {
-	return te.sql
-}
+// TypeBoundExpr represents a SQLair statement bound to concrete Go types. It
+// contains information used to generate the underlying SQL query and map it to
+// the SQLair query.
+type TypeBoundExpr []typedExpression
 
 // BindInputs takes the SQLair input arguments and returns the PrimedQuery ready
 // for use with the database.
-func (te *TypedExpr) BindInputs(args ...any) (pq *PrimedQuery, err error) {
+func (tbe *TypeBoundExpr) BindInputs(args ...any) (pq *PrimedQuery, err error) {
 	defer func() {
 		if err != nil {
 			err = fmt.Errorf("invalid input parameter: %s", err)
 		}
 	}()
-
-	inQuery := map[reflect.Type]bool{}
-	for _, input := range te.inputs {
-		inQuery[input.ArgType()] = true
-	}
 
 	typeToValue := map[reflect.Type]reflect.Value{}
 	for _, arg := range args {
@@ -52,32 +40,107 @@ func (te *TypedExpr) BindInputs(args ...any) (pq *PrimedQuery, err error) {
 			return nil, fmt.Errorf("type %q provided more than once", t.Name())
 		}
 		typeToValue[t] = v
-		if !inQuery[t] {
-			// Check if we have a type with the same name from a different package.
-			for _, input := range te.inputs {
-				if t.Name() == input.ArgType().Name() {
-					return nil, fmt.Errorf("parameter with type %q missing, have type with same name: %q", input.ArgType().String(), t.String())
-				}
+	}
+
+	// Generate SQL and query parameters.
+	params := []any{}
+	outputs := []typeinfo.Output{}
+	// argTypeUsed is used to check that all the query parameters are
+	// referenced in the query.
+	argTypeUsed := map[reflect.Type]bool{}
+	inputCount := 0
+	outputCount := 0
+	sqlStr := bytes.Buffer{}
+	for _, te := range *tbe {
+		switch te := te.(type) {
+		case *typedInputExpr:
+			vals, err := te.input.LocateParams(typeToValue)
+			if err != nil {
+				return nil, err
 			}
-			return nil, fmt.Errorf("%s not referenced in query", t.Name())
+			argTypeUsed[te.input.ArgType()] = true
+			for _, val := range vals {
+				namedInput := sql.Named("sqlair_"+strconv.Itoa(inputCount), val.Interface())
+				params = append(params, namedInput)
+				sqlStr.WriteString("@sqlair_" + strconv.Itoa(inputCount))
+				inputCount++
+			}
+		case *typedOutputExpr:
+			for i, oc := range te.outputColumns {
+				sqlStr.WriteString(oc.sql(outputCount))
+				if i != len(te.outputColumns)-1 {
+					sqlStr.WriteString(", ")
+				}
+				outputCount++
+				outputs = append(outputs, oc.output)
+			}
+		case *bypass:
+			sqlStr.WriteString(te.chunk)
 		}
 	}
 
-	// Query parameters.
-	var params []any
-	inputCount := 0
-	for _, input := range te.inputs {
-		vals, err := input.LocateParams(typeToValue)
-		if err != nil {
-			return nil, err
-		}
-		for _, val := range vals {
-			params = append(params, sql.Named("sqlair_"+strconv.Itoa(inputCount), val.Interface()))
-			inputCount++
+	for argType := range typeToValue {
+		if !argTypeUsed[argType] {
+			return nil, fmt.Errorf("%s not referenced in query", argType.Name())
 		}
 	}
-	return &PrimedQuery{outputs: te.outputs, sql: te.sql, params: params}, nil
+
+	return &PrimedQuery{outputs: outputs, sql: sqlStr.String(), params: params}, nil
 }
+
+// typedExpression represents a expression with the type names bound to Go
+// types.
+type typedExpression interface {
+	// typedExpr is a marker method.
+	typedExpr()
+}
+
+// outputColumn stores the name of a column to fetch from the database and the
+// output type location specifying the value to scan the result into.
+type outputColumn struct {
+	output typeinfo.Output
+	column string
+}
+
+// sql generates the SQL for a single output column.
+func (oc *outputColumn) sql(outputCount int) string {
+	return oc.column + " AS " + markerName(outputCount)
+}
+
+// newOutputColumn generates an output column with the correct column string to
+// write in the generated query.
+func newOutputColumn(tableName string, columnName string, output typeinfo.Output) outputColumn {
+	if tableName == "" {
+		return outputColumn{column: columnName, output: output}
+	}
+	return outputColumn{column: tableName + "." + columnName, output: output}
+}
+
+// typedInputExpr stores information about a Go value to use as a query input.
+type typedInputExpr struct {
+	input typeinfo.Input
+}
+
+// typedExpr is a marker method.
+func (*typedInputExpr) typedExpr() {}
+
+var _ typedExpression = (*typedInputExpr)(nil)
+
+// typedOutputExpr contains the columns to fetch from the database and
+// information about the Go values to read the query results into.
+type typedOutputExpr struct {
+	outputColumns []outputColumn
+}
+
+// typedExpr is a marker method.
+func (*typedOutputExpr) typedExpr() {}
+
+var _ typedExpression = (*typedOutputExpr)(nil)
+
+// typedExpr is a marker method.
+func (*bypass) typedExpr() {}
+
+var _ typedExpression = (*bypass)(nil)
 
 const markerPrefix = "_sqlair_"
 

--- a/internal/expr/bindinputs.go
+++ b/internal/expr/bindinputs.go
@@ -76,6 +76,8 @@ func (tbe *TypeBoundExpr) BindInputs(args ...any) (pq *PrimedQuery, err error) {
 			}
 		case *bypass:
 			sqlStr.WriteString(te.chunk)
+		default:
+			return nil, fmt.Errorf("internal error: unknown type %T", te)
 		}
 	}
 

--- a/internal/expr/bindinputs.go
+++ b/internal/expr/bindinputs.go
@@ -43,8 +43,8 @@ func (tbe *TypeBoundExpr) BindInputs(args ...any) (pq *PrimedQuery, err error) {
 	}
 
 	// Generate SQL and query parameters.
-	params := []any{}
-	outputs := []typeinfo.Output{}
+	var params []any
+	var outputs []typeinfo.Output
 	// argTypeUsed is used to check that all the query parameters are
 	// referenced in the query.
 	argTypeUsed := map[reflect.Type]bool{}

--- a/internal/expr/bindinputs.go
+++ b/internal/expr/bindinputs.go
@@ -14,7 +14,7 @@ import (
 // TypeBoundExpr represents a SQLair statement bound to concrete Go types. It
 // contains information used to generate the underlying SQL query and map it to
 // the SQLair query.
-type TypeBoundExpr []typedExpression
+type TypeBoundExpr []any
 
 // BindInputs takes the SQLair input arguments and returns the PrimedQuery ready
 // for use with the database.
@@ -88,13 +88,6 @@ func (tbe *TypeBoundExpr) BindInputs(args ...any) (pq *PrimedQuery, err error) {
 	return &PrimedQuery{outputs: outputs, sql: sqlStr.String(), params: params}, nil
 }
 
-// typedExpression represents a expression with the type names bound to Go
-// types.
-type typedExpression interface {
-	// typedExpr is a marker method.
-	typedExpr()
-}
-
 // outputColumn stores the name of a column to fetch from the database and the
 // output type location specifying the value to scan the result into.
 type outputColumn struct {
@@ -121,26 +114,11 @@ type typedInputExpr struct {
 	input typeinfo.Input
 }
 
-// typedExpr is a marker method.
-func (*typedInputExpr) typedExpr() {}
-
-var _ typedExpression = (*typedInputExpr)(nil)
-
 // typedOutputExpr contains the columns to fetch from the database and
 // information about the Go values to read the query results into.
 type typedOutputExpr struct {
 	outputColumns []outputColumn
 }
-
-// typedExpr is a marker method.
-func (*typedOutputExpr) typedExpr() {}
-
-var _ typedExpression = (*typedOutputExpr)(nil)
-
-// typedExpr is a marker method.
-func (*bypass) typedExpr() {}
-
-var _ typedExpression = (*bypass)(nil)
 
 const markerPrefix = "_sqlair_"
 

--- a/internal/expr/bindinputs.go
+++ b/internal/expr/bindinputs.go
@@ -14,7 +14,7 @@ import (
 // TypeBoundExpr represents a SQLair statement bound to concrete Go types. It
 // contains information used to generate the underlying SQL query and map it to
 // the SQLair query.
-type TypeBoundExpr []typedExpression
+type TypeBoundExpr []any
 
 // BindInputs takes the SQLair input arguments and returns the PrimedQuery ready
 // for use with the database.
@@ -76,6 +76,8 @@ func (tbe *TypeBoundExpr) BindInputs(args ...any) (pq *PrimedQuery, err error) {
 			}
 		case *bypass:
 			sqlStr.WriteString(te.chunk)
+		default:
+			return nil, fmt.Errorf("invalid expression type %t", te)
 		}
 	}
 
@@ -86,13 +88,6 @@ func (tbe *TypeBoundExpr) BindInputs(args ...any) (pq *PrimedQuery, err error) {
 	}
 
 	return &PrimedQuery{outputs: outputs, sql: sqlStr.String(), params: params}, nil
-}
-
-// typedExpression represents a expression with the type names bound to Go
-// types.
-type typedExpression interface {
-	// typedExpr is a marker method.
-	typedExpr()
 }
 
 // outputColumn stores the name of a column to fetch from the database and the
@@ -121,26 +116,11 @@ type typedInputExpr struct {
 	input typeinfo.Input
 }
 
-// typedExpr is a marker method.
-func (*typedInputExpr) typedExpr() {}
-
-var _ typedExpression = (*typedInputExpr)(nil)
-
 // typedOutputExpr contains the columns to fetch from the database and
 // information about the Go values to read the query results into.
 type typedOutputExpr struct {
 	outputColumns []outputColumn
 }
-
-// typedExpr is a marker method.
-func (*typedOutputExpr) typedExpr() {}
-
-var _ typedExpression = (*typedOutputExpr)(nil)
-
-// typedExpr is a marker method.
-func (*bypass) typedExpr() {}
-
-var _ typedExpression = (*bypass)(nil)
 
 const markerPrefix = "_sqlair_"
 

--- a/internal/expr/bindinputs.go
+++ b/internal/expr/bindinputs.go
@@ -77,7 +77,7 @@ func (tbe *TypeBoundExpr) BindInputs(args ...any) (pq *PrimedQuery, err error) {
 		case *bypass:
 			sqlStr.WriteString(te.chunk)
 		default:
-			return nil, fmt.Errorf("invalid expression type %t", te)
+			return nil, fmt.Errorf("internal error: unknown expression type %T", te)
 		}
 	}
 

--- a/internal/expr/bindinputs.go
+++ b/internal/expr/bindinputs.go
@@ -14,7 +14,7 @@ import (
 // TypeBoundExpr represents a SQLair statement bound to concrete Go types. It
 // contains information used to generate the underlying SQL query and map it to
 // the SQLair query.
-type TypeBoundExpr []any
+type TypeBoundExpr []typedExpression
 
 // BindInputs takes the SQLair input arguments and returns the PrimedQuery ready
 // for use with the database.
@@ -90,6 +90,13 @@ func (tbe *TypeBoundExpr) BindInputs(args ...any) (pq *PrimedQuery, err error) {
 	return &PrimedQuery{outputs: outputs, sql: sqlStr.String(), params: params}, nil
 }
 
+// typedExpression represents a expression with the type names bound to Go
+// types.
+type typedExpression interface {
+	// typedExpr is a marker method.
+	typedExpr()
+}
+
 // outputColumn stores the name of a column to fetch from the database and the
 // output type location specifying the value to scan the result into.
 type outputColumn struct {
@@ -116,11 +123,26 @@ type typedInputExpr struct {
 	input typeinfo.Input
 }
 
+// typedExpr is a marker method.
+func (*typedInputExpr) typedExpr() {}
+
+var _ typedExpression = (*typedInputExpr)(nil)
+
 // typedOutputExpr contains the columns to fetch from the database and
 // information about the Go values to read the query results into.
 type typedOutputExpr struct {
 	outputColumns []outputColumn
 }
+
+// typedExpr is a marker method.
+func (*typedOutputExpr) typedExpr() {}
+
+var _ typedExpression = (*typedOutputExpr)(nil)
+
+// typedExpr is a marker method.
+func (*bypass) typedExpr() {}
+
+var _ typedExpression = (*bypass)(nil)
 
 const markerPrefix = "_sqlair_"
 

--- a/internal/expr/bindtypes.go
+++ b/internal/expr/bindtypes.go
@@ -44,9 +44,9 @@ func (pe *ParsedExpr) BindTypes(args ...any) (tbe *TypeBoundExpr, err error) {
 	}
 
 	// Bind types to each expression.
-	typedExprs := []typedExpression{}
+	var typedExprs TypeBoundExpr
 	outputUsed := map[typeinfo.Output]bool{}
-	var te typedExpression
+	var te any
 	for _, expr := range pe.exprs {
 		switch e := expr.(type) {
 		case *inputExpr:
@@ -75,8 +75,7 @@ func (pe *ParsedExpr) BindTypes(args ...any) (tbe *TypeBoundExpr, err error) {
 		typedExprs = append(typedExprs, te)
 	}
 
-	typedExpr := TypeBoundExpr(typedExprs)
-	return &typedExpr, nil
+	return &typedExprs, nil
 }
 
 // bindInputTypes binds the input expression to a query type and returns a typed

--- a/internal/expr/bindtypes.go
+++ b/internal/expr/bindtypes.go
@@ -44,44 +44,52 @@ func (pe *ParsedExpr) BindTypes(args ...any) (tbe *TypeBoundExpr, err error) {
 	}
 
 	// Bind types to each expression.
-	typedExprs := []typedExpression{}
+	typedExprs := []any{}
 	outputUsed := map[typeinfo.Output]bool{}
-	var te typedExpression
+	var typedExpr any
 	for _, expr := range pe.exprs {
-		switch e := expr.(type) {
-		case *inputExpr:
-			te, err = bindInputTypes(e, argInfo)
-			if err != nil {
-				return nil, err
-			}
-		case *outputExpr:
-			toe, err := bindOutputTypes(e, argInfo)
-			if err != nil {
-				return nil, err
-			}
-
+		typedExpr, err = expr.bindTypes(argInfo)
+		if err != nil {
+			return nil, err
+		}
+		if toe, ok := typedExpr.(*typedOutputExpr); ok {
 			for _, oc := range toe.outputColumns {
 				if ok := outputUsed[oc.output]; ok {
 					return nil, fmt.Errorf("%s appears more than once in output expressions", oc.output.String())
 				}
 				outputUsed[oc.output] = true
 			}
-			te = toe
-		case *bypass:
-			te = e
-		default:
-			return nil, fmt.Errorf("internal error: unknown query expr type %T", expr)
 		}
-		typedExprs = append(typedExprs, te)
+		typedExprs = append(typedExprs, typedExpr)
 	}
 
-	typedExpr := TypeBoundExpr(typedExprs)
-	return &typedExpr, nil
+	typeBoundExpr := TypeBoundExpr(typedExprs)
+	return &typeBoundExpr, nil
 }
 
-// bindInputTypes binds the input expression to a query type and returns a typed
+// expression represents a parsed node of the SQLair query's AST.
+type expression interface {
+	// String returns a text representation for debugging and testing purposes.
+	String() string
+
+	// bindTypes generates a typed expression from the query argument type information.
+	bindTypes(typeinfo.ArgInfo) (any, error)
+}
+
+// inputExpr represents a named parameter that will be sent to the database
+// while performing the query.
+type inputExpr struct {
+	sourceType valueAccessor
+	raw        string
+}
+
+func (p *inputExpr) String() string {
+	return fmt.Sprintf("Input[%+v]", p.sourceType)
+}
+
+// bindTypes binds the input expression to a query type and returns a typed
 // input expression.
-func bindInputTypes(e *inputExpr, argInfo typeinfo.ArgInfo) (te *typedInputExpr, err error) {
+func (e *inputExpr) bindTypes(argInfo typeinfo.ArgInfo) (typedExpr any, err error) {
 	defer func() {
 		if err != nil {
 			err = fmt.Errorf("input expression: %s: %s", err, e.raw)
@@ -95,10 +103,22 @@ func bindInputTypes(e *inputExpr, argInfo typeinfo.ArgInfo) (te *typedInputExpr,
 	return &typedInputExpr{input}, nil
 }
 
-// bindOutputTypes binds the output expression to concrete types. It then checks the
-// expression valid with respect to its bound types and generates a typed output
-// expression.
-func bindOutputTypes(e *outputExpr, argInfo typeinfo.ArgInfo) (te *typedOutputExpr, err error) {
+// outputExpr represents a named target output variable in the SQL expression,
+// as well as the source table and column where it will be read from.
+type outputExpr struct {
+	sourceColumns []columnAccessor
+	targetTypes   []valueAccessor
+	raw           string
+}
+
+func (p *outputExpr) String() string {
+	return fmt.Sprintf("Output[%+v %+v]", p.sourceColumns, p.targetTypes)
+}
+
+// bindTypes binds the output expression to concrete types. It then checks the
+// expression valid with respect to its bound types and generates a typed
+// output expression.
+func (e *outputExpr) bindTypes(argInfo typeinfo.ArgInfo) (typedExpr any, err error) {
 	defer func() {
 		if err != nil {
 			err = fmt.Errorf("output expression: %s: %s", err, e.raw)
@@ -177,6 +197,22 @@ func bindOutputTypes(e *outputExpr, argInfo typeinfo.ArgInfo) (te *typedOutputEx
 	}
 
 	return toe, nil
+}
+
+// bypass represents part of the expression that we want to pass to the backend
+// database verbatim.
+type bypass struct {
+	chunk string
+}
+
+func (b *bypass) String() string {
+	return "Bypass[" + b.chunk + "]"
+}
+
+// bindTypes is part of the expression interface. bypass expressions have no
+// types so the same expression is returned.
+func (b *bypass) bindTypes(argInfo typeinfo.ArgInfo) (any, error) {
+	return b, nil
 }
 
 // starCountColumns counts the number of asterisks in a list of columns.

--- a/internal/expr/parser.go
+++ b/internal/expr/parser.go
@@ -68,6 +68,15 @@ func (p *Parser) Parse(input string) (pe *ParsedExpr, err error) {
 	return &ParsedExpr{exprs: p.exprs}, nil
 }
 
+// expression represents a parsed node of the SQLair query's AST.
+type expression interface {
+	// String returns a text representation for debugging and testing purposes.
+	String() string
+
+	// marker method
+	expr()
+}
+
 // valueAccessor stores information for accessing a Go value. It consists of a
 // type name and some value within it to be accessed. For example: a field of a
 // struct, or a key of a map.
@@ -90,6 +99,45 @@ func (ca columnAccessor) String() string {
 	}
 	return ca.tableName + "." + ca.columnName
 }
+
+// inputExpr represents a named parameter that will be sent to the database
+// while performing the query.
+type inputExpr struct {
+	sourceType valueAccessor
+	raw        string
+}
+
+func (p *inputExpr) String() string {
+	return fmt.Sprintf("Input[%+v]", p.sourceType)
+}
+
+func (p *inputExpr) expr() {}
+
+// outputExpr represents a named target output variable in the SQL expression,
+// as well as the source table and column where it will be read from.
+type outputExpr struct {
+	sourceColumns []columnAccessor
+	targetTypes   []valueAccessor
+	raw           string
+}
+
+func (p *outputExpr) String() string {
+	return fmt.Sprintf("Output[%+v %+v]", p.sourceColumns, p.targetTypes)
+}
+
+func (p *outputExpr) expr() {}
+
+// bypass represents part of the expression that we want to pass to the backend
+// database verbatim.
+type bypass struct {
+	chunk string
+}
+
+func (p *bypass) String() string {
+	return "Bypass[" + p.chunk + "]"
+}
+
+func (p *bypass) expr() {}
 
 // init resets the state of the parser and sets the input string.
 func (p *Parser) init(input string) {

--- a/internal/expr/parser.go
+++ b/internal/expr/parser.go
@@ -68,15 +68,6 @@ func (p *Parser) Parse(input string) (pe *ParsedExpr, err error) {
 	return &ParsedExpr{exprs: p.exprs}, nil
 }
 
-// expression represents a parsed node of the SQLair query's AST.
-type expression interface {
-	// String returns a text representation for debugging and testing purposes.
-	String() string
-
-	// marker method
-	expr()
-}
-
 // valueAccessor stores information for accessing a Go value. It consists of a
 // type name and some value within it to be accessed. For example: a field of a
 // struct, or a key of a map.
@@ -99,45 +90,6 @@ func (ca columnAccessor) String() string {
 	}
 	return ca.tableName + "." + ca.columnName
 }
-
-// inputExpr represents a named parameter that will be sent to the database
-// while performing the query.
-type inputExpr struct {
-	sourceType valueAccessor
-	raw        string
-}
-
-func (p *inputExpr) String() string {
-	return fmt.Sprintf("Input[%+v]", p.sourceType)
-}
-
-func (p *inputExpr) expr() {}
-
-// outputExpr represents a named target output variable in the SQL expression,
-// as well as the source table and column where it will be read from.
-type outputExpr struct {
-	sourceColumns []columnAccessor
-	targetTypes   []valueAccessor
-	raw           string
-}
-
-func (p *outputExpr) String() string {
-	return fmt.Sprintf("Output[%+v %+v]", p.sourceColumns, p.targetTypes)
-}
-
-func (p *outputExpr) expr() {}
-
-// bypass represents part of the expression that we want to pass to the backend
-// database verbatim.
-type bypass struct {
-	chunk string
-}
-
-func (p *bypass) String() string {
-	return "Bypass[" + p.chunk + "]"
-}
-
-func (p *bypass) expr() {}
 
 // init resets the state of the parser and sets the input string.
 func (p *Parser) init(input string) {

--- a/internal/expr/query.go
+++ b/internal/expr/query.go
@@ -29,6 +29,11 @@ func (pq *PrimedQuery) HasOutputs() bool {
 	return len(pq.outputs) > 0
 }
 
+// SQL returns the SQL string to send to the database.
+func (pq *PrimedQuery) SQL() string {
+	return pq.sql
+}
+
 // ScanArgs produces a list of pointers to be passed to rows.Scan. After a
 // successful call, the onSuccess function must be invoked. The outputArgs will
 // be populated with the query results. All the structs/maps/slices mentioned in

--- a/internal/typeinfo/member_test.go
+++ b/internal/typeinfo/member_test.go
@@ -109,6 +109,19 @@ func (s *typeInfoSuite) TestLocateScanTargetError(c *C) {
 	// Check missing type error.
 	_, _, err = output.LocateScanTarget(map[reflect.Type]reflect.Value{})
 	c.Assert(err, ErrorMatches, `parameter with type "M" missing`)
+
+	// Check missing type with same name error.
+	//
+	// This error is designed to catch types from different packages with the
+	// same name. Since this requires creating a package just for the test we
+	// instead test it with a shadowed type which still hits this error
+	// message.
+	{
+		type M map[string]any
+		typeToValue := map[reflect.Type]reflect.Value{reflect.TypeOf(M{}): reflect.ValueOf(M{})}
+		_, _, err = output.LocateScanTarget(typeToValue)
+		c.Assert(err, ErrorMatches, `parameter with type "typeinfo.M" missing, have type with same name: "typeinfo.M"`)
+	}
 }
 
 func (s *typeInfoSuite) TestLocateParamsMap(c *C) {


### PR DESCRIPTION
Move the responsibility of generating SQL to the Bind Inputs stage. This will allow SQL to support IN expressions where the SQL that is generated depends on the input arguments.

- Change `TypedBoundExpr` from containing lists of inputs outputs and the SQL to containing a typed versions of the expressions. This means it retains the shape of `ParsedExpr`.
- Rename `TypedExpr` to `TypeBoundExpr`. This removes the confusion with the name of the its constituents: `typedExpression`.
- Move the SQL generation to the bind inputs stage. It is now generated it alongside the query parameters.
- Change `ExprPkgTest` in `expr_test.go` to test the Bind Inputs stage as well.
 