### PR TITLE
bugfix: Fix duplicate output error

### DIFF
--- a/internal/expr/bindtypes.go
+++ b/internal/expr/bindtypes.go
@@ -64,10 +64,10 @@ func (pe *ParsedExpr) BindTypes(args ...any) (tbe *TypeBoundExpr, err error) {
 			}
 
 			for _, oc := range toe.outputColumns {
-				if ok := outputUsed[oc.output.Repr()]; ok {
+				if ok := outputUsed[oc.output.Identifier()]; ok {
 					return nil, fmt.Errorf("%s appears more than once in output expressions", oc.output.Desc())
 				}
-				outputUsed[oc.output.Repr()] = true
+				outputUsed[oc.output.Identifier()] = true
 			}
 			te = toe
 		case *bypass:

--- a/internal/expr/bindtypes.go
+++ b/internal/expr/bindtypes.go
@@ -67,10 +67,10 @@ func (pe *ParsedExpr) BindTypes(args ...any) (tbe *TypeBoundExpr, err error) {
 			}
 
 			for _, oc := range toe.outputColumns {
-				if ok := outputUsed[oc.output.String()]; ok {
+				if ok := outputUsed[oc.output.IDString()]; ok {
 					return nil, fmt.Errorf("%s appears more than once in output expressions", oc.output.String())
 				}
-				outputUsed[oc.output.String()] = true
+				outputUsed[oc.output.IDString()] = true
 			}
 			te = toe
 		case *bypass:

--- a/internal/expr/bindtypes.go
+++ b/internal/expr/bindtypes.go
@@ -48,7 +48,10 @@ func (pe *ParsedExpr) BindTypes(args ...any) (tbe *TypeBoundExpr, err error) {
 
 	// Bind types to each expression.
 	var typedExprs TypeBoundExpr
-	outputUsed := map[typeinfo.Output]bool{}
+	// outputUsed records if the string representation of an output appears
+	// more than once in the query. If the string appears more than once then
+	// there is ambiguity in the query.
+	outputUsed := map[string]bool{}
 	var te any
 	for _, expr := range pe.exprs {
 		switch e := expr.(type) {
@@ -64,10 +67,10 @@ func (pe *ParsedExpr) BindTypes(args ...any) (tbe *TypeBoundExpr, err error) {
 			}
 
 			for _, oc := range toe.outputColumns {
-				if ok := outputUsed[oc.output]; ok {
+				if ok := outputUsed[oc.output.String()]; ok {
 					return nil, fmt.Errorf("%s appears more than once in output expressions", oc.output.String())
 				}
-				outputUsed[oc.output] = true
+				outputUsed[oc.output.String()] = true
 			}
 			te = toe
 		case *bypass:

--- a/internal/expr/bindtypes.go
+++ b/internal/expr/bindtypes.go
@@ -64,10 +64,10 @@ func (pe *ParsedExpr) BindTypes(args ...any) (tbe *TypeBoundExpr, err error) {
 			}
 
 			for _, oc := range toe.outputColumns {
-				if ok := outputUsed[oc.output.ID()]; ok {
-					return nil, fmt.Errorf("%s appears more than once in output expressions", oc.output.String())
+				if ok := outputUsed[oc.output.Repr()]; ok {
+					return nil, fmt.Errorf("%s appears more than once in output expressions", oc.output.Desc())
 				}
-				outputUsed[oc.output.ID()] = true
+				outputUsed[oc.output.Repr()] = true
 			}
 			te = toe
 		case *bypass:

--- a/internal/expr/bindtypes.go
+++ b/internal/expr/bindtypes.go
@@ -48,9 +48,6 @@ func (pe *ParsedExpr) BindTypes(args ...any) (tbe *TypeBoundExpr, err error) {
 
 	// Bind types to each expression.
 	var typedExprs TypeBoundExpr
-	// outputUsed records if the string representation of an output appears
-	// more than once in the query. If the string appears more than once then
-	// there is ambiguity in the query.
 	outputUsed := map[string]bool{}
 	var te any
 	for _, expr := range pe.exprs {
@@ -67,10 +64,10 @@ func (pe *ParsedExpr) BindTypes(args ...any) (tbe *TypeBoundExpr, err error) {
 			}
 
 			for _, oc := range toe.outputColumns {
-				if ok := outputUsed[oc.output.IDString()]; ok {
+				if ok := outputUsed[oc.output.ID()]; ok {
 					return nil, fmt.Errorf("%s appears more than once in output expressions", oc.output.String())
 				}
-				outputUsed[oc.output.IDString()] = true
+				outputUsed[oc.output.ID()] = true
 			}
 			te = toe
 		case *bypass:

--- a/internal/expr/expr_test.go
+++ b/internal/expr/expr_test.go
@@ -541,6 +541,10 @@ func (s *ExprSuite) TestBindTypesErrors(c *C) {
 		typeSamples: []any{Address{}, Person{}},
 		err:         `cannot prepare statement: tag "id" of struct "Address" appears more than once in output expressions`,
 	}, {
+		query:       "SELECT (&M.id, &M.id) FROM t",
+		typeSamples: []any{sqlair.M{}},
+		err:         `cannot prepare statement: key "id" of map "M" appears more than once in output expressions`,
+	}, {
 		query:       "SELECT (p.*, t.name) AS (&Address.*) FROM t",
 		typeSamples: []any{Address{}},
 		err:         "cannot prepare statement: output expression: invalid asterisk in columns: (p.*, t.name) AS (&Address.*)",

--- a/internal/typeinfo/member.go
+++ b/internal/typeinfo/member.go
@@ -16,7 +16,9 @@ var scannerInterface = reflect.TypeOf((*sql.Scanner)(nil)).Elem()
 type ValueLocator interface {
 	ArgType() reflect.Type
 	String() string
-	IDString() string
+	// ID returns an accessor string for this ValueLocator specifying the type
+	// and, if present, member.
+	ID() string
 }
 
 // Input is a locator for a Go value from SQLair input arguments to be used in
@@ -80,8 +82,8 @@ func (mk *mapKey) String() string {
 	return "key \"" + mk.name + "\" of map \"" + mk.mapType.Name() + "\""
 }
 
-// IDString returns a string identifier for the map and key.
-func (mk *mapKey) IDString() string {
+// ID returns a string identifier for the map and key.
+func (mk *mapKey) ID() string {
 	return mk.mapType.Name() + "." + mk.name
 }
 
@@ -140,8 +142,8 @@ func (f *structField) String() string {
 	return "tag \"" + f.tag + "\" of struct \"" + f.structType.Name() + "\""
 }
 
-// IDString returns a string identifier for the field and its struct.
-func (f *structField) IDString() string {
+// ID returns a string identifier for the field and its struct.
+func (f *structField) ID() string {
 	return f.structType.Name() + "." + f.tag
 }
 

--- a/internal/typeinfo/member.go
+++ b/internal/typeinfo/member.go
@@ -80,7 +80,7 @@ func (mk *mapKey) LocateParams(typeToValue map[reflect.Type]reflect.Value) ([]re
 // Desc returns a natural language description of the mapKey for use in error
 // messages.
 func (mk *mapKey) Desc() string {
-	return "key \"" + mk.name + "\" of map \"" + mk.mapType.Name() + "\""
+	return fmt.Sprintf("key %q of map %q", mk.name, mk.mapType.Name())
 }
 
 // Identifier returns a string that uniquely identifies the map key in the
@@ -141,7 +141,7 @@ func (f *structField) LocateParams(typeToValue map[reflect.Type]reflect.Value) (
 // Desc returns a natural language description of the struct field for use in
 // error messages.
 func (f *structField) Desc() string {
-	return "tag \"" + f.tag + "\" of struct \"" + f.structType.Name() + "\""
+	return fmt.Sprintf("tag %q of struct %q", f.tag, f.structType.Name())
 }
 
 // Identifier returns a string that uniquely identifies the struct field in the

--- a/internal/typeinfo/member.go
+++ b/internal/typeinfo/member.go
@@ -17,9 +17,9 @@ type ValueLocator interface {
 	ArgType() reflect.Type
 	// Desc returns a written description of the ValueLocator for error messages.
 	Desc() string
-	// Repr returns a string representation for the ValueLocator specifying the
-	// type and, if present, member.
-	Repr() string
+	// Identifier returns a string that uniquely identifies the ValueLocator in
+	// the query.
+	Identifier() string
 }
 
 // Input is a locator for a Go value from SQLair input arguments to be used in
@@ -83,8 +83,9 @@ func (mk *mapKey) Desc() string {
 	return "key \"" + mk.name + "\" of map \"" + mk.mapType.Name() + "\""
 }
 
-// Repr returns a string identifier for the map and key.
-func (mk *mapKey) Repr() string {
+// Identifier returns a string that uniquely identifies the map key in the
+// context of the query.
+func (mk *mapKey) Identifier() string {
 	return mk.mapType.Name() + "." + mk.name
 }
 
@@ -143,8 +144,9 @@ func (f *structField) Desc() string {
 	return "tag \"" + f.tag + "\" of struct \"" + f.structType.Name() + "\""
 }
 
-// Repr returns a string representation of the field and its struct.
-func (f *structField) Repr() string {
+// Identifier returns a string that uniquely identifies the struct field in the
+// context of the query.
+func (f *structField) Identifier() string {
 	return f.structType.Name() + "." + f.tag
 }
 

--- a/internal/typeinfo/member.go
+++ b/internal/typeinfo/member.go
@@ -16,6 +16,7 @@ var scannerInterface = reflect.TypeOf((*sql.Scanner)(nil)).Elem()
 type ValueLocator interface {
 	ArgType() reflect.Type
 	String() string
+	IDString() string
 }
 
 // Input is a locator for a Go value from SQLair input arguments to be used in
@@ -79,6 +80,11 @@ func (mk *mapKey) String() string {
 	return "key \"" + mk.name + "\" of map \"" + mk.mapType.Name() + "\""
 }
 
+// IDString returns a string identifier for the map and key.
+func (mk *mapKey) IDString() string {
+	return mk.mapType.Name() + "." + mk.name
+}
+
 // LocateScanTarget locates the map specified in mapKey from the provided
 // typeToValue map. It returns a pointer to pass to rows.Scan, and a ScanProxy
 // reference for setting the key value in the map once the pointer has been
@@ -132,6 +138,11 @@ func (f *structField) LocateParams(typeToValue map[reflect.Type]reflect.Value) (
 // error messages.
 func (f *structField) String() string {
 	return "tag \"" + f.tag + "\" of struct \"" + f.structType.Name() + "\""
+}
+
+// IDString returns a string identifier for the field and its struct.
+func (f *structField) IDString() string {
+	return f.structType.Name() + "." + f.tag
 }
 
 // LocateScanTarget locates the struct specified in structField from the

--- a/internal/typeinfo/member.go
+++ b/internal/typeinfo/member.go
@@ -15,10 +15,11 @@ var scannerInterface = reflect.TypeOf((*sql.Scanner)(nil)).Elem()
 // ValueLocator specifies how to locate a value in a SQLair argument type.
 type ValueLocator interface {
 	ArgType() reflect.Type
-	String() string
-	// ID returns an accessor string for this ValueLocator specifying the type
-	// and, if present, member.
-	ID() string
+	// Desc returns a written description of the ValueLocator for error messages.
+	Desc() string
+	// Repr returns a string representation for the ValueLocator specifying the
+	// type and, if present, member.
+	Repr() string
 }
 
 // Input is a locator for a Go value from SQLair input arguments to be used in
@@ -76,14 +77,14 @@ func (mk *mapKey) LocateParams(typeToValue map[reflect.Type]reflect.Value) ([]re
 	return []reflect.Value{v}, nil
 }
 
-// String returns a natural language description of the mapKey for use in error
+// Desc returns a natural language description of the mapKey for use in error
 // messages.
-func (mk *mapKey) String() string {
+func (mk *mapKey) Desc() string {
 	return "key \"" + mk.name + "\" of map \"" + mk.mapType.Name() + "\""
 }
 
-// ID returns a string identifier for the map and key.
-func (mk *mapKey) ID() string {
+// Repr returns a string identifier for the map and key.
+func (mk *mapKey) Repr() string {
 	return mk.mapType.Name() + "." + mk.name
 }
 
@@ -136,14 +137,14 @@ func (f *structField) LocateParams(typeToValue map[reflect.Type]reflect.Value) (
 	return []reflect.Value{s.Field(f.index)}, nil
 }
 
-// String returns a natural language description of the struct field for use in
+// Desc returns a natural language description of the struct field for use in
 // error messages.
-func (f *structField) String() string {
+func (f *structField) Desc() string {
 	return "tag \"" + f.tag + "\" of struct \"" + f.structType.Name() + "\""
 }
 
-// ID returns a string identifier for the field and its struct.
-func (f *structField) ID() string {
+// Repr returns a string representation of the field and its struct.
+func (f *structField) Repr() string {
 	return f.structType.Name() + "." + f.tag
 }
 

--- a/package_test.go
+++ b/package_test.go
@@ -8,9 +8,10 @@ import (
 	"database/sql"
 	"errors"
 	"fmt"
+	"testing"
+
 	_ "github.com/mattn/go-sqlite3"
 	. "gopkg.in/check.v1"
-	"testing"
 
 	"github.com/canonical/sqlair"
 )


### PR DESCRIPTION
Fix error where a single map member can be used as an output multiple times in a query.

The `outputUsed` map mapped `typeinfo.Output` to booleans recording if the output had been used. For maps the `mapKey` object that implemented the `typeinfo.Output` has a pointer receiver. It was possible to have two identical `mapKey` structs with different pointers.

Here, the error is fixed by indexing `outputUsed` with a string representation of the `typeinfo.Output` using its `String` method. 