### PR TITLE
Add parsing support for input expressions in INSERT statements

### DIFF
--- a/internal/expr/bindtypes.go
+++ b/internal/expr/bindtypes.go
@@ -118,34 +118,34 @@ func (e *memberInputExpr) bindTypes(argInfo typeinfo.ArgInfo) (any, error) {
 	return &typedInputExpr{input: input}, nil
 }
 
-// insertIntoAsteriskExpr is a form of input expression for insert statements e.g.
+// insertToAsteriskExpr is a form of input expression for insert statements e.g.
 // "(*) VALUES ($Type1.member, $Type2.*)".
-type insertIntoAsteriskExpr struct {
+type insertToAsteriskExpr struct {
 	sources []memberAccessor
 	raw     string
 }
 
-func (e *insertIntoAsteriskExpr) String() string {
+func (e *insertToAsteriskExpr) String() string {
 	return fmt.Sprintf("AsteriskInsert[[*] %v]", e.sources)
 }
 
-func (e *insertIntoAsteriskExpr) bindTypes(argInfo typeinfo.ArgInfo) (any, error) {
+func (e *insertToAsteriskExpr) bindTypes(argInfo typeinfo.ArgInfo) (any, error) {
 	return nil, fmt.Errorf("insert input expression not implemented")
 }
 
-// insertIntoColumnsExpr is a form of input expression for insert statements e.g.
+// insertToColumnsExpr is a form of input expression for insert statements e.g.
 // "(col1, col2, col3) VALUES ($Type.*)".
-type insertIntoColumnsExpr struct {
+type insertToColumnsExpr struct {
 	columns  []columnAccessor
 	typeName string
 	raw      string
 }
 
-func (e *insertIntoColumnsExpr) String() string {
+func (e *insertToColumnsExpr) String() string {
 	return fmt.Sprintf("ColumnInsert[%v [%v.*]]", e.columns, e.typeName)
 }
 
-func (e *insertIntoColumnsExpr) bindTypes(argInfo typeinfo.ArgInfo) (any, error) {
+func (e *insertToColumnsExpr) bindTypes(argInfo typeinfo.ArgInfo) (any, error) {
 	return nil, fmt.Errorf("insert input expression not implemented")
 }
 

--- a/internal/expr/bindtypes.go
+++ b/internal/expr/bindtypes.go
@@ -118,6 +118,8 @@ func (e *memberInputExpr) bindTypes(argInfo typeinfo.ArgInfo) (any, error) {
 	return &typedInputExpr{input: input}, nil
 }
 
+// insertInput is a form of input expression for insert statements e.g.
+// "(*) VALUES ($Type1.member, $Type2.*)".
 type insertInputExpr struct {
 	raw           string
 	targetColumns []columnAccessor

--- a/internal/expr/bindtypes.go
+++ b/internal/expr/bindtypes.go
@@ -118,39 +118,39 @@ func (e *memberInputExpr) bindTypes(argInfo typeinfo.ArgInfo) (any, error) {
 	return &typedInputExpr{input: input}, nil
 }
 
-// asteriskInputExpr is an input expression occurring within an INSERT
+// asteriskInsertExpr is an input expression occurring within an INSERT
 // statement that consists of an asterisk on the left and explicit type accessors
 // on the right. This means that SQLair generates the columns.
 // e.g. "(*) VALUES ($Type1.col1, $Type2.*)".
-type asteriskInputExpr struct {
+type asteriskInsertExpr struct {
 	sources []memberAccessor
 	raw     string
 }
 
 // String returns a text representation for debugging and testing purposes.
-func (e *asteriskInputExpr) String() string {
-	return fmt.Sprintf("AsteriskInput[[*] %v]", e.sources)
+func (e *asteriskInsertExpr) String() string {
+	return fmt.Sprintf("AsteriskInsert[[*] %v]", e.sources)
 }
 
-func (e *asteriskInputExpr) bindTypes(argInfo typeinfo.ArgInfo) (any, error) {
+func (e *asteriskInsertExpr) bindTypes(argInfo typeinfo.ArgInfo) (any, error) {
 	return nil, fmt.Errorf("insert input expression not implemented")
 }
 
-// columnsInputExpr is an input expression occurring within an INSERT statement
+// columnsInsertExpr is an input expression occurring within an INSERT statement
 // that consists of explicit columns on the left and type accessors on the right.
 // e.g. "(col1, col2, col3) VALUES ($Type.*, $Type2.col1)".
-type columnsInputExpr struct {
+type columnsInsertExpr struct {
 	columns []columnAccessor
 	sources []memberAccessor
 	raw     string
 }
 
 // String returns a text representation for debugging and testing purposes.
-func (e *columnsInputExpr) String() string {
-	return fmt.Sprintf("ColumnInput[%v %v]", e.columns, e.sources)
+func (e *columnsInsertExpr) String() string {
+	return fmt.Sprintf("ColumnInsert[%v %v]", e.columns, e.sources)
 }
 
-func (e *columnsInputExpr) bindTypes(argInfo typeinfo.ArgInfo) (any, error) {
+func (e *columnsInsertExpr) bindTypes(argInfo typeinfo.ArgInfo) (any, error) {
 	return nil, fmt.Errorf("insert input expression not implemented")
 }
 

--- a/internal/expr/bindtypes.go
+++ b/internal/expr/bindtypes.go
@@ -115,7 +115,21 @@ func (e *memberInputExpr) bindTypes(argInfo typeinfo.ArgInfo) (any, error) {
 	if err != nil {
 		return nil, fmt.Errorf("input expression: %s: %s", err, e.raw)
 	}
-	return &typedInputExpr{input}, nil
+	return &typedInputExpr{input: input}, nil
+}
+
+type insertInputExpr struct {
+	raw           string
+	targetColumns []columnAccessor
+	sourceTypes   []memberAccessor
+}
+
+func (ie *insertInputExpr) String() string {
+	return fmt.Sprintf("Input[%+v %+v]", ie.targetColumns, ie.sourceTypes)
+}
+
+func (ie *insertInputExpr) bindTypes(argInfo typeinfo.ArgInfo) (any, error) {
+	return nil, fmt.Errorf("insert input expression not implemented")
 }
 
 // sliceInputExpr is an input expression of the form "$S[:]" that represents a

--- a/internal/expr/bindtypes.go
+++ b/internal/expr/bindtypes.go
@@ -139,14 +139,14 @@ func (e *asteriskInputExpr) bindTypes(argInfo typeinfo.ArgInfo) (any, error) {
 // asterisk type and explicit columns.
 // e.g. "(col1, col2, col3) VALUES ($Type.*)".
 type columnsInputExpr struct {
-	columns  []columnAccessor
-	typeName string
-	raw      string
+	columns []columnAccessor
+	sources []memberAccessor
+	raw     string
 }
 
 // String returns a text representation for debugging and testing purposes.
 func (e *columnsInputExpr) String() string {
-	return fmt.Sprintf("ColumnInput[%v [%v.*]]", e.columns, e.typeName)
+	return fmt.Sprintf("ColumnInput[%v %v]", e.columns, e.sources)
 }
 
 func (e *columnsInputExpr) bindTypes(argInfo typeinfo.ArgInfo) (any, error) {

--- a/internal/expr/bindtypes.go
+++ b/internal/expr/bindtypes.go
@@ -118,9 +118,10 @@ func (e *memberInputExpr) bindTypes(argInfo typeinfo.ArgInfo) (any, error) {
 	return &typedInputExpr{input: input}, nil
 }
 
-// asteriskInputExpr is an input expression in an INSERT statement with an
-// asterisk on the left meaning that SQLair generates the columns.
-// e.g. "(*) VALUES ($Type1.member, $Type2.*)".
+// asteriskInputExpr is an input expression occurring within an INSERT
+// statement that consists of an asterisk on the left and explicit type accessors
+// on the right. This means that SQLair generates the columns.
+// e.g. "(*) VALUES ($Type1.col1, $Type2.*)".
 type asteriskInputExpr struct {
 	sources []memberAccessor
 	raw     string
@@ -135,9 +136,9 @@ func (e *asteriskInputExpr) bindTypes(argInfo typeinfo.ArgInfo) (any, error) {
 	return nil, fmt.Errorf("insert input expression not implemented")
 }
 
-// columnsInputExpr is an input expression in an INSERT statement with a single
-// asterisk type and explicit columns.
-// e.g. "(col1, col2, col3) VALUES ($Type.*)".
+// columnsInputExpr is an input expression occurring within an INSERT statement
+// that consists of explicit columns on the left and type accessors on the right.
+// e.g. "(col1, col2, col3) VALUES ($Type.*, $Type2.col1)".
 type columnsInputExpr struct {
 	columns []columnAccessor
 	sources []memberAccessor

--- a/internal/expr/bindtypes.go
+++ b/internal/expr/bindtypes.go
@@ -118,34 +118,38 @@ func (e *memberInputExpr) bindTypes(argInfo typeinfo.ArgInfo) (any, error) {
 	return &typedInputExpr{input: input}, nil
 }
 
-// insertToAsteriskExpr is a form of input expression for insert statements e.g.
-// "(*) VALUES ($Type1.member, $Type2.*)".
-type insertToAsteriskExpr struct {
+// asteriskInputExpr is an input expression in an INSERT statement with an
+// asterisk on the left meaning that SQLair generates the columns.
+// e.g. "(*) VALUES ($Type1.member, $Type2.*)".
+type asteriskInputExpr struct {
 	sources []memberAccessor
 	raw     string
 }
 
-func (e *insertToAsteriskExpr) String() string {
-	return fmt.Sprintf("AsteriskInsert[[*] %v]", e.sources)
+// String returns a text representation for debugging and testing purposes.
+func (e *asteriskInputExpr) String() string {
+	return fmt.Sprintf("AsteriskInput[[*] %v]", e.sources)
 }
 
-func (e *insertToAsteriskExpr) bindTypes(argInfo typeinfo.ArgInfo) (any, error) {
+func (e *asteriskInputExpr) bindTypes(argInfo typeinfo.ArgInfo) (any, error) {
 	return nil, fmt.Errorf("insert input expression not implemented")
 }
 
-// insertToColumnsExpr is a form of input expression for insert statements e.g.
-// "(col1, col2, col3) VALUES ($Type.*)".
-type insertToColumnsExpr struct {
+// columnsInputExpr is an input expression in an INSERT statement with a single
+// asterisk type and explicit columns.
+// e.g. "(col1, col2, col3) VALUES ($Type.*)".
+type columnsInputExpr struct {
 	columns  []columnAccessor
 	typeName string
 	raw      string
 }
 
-func (e *insertToColumnsExpr) String() string {
-	return fmt.Sprintf("ColumnInsert[%v [%v.*]]", e.columns, e.typeName)
+// String returns a text representation for debugging and testing purposes.
+func (e *columnsInputExpr) String() string {
+	return fmt.Sprintf("ColumnInput[%v [%v.*]]", e.columns, e.typeName)
 }
 
-func (e *insertToColumnsExpr) bindTypes(argInfo typeinfo.ArgInfo) (any, error) {
+func (e *columnsInputExpr) bindTypes(argInfo typeinfo.ArgInfo) (any, error) {
 	return nil, fmt.Errorf("insert input expression not implemented")
 }
 

--- a/internal/expr/bindtypes.go
+++ b/internal/expr/bindtypes.go
@@ -118,19 +118,34 @@ func (e *memberInputExpr) bindTypes(argInfo typeinfo.ArgInfo) (any, error) {
 	return &typedInputExpr{input: input}, nil
 }
 
-// insertInput is a form of input expression for insert statements e.g.
+// insertIntoAsteriskExpr is a form of input expression for insert statements e.g.
 // "(*) VALUES ($Type1.member, $Type2.*)".
-type insertInputExpr struct {
-	raw           string
-	targetColumns []columnAccessor
-	sourceTypes   []memberAccessor
+type insertIntoAsteriskExpr struct {
+	sources []memberAccessor
+	raw     string
 }
 
-func (ie *insertInputExpr) String() string {
-	return fmt.Sprintf("Input[%+v %+v]", ie.targetColumns, ie.sourceTypes)
+func (e *insertIntoAsteriskExpr) String() string {
+	return fmt.Sprintf("AsteriskInsert[[*] %v]", e.sources)
 }
 
-func (ie *insertInputExpr) bindTypes(argInfo typeinfo.ArgInfo) (any, error) {
+func (e *insertIntoAsteriskExpr) bindTypes(argInfo typeinfo.ArgInfo) (any, error) {
+	return nil, fmt.Errorf("insert input expression not implemented")
+}
+
+// insertIntoColumnsExpr is a form of input expression for insert statements e.g.
+// "(col1, col2, col3) VALUES ($Type.*)".
+type insertIntoColumnsExpr struct {
+	columns  []columnAccessor
+	typeName string
+	raw      string
+}
+
+func (e *insertIntoColumnsExpr) String() string {
+	return fmt.Sprintf("ColumnInsert[%v [%v.*]]", e.columns, e.typeName)
+}
+
+func (e *insertIntoColumnsExpr) bindTypes(argInfo typeinfo.ArgInfo) (any, error) {
 	return nil, fmt.Errorf("insert input expression not implemented")
 }
 

--- a/internal/expr/expr_test.go
+++ b/internal/expr/expr_test.go
@@ -626,10 +626,10 @@ of three lines' AND id = $Person.*`,
 		err:   `cannot parse expression: column 8: cannot read function call "count(*)" into asterisk`,
 	}, {
 		query: "INSERT INTO person (*) VALUES $Address.*",
-		err:   `cannot parse expression: column 20: missing parentheses around types after "VALUES"`,
+		err:   `cannot parse expression: column 21: missing parentheses around types after "VALUES"`,
 	}, {
 		query: "INSERT INTO person (*) VALUES $M.col1",
-		err:   `cannot parse expression: column 20: missing parentheses around types after "VALUES"`,
+		err:   `cannot parse expression: column 21: missing parentheses around types after "VALUES"`,
 	}, {
 		query: "INSERT INTO person * VALUES $Address.*",
 		err:   `cannot parse expression: column 29: invalid asterisk input placement "$Address.*"`,

--- a/internal/expr/expr_test.go
+++ b/internal/expr/expr_test.go
@@ -479,6 +479,10 @@ func (s *ExprSuite) TestInsertInputParser(c *C) {
 		query:          "INSERT INTO person(*) VALUES ($Person.*)ON CONFLICT DO NOTHING",
 		expectedParsed: "[Bypass[INSERT INTO person] AsteriskInput[[*] [Person.*]] Bypass[ON CONFLICT DO NOTHING]]",
 	}, {
+		summary:        "insert asterisk (weird spacing)",
+		query:          "INSERT INTO person ( * )VALUES( $Person.* )ON CONFLICT DO NOTHING",
+		expectedParsed: "[Bypass[INSERT INTO person ] AsteriskInput[[*] [Person.*]] Bypass[ON CONFLICT DO NOTHING]]",
+	}, {
 		summary:        "insert with returning clause",
 		query:          "INSERT INTO address(*) VALUES($Address.*) RETURNING (&Address.*)",
 		expectedParsed: "[Bypass[INSERT INTO address] AsteriskInput[[*] [Address.*]] Bypass[ RETURNING (] Output[[] [Address.*]] Bypass[)]]",
@@ -626,10 +630,10 @@ of three lines' AND id = $Person.*`,
 		err:   `cannot parse expression: column 8: cannot read function call "count(*)" into asterisk`,
 	}, {
 		query: "INSERT INTO person (*) VALUES $Address.*",
-		err:   `cannot parse expression: column 21: missing parentheses around types after "VALUES"`,
+		err:   `cannot parse expression: column 20: missing parentheses around types after "VALUES"`,
 	}, {
 		query: "INSERT INTO person (*) VALUES $M.col1",
-		err:   `cannot parse expression: column 21: missing parentheses around types after "VALUES"`,
+		err:   `cannot parse expression: column 20: missing parentheses around types after "VALUES"`,
 	}, {
 		query: "INSERT INTO person * VALUES $Address.*",
 		err:   `cannot parse expression: column 29: invalid asterisk input placement "$Address.*"`,

--- a/internal/expr/expr_test.go
+++ b/internal/expr/expr_test.go
@@ -457,35 +457,35 @@ func (s *ExprSuite) TestInsertInputParser(c *C) {
 	}{{
 		summary:        "insert asterisk",
 		query:          "INSERT INTO person (*) VALUES ($Address.street, $Person.*, $M.team)",
-		expectedParsed: "[Bypass[INSERT INTO person ] Input[[*] [Address.street Person.* M.team]]]",
+		expectedParsed: "[Bypass[INSERT INTO person ] AsteriskInsert[[*] [Address.street Person.* M.team]]]",
 	}, {
 		summary:        "insert specified columns",
 		query:          "INSERT INTO person (id, street) VALUES ($Address.*)",
-		expectedParsed: "[Bypass[INSERT INTO person ] Input[[id street] [Address.*]]]",
-	}, {
-		summary:        "insert renamed columns",
-		query:          "INSERT INTO person (id, street) VALUES ($Person.address_id, $Address.street)",
-		expectedParsed: "[Bypass[INSERT INTO person ] Input[[id street] [Person.address_id Address.street]]]",
+		expectedParsed: "[Bypass[INSERT INTO person ] ColumnInsert[[id street] [Address.*]]]",
 	}, {
 		summary:        "insert asterisk with comment",
 		query:          "INSERT INTO person (*) VALUES ($Person.address_id, /* rouge comment */$Address.street)",
-		expectedParsed: "[Bypass[INSERT INTO person ] Input[[*] [Person.address_id Address.street]]]",
-	}, {
-		summary:        "insert single value",
-		query:          "INSERT INTO person (name) VALUES ($Person.name)",
-		expectedParsed: "[Bypass[INSERT INTO person ] Input[[name] [Person.name]]]",
+		expectedParsed: "[Bypass[INSERT INTO person ] AsteriskInsert[[*] [Person.address_id Address.street]]]",
 	}, {
 		summary:        "insert asterisk (no space)",
 		query:          "INSERT INTO person(*) VALUES ($Person.*)ON CONFLICT DO NOTHING",
-		expectedParsed: "[Bypass[INSERT INTO person] Input[[*] [Person.*]] Bypass[ON CONFLICT DO NOTHING]]",
+		expectedParsed: "[Bypass[INSERT INTO person] AsteriskInsert[[*] [Person.*]] Bypass[ON CONFLICT DO NOTHING]]",
+	}, {
+		summary:        "insert with returning clause",
+		query:          "INSERT INTO address (*) VALUES($Address.*) RETURNING (&Address.*)",
+		expectedParsed: "[Bypass[INSERT INTO address ] AsteriskInsert[[*] [Address.*]] Bypass[ RETURNING (] Output[[] [Address.*]] Bypass[)]]",
+	}, {
+		summary:        "insert renamed columns",
+		query:          "INSERT INTO person (id, street) VALUES ($Person.address_id, $Address.street)",
+		expectedParsed: "[Bypass[INSERT INTO person (id, street) VALUES (] Input[Person.address_id] Bypass[, ] Input[Address.street] Bypass[)]]",
+	}, {
+		summary:        "insert single value",
+		query:          "INSERT INTO person (name) VALUES ($Person.name)",
+		expectedParsed: "[Bypass[INSERT INTO person (name) VALUES (] Input[Person.name] Bypass[)]]",
 	}, {
 		summary:        "insert with standalone input expressions",
 		query:          "INSERT INTO person VALUES ($Person.name, $Person.id)",
 		expectedParsed: "[Bypass[INSERT INTO person VALUES (] Input[Person.name] Bypass[, ] Input[Person.id] Bypass[)]]",
-	}, {
-		summary:        "insert with returning clause",
-		query:          "INSERT INTO address (*) VALUES($Address.*) RETURNING (&Address.*)",
-		expectedParsed: "[Bypass[INSERT INTO address ] Input[[*] [Address.*]] Bypass[ RETURNING (] Output[[] [Address.*]] Bypass[)]]",
 	}}
 	for i, t := range tests {
 		parser := expr.NewParser()

--- a/internal/expr/expr_test.go
+++ b/internal/expr/expr_test.go
@@ -565,7 +565,7 @@ comment */ WHERE x = $Address.&d`,
 		err:   `cannot parse expression: column 22: missing closing parentheses`,
 	}, {
 		query: "SELECT (name, id) WHERE id = $Person.*",
-		err:   `cannot parse expression: column 30: input expression asterisk not allowed outside insert statement "$Person.*"`,
+		err:   `cannot parse expression: column 30: asterisk not allowed in input outside insert statement "$Person.*"`,
 	}, {
 		query: `SELECT (name, id) AS (&Person.name, /* multiline
 comment */
@@ -576,7 +576,7 @@ comment */
 		query: `SELECT (name, id) WHERE name = 'multiline
 string
 of three lines' AND id = $Person.*`,
-		err: `cannot parse expression: line 3, column 26: input expression asterisk not allowed outside insert statement "$Person.*"`,
+		err: `cannot parse expression: line 3, column 26: asterisk not allowed in input outside insert statement "$Person.*"`,
 	}, {
 		query: "SELECT &S[:] FROM t",
 		err:   `cannot parse expression: column 8: cannot use slice syntax "S[:]" in output expression`,

--- a/internal/expr/expr_test.go
+++ b/internal/expr/expr_test.go
@@ -457,35 +457,35 @@ func (s *ExprSuite) TestInsertInputParser(c *C) {
 	}{{
 		summary:        "insert asterisk",
 		query:          "INSERT INTO person (*) VALUES ($Address.street, $Person.*, $M.team)",
-		expectedParsed: "[Bypass[INSERT INTO person ] AsteriskInsert[[*] [Address.street Person.* M.team]]]",
+		expectedParsed: "[Bypass[INSERT INTO person ] AsteriskInput[[*] [Address.street Person.* M.team]]]",
 	}, {
 		summary:        "insert specified columns",
 		query:          "INSERT INTO person (id, street) VALUES ($Address.*)",
-		expectedParsed: "[Bypass[INSERT INTO person ] ColumnInsert[[id street] [Address.*]]]",
+		expectedParsed: "[Bypass[INSERT INTO person ] ColumnInput[[id street] [Address.*]]]",
 	}, {
 		summary:        "insert asterisk with comment",
 		query:          "INSERT INTO person (*) VALUES ($Person.address_id, /* rouge comment */$Address.street)",
-		expectedParsed: "[Bypass[INSERT INTO person ] AsteriskInsert[[*] [Person.address_id Address.street]]]",
+		expectedParsed: "[Bypass[INSERT INTO person ] AsteriskInput[[*] [Person.address_id Address.street]]]",
 	}, {
 		summary:        "insert asterisk (no space)",
 		query:          "INSERT INTO person(*) VALUES ($Person.*)ON CONFLICT DO NOTHING",
-		expectedParsed: "[Bypass[INSERT INTO person] AsteriskInsert[[*] [Person.*]] Bypass[ON CONFLICT DO NOTHING]]",
+		expectedParsed: "[Bypass[INSERT INTO person] AsteriskInput[[*] [Person.*]] Bypass[ON CONFLICT DO NOTHING]]",
 	}, {
 		summary:        "insert with returning clause",
-		query:          "INSERT INTO address (*) VALUES($Address.*) RETURNING (&Address.*)",
-		expectedParsed: "[Bypass[INSERT INTO address ] AsteriskInsert[[*] [Address.*]] Bypass[ RETURNING (] Output[[] [Address.*]] Bypass[)]]",
+		query:          "INSERT INTO address(*) VALUES($Address.*) RETURNING (&Address.*)",
+		expectedParsed: "[Bypass[INSERT INTO address] AsteriskInput[[*] [Address.*]] Bypass[ RETURNING (] Output[[] [Address.*]] Bypass[)]]",
 	}, {
-		summary:        "insert renamed columns",
-		query:          "INSERT INTO person (id, street) VALUES ($Person.address_id, $Address.street)",
-		expectedParsed: "[Bypass[INSERT INTO person (id, street) VALUES (] Input[Person.address_id] Bypass[, ] Input[Address.street] Bypass[)]]",
+		summary:        "insert rename columns with standalone inputs",
+		query:          `INSERT INTO person (id, street) VALUES ($Person.address_id, "random string", rand(), $Address.street)`,
+		expectedParsed: `[Bypass[INSERT INTO person (id, street) VALUES (] Input[Person.address_id] Bypass[, "random string", rand(), ] Input[Address.street] Bypass[)]]`,
 	}, {
 		summary:        "insert single value",
 		query:          "INSERT INTO person (name) VALUES ($Person.name)",
 		expectedParsed: "[Bypass[INSERT INTO person (name) VALUES (] Input[Person.name] Bypass[)]]",
 	}, {
 		summary:        "insert with standalone input expressions",
-		query:          "INSERT INTO person VALUES ($Person.name, $Person.id)",
-		expectedParsed: "[Bypass[INSERT INTO person VALUES (] Input[Person.name] Bypass[, ] Input[Person.id] Bypass[)]]",
+		query:          `INSERT INTO person VALUES ($Person.name, "random string", $Person.id)`,
+		expectedParsed: `[Bypass[INSERT INTO person VALUES (] Input[Person.name] Bypass[, "random string", ] Input[Person.id] Bypass[)]]`,
 	}}
 	for i, t := range tests {
 		parser := expr.NewParser()
@@ -565,7 +565,7 @@ comment */ WHERE x = $Address.&d`,
 		err:   `cannot parse expression: column 22: missing closing parentheses`,
 	}, {
 		query: "SELECT (name, id) WHERE id = $Person.*",
-		err:   `cannot parse expression: column 30: asterisk not allowed in input outside insert statement "$Person.*"`,
+		err:   `cannot parse expression: column 30: invalid asterisk input placement "$Person.*"`,
 	}, {
 		query: `SELECT (name, id) AS (&Person.name, /* multiline
 comment */
@@ -576,7 +576,7 @@ comment */
 		query: `SELECT (name, id) WHERE name = 'multiline
 string
 of three lines' AND id = $Person.*`,
-		err: `cannot parse expression: line 3, column 26: asterisk not allowed in input outside insert statement "$Person.*"`,
+		err: `cannot parse expression: line 3, column 26: invalid asterisk input placement "$Person.*"`,
 	}, {
 		query: "SELECT &S[:] FROM t",
 		err:   `cannot parse expression: column 8: cannot use slice syntax "S[:]" in output expression`,
@@ -616,6 +616,33 @@ of three lines' AND id = $Person.*`,
 	}, {
 		query: "SELECT (id, count(*)) AS (&M.*) FROM t",
 		err:   `cannot parse expression: column 8: cannot read function call "count(*)" into asterisk`,
+	}, {
+		query: "INSERT INTO person (*) VALUES $Address.*",
+		err:   `cannot parse expression: column 20: missing parentheses around types after "VALUES"`,
+	}, {
+		query: "INSERT INTO person (*) VALUES $M.col1",
+		err:   `cannot parse expression: column 20: missing parentheses around types after "VALUES"`,
+	}, {
+		query: "INSERT INTO person * VALUES $Address.*",
+		err:   `cannot parse expression: column 29: invalid asterisk input placement "$Address.*"`,
+	}, {
+		query: "INSERT INTO person * VALUES ($Address.*)",
+		err:   `cannot parse expression: column 30: invalid asterisk input placement "$Address.*"`,
+	}, {
+		query: "INSERT INTO person VALUES ($Address.*)",
+		err:   `cannot parse expression: column 28: invalid asterisk input placement "$Address.*"`,
+	}, {
+		query: "INSERT INTO person VALUES ($Address.*)",
+		err:   `cannot parse expression: column 28: invalid asterisk input placement "$Address.*"`,
+	}, {
+		query: "INSERT INTO person (col1, col2) VALUES ($Address.*, $M.*)",
+		err:   `cannot parse expression: column 40: got multiple types in insert expression with columns`,
+	}, {
+		query: "INSERT INTO person (col1, col2) VALUES ($Address.*, $M.col2)",
+		err:   `cannot parse expression: column 40: got multiple types in insert expression with columns`,
+	}, {
+		query: "INSERT INTO person (col1, col2) VALUES ($M.col2, $Address.*)",
+		err:   `cannot parse expression: column 40: got multiple types in insert expression with columns`,
 	}}
 
 	for _, t := range tests {

--- a/internal/expr/expr_test.go
+++ b/internal/expr/expr_test.go
@@ -577,7 +577,7 @@ comment */ WHERE x = $Address.&d`,
 		err:   `cannot parse expression: column 22: missing closing parentheses`,
 	}, {
 		query: "SELECT (name, id) WHERE id = $Person.*",
-		err:   `cannot parse expression: column 30: invalid asterisk input placement "$Person.*"`,
+		err:   `cannot parse expression: column 30: invalid asterisk placement in input "$Person.*"`,
 	}, {
 		query: `SELECT (name, id) AS (&Person.name, /* multiline
 comment */
@@ -588,7 +588,7 @@ comment */
 		query: `SELECT (name, id) WHERE name = 'multiline
 string
 of three lines' AND id = $Person.*`,
-		err: `cannot parse expression: line 3, column 26: invalid asterisk input placement "$Person.*"`,
+		err: `cannot parse expression: line 3, column 26: invalid asterisk placement in input "$Person.*"`,
 	}, {
 		query: "SELECT &S[:] FROM t",
 		err:   `cannot parse expression: column 8: cannot use slice syntax "S[:]" in output expression`,
@@ -636,13 +636,13 @@ of three lines' AND id = $Person.*`,
 		err:   `cannot parse expression: column 20: missing parentheses around types after "VALUES"`,
 	}, {
 		query: "INSERT INTO person * VALUES $Address.*",
-		err:   `cannot parse expression: column 29: invalid asterisk input placement "$Address.*"`,
+		err:   `cannot parse expression: column 29: invalid asterisk placement in input "$Address.*"`,
 	}, {
 		query: "INSERT INTO person * VALUES ($Address.*)",
-		err:   `cannot parse expression: column 30: invalid asterisk input placement "$Address.*"`,
+		err:   `cannot parse expression: column 30: invalid asterisk placement in input "$Address.*"`,
 	}, {
 		query: "INSERT INTO person VALUES ($Address.*)",
-		err:   `cannot parse expression: column 28: invalid asterisk input placement "$Address.*"`,
+		err:   `cannot parse expression: column 28: invalid asterisk placement in input "$Address.*"`,
 	}}
 
 	for _, t := range tests {

--- a/internal/expr/expr_test.go
+++ b/internal/expr/expr_test.go
@@ -484,8 +484,8 @@ func (s *ExprSuite) TestInsertInputParser(c *C) {
 		expectedParsed: "[Bypass[INSERT INTO address] AsteriskInput[[*] [Address.*]] Bypass[ RETURNING (] Output[[] [Address.*]] Bypass[)]]",
 	}, {
 		summary:        "insert rename columns with standalone inputs",
-		query:          `INSERT INTO person (id, street) VALUES ($Person.address_id, "random string", rand(), $Address.street)`,
-		expectedParsed: `[Bypass[INSERT INTO person (id, street) VALUES (] Input[Person.address_id] Bypass[, "random string", rand(), ] Input[Address.street] Bypass[)]]`,
+		query:          `INSERT INTO person (id, random_string, random_thing, street) VALUES ($Person.address_id, "random string", rand(), $Address.street)`,
+		expectedParsed: `[Bypass[INSERT INTO person (id, random_string, random_thing, street) VALUES (] Input[Person.address_id] Bypass[, "random string", rand(), ] Input[Address.street] Bypass[)]]`,
 	}, {
 		summary:        "insert single value",
 		query:          "INSERT INTO person (name) VALUES ($Person.name)",
@@ -636,9 +636,6 @@ of three lines' AND id = $Person.*`,
 	}, {
 		query: "INSERT INTO person * VALUES ($Address.*)",
 		err:   `cannot parse expression: column 30: invalid asterisk input placement "$Address.*"`,
-	}, {
-		query: "INSERT INTO person VALUES ($Address.*)",
-		err:   `cannot parse expression: column 28: invalid asterisk input placement "$Address.*"`,
 	}, {
 		query: "INSERT INTO person VALUES ($Address.*)",
 		err:   `cannot parse expression: column 28: invalid asterisk input placement "$Address.*"`,

--- a/internal/expr/expr_test.go
+++ b/internal/expr/expr_test.go
@@ -459,9 +459,17 @@ func (s *ExprSuite) TestInsertInputParser(c *C) {
 		query:          "INSERT INTO person (*) VALUES ($Address.street, $Person.*, $M.team)",
 		expectedParsed: "[Bypass[INSERT INTO person ] AsteriskInput[[*] [Address.street Person.* M.team]]]",
 	}, {
-		summary:        "insert specified columns",
+		summary:        "insert specified columns to single type",
 		query:          "INSERT INTO person (id, street) VALUES ($Address.*)",
 		expectedParsed: "[Bypass[INSERT INTO person ] ColumnInput[[id street] [Address.*]]]",
+	}, {
+		summary:        "insert specified columns to multiple types",
+		query:          "INSERT INTO person (id, street) VALUES ($Address.*, $M.street)",
+		expectedParsed: "[Bypass[INSERT INTO person ] ColumnInput[[id street] [Address.* M.street]]]",
+	}, {
+		summary:        "insert specified columns to multiple structs",
+		query:          "INSERT INTO person (name, street) VALUES ($Address.*, $Person.*)",
+		expectedParsed: "[Bypass[INSERT INTO person ] ColumnInput[[name street] [Address.* Person.*]]]",
 	}, {
 		summary:        "insert asterisk with comment",
 		query:          "INSERT INTO person (*) VALUES ($Person.address_id, /* rouge comment */$Address.street)",
@@ -634,15 +642,6 @@ of three lines' AND id = $Person.*`,
 	}, {
 		query: "INSERT INTO person VALUES ($Address.*)",
 		err:   `cannot parse expression: column 28: invalid asterisk input placement "$Address.*"`,
-	}, {
-		query: "INSERT INTO person (col1, col2) VALUES ($Address.*, $M.*)",
-		err:   `cannot parse expression: column 40: got multiple types in insert expression with columns`,
-	}, {
-		query: "INSERT INTO person (col1, col2) VALUES ($Address.*, $M.col2)",
-		err:   `cannot parse expression: column 40: got multiple types in insert expression with columns`,
-	}, {
-		query: "INSERT INTO person (col1, col2) VALUES ($M.col2, $Address.*)",
-		err:   `cannot parse expression: column 40: got multiple types in insert expression with columns`,
 	}}
 
 	for _, t := range tests {

--- a/internal/expr/expr_test.go
+++ b/internal/expr/expr_test.go
@@ -66,8 +66,8 @@ var tests = []struct {
 	typeSamples:    []any{Person{}},
 	expectedSQL:    "SELECT p.address_id AS _sqlair_0, p.id AS _sqlair_1, p.name AS _sqlair_2",
 }, {
-	summary: "spaces and tabs",
-	query: "SELECT p.* 	AS 		   &Person.*",
+	summary:        "spaces and tabs",
+	query:          "SELECT p.* 	AS 		   &Person.*",
 	expectedParsed: "[Bypass[SELECT ] Output[[p.*] [Person.*]]]",
 	typeSamples:    []any{Person{}},
 	expectedSQL:    "SELECT p.address_id AS _sqlair_0, p.id AS _sqlair_1, p.name AS _sqlair_2",
@@ -457,35 +457,35 @@ func (s *ExprSuite) TestInsertInputParser(c *C) {
 	}{{
 		summary:        "insert asterisk",
 		query:          "INSERT INTO person (*) VALUES ($Address.street, $Person.*, $M.team)",
-		expectedParsed: "[Bypass[INSERT INTO person ] AsteriskInput[[*] [Address.street Person.* M.team]]]",
+		expectedParsed: "[Bypass[INSERT INTO person ] AsteriskInsert[[*] [Address.street Person.* M.team]]]",
 	}, {
 		summary:        "insert specified columns to single type",
 		query:          "INSERT INTO person (id, street) VALUES ($Address.*)",
-		expectedParsed: "[Bypass[INSERT INTO person ] ColumnInput[[id street] [Address.*]]]",
+		expectedParsed: "[Bypass[INSERT INTO person ] ColumnInsert[[id street] [Address.*]]]",
 	}, {
 		summary:        "insert specified columns to multiple types",
 		query:          "INSERT INTO person (id, street) VALUES ($Address.*, $M.street)",
-		expectedParsed: "[Bypass[INSERT INTO person ] ColumnInput[[id street] [Address.* M.street]]]",
+		expectedParsed: "[Bypass[INSERT INTO person ] ColumnInsert[[id street] [Address.* M.street]]]",
 	}, {
 		summary:        "insert specified columns to multiple structs",
 		query:          "INSERT INTO person (name, street) VALUES ($Address.*, $Person.*)",
-		expectedParsed: "[Bypass[INSERT INTO person ] ColumnInput[[name street] [Address.* Person.*]]]",
+		expectedParsed: "[Bypass[INSERT INTO person ] ColumnInsert[[name street] [Address.* Person.*]]]",
 	}, {
 		summary:        "insert asterisk with comment",
 		query:          "INSERT INTO person (*) VALUES ($Person.address_id, /* rouge comment */$Address.street)",
-		expectedParsed: "[Bypass[INSERT INTO person ] AsteriskInput[[*] [Person.address_id Address.street]]]",
+		expectedParsed: "[Bypass[INSERT INTO person ] AsteriskInsert[[*] [Person.address_id Address.street]]]",
 	}, {
 		summary:        "insert asterisk (no space)",
 		query:          "INSERT INTO person(*) VALUES ($Person.*)ON CONFLICT DO NOTHING",
-		expectedParsed: "[Bypass[INSERT INTO person] AsteriskInput[[*] [Person.*]] Bypass[ON CONFLICT DO NOTHING]]",
+		expectedParsed: "[Bypass[INSERT INTO person] AsteriskInsert[[*] [Person.*]] Bypass[ON CONFLICT DO NOTHING]]",
 	}, {
 		summary:        "insert asterisk (weird spacing)",
 		query:          "INSERT INTO person ( * )VALUES( $Person.* )ON CONFLICT DO NOTHING",
-		expectedParsed: "[Bypass[INSERT INTO person ] AsteriskInput[[*] [Person.*]] Bypass[ON CONFLICT DO NOTHING]]",
+		expectedParsed: "[Bypass[INSERT INTO person ] AsteriskInsert[[*] [Person.*]] Bypass[ON CONFLICT DO NOTHING]]",
 	}, {
 		summary:        "insert with returning clause",
 		query:          "INSERT INTO address(*) VALUES($Address.*) RETURNING (&Address.*)",
-		expectedParsed: "[Bypass[INSERT INTO address] AsteriskInput[[*] [Address.*]] Bypass[ RETURNING (] Output[[] [Address.*]] Bypass[)]]",
+		expectedParsed: "[Bypass[INSERT INTO address] AsteriskInsert[[*] [Address.*]] Bypass[ RETURNING (] Output[[] [Address.*]] Bypass[)]]",
 	}, {
 		summary:        "insert rename columns with standalone inputs",
 		query:          `INSERT INTO person (id, random_string, random_thing, street) VALUES ($Person.address_id, "random string", rand(), $Address.street)`,

--- a/internal/expr/parser.go
+++ b/internal/expr/parser.go
@@ -780,9 +780,6 @@ func (p *Parser) parseMemberInputExpr() (*memberInputExpr, bool, error) {
 // It is of the form "(*) VALUES ($Type.*, $Type.member,...)".
 func (p *Parser) parseAsteriskInputExpr() (*asteriskInputExpr, bool, error) {
 	cp := p.save()
-
-	parenCol := p.colNum()
-	parenLine := p.lineNum
 	if !p.skipByte('(') {
 		return nil, false, nil
 	}
@@ -811,7 +808,7 @@ func (p *Parser) parseAsteriskInputExpr() (*asteriskInputExpr, bool, error) {
 	} else if !ok {
 		// Check for types with missing parentheses.
 		if _, ok, _ := p.parseInputMemberAccessor(); ok {
-			err = errorAt(fmt.Errorf(`missing parentheses around types after "VALUES"`), parenLine, parenCol, p.input)
+			err = errorAt(fmt.Errorf(`missing parentheses around types after "VALUES"`), cp.colNum(), cp.lineNum, p.input)
 		}
 		cp.restore()
 		return nil, false, err

--- a/internal/expr/parser.go
+++ b/internal/expr/parser.go
@@ -297,11 +297,7 @@ loop:
 			}
 			continue
 		}
-
 		p.advanceByte()
-		if p.pos == len(p.input) {
-			break loop
-		}
 	}
 
 	p.skipBlanks()

--- a/internal/expr/parser.go
+++ b/internal/expr/parser.go
@@ -743,9 +743,9 @@ func (p *Parser) parseInputExpr() (expression, bool, error) {
 	}
 
 	// Case 2: Struct or map, "$Type.something".
-	if ma, ok, err := p.parseTypeAndMember(); ok {
+	if ma, ok, err := p.parseInputMemberAccessor(); ok {
 		if ma.memberName == "*" {
-			return nil, false, errorAt(fmt.Errorf("asterisk not allowed in input expression %q", "$"+ma.String()), cp.lineNum, cp.colNum(), p.input)
+			return nil, false, errorAt(fmt.Errorf("asterisk not allowed in input outside insert statement %q", "$"+ma.String()), cp.lineNum, cp.colNum(), p.input)
 		}
 		return &memberInputExpr{ma: ma, raw: p.input[cp.pos:p.pos]}, true, nil
 	} else if err != nil {

--- a/internal/expr/parser.go
+++ b/internal/expr/parser.go
@@ -783,7 +783,8 @@ func (p *Parser) parseAsteriskInputExpr() (*asteriskInputExpr, bool, error) {
 	if !p.skipByte('(') {
 		return nil, false, nil
 	}
-	parenCol := p.pos
+	parenCol := p.colNum()
+	parenLine := p.lineNum
 	p.skipBlanks()
 	if !p.skipByte('*') {
 		cp.restore()
@@ -809,7 +810,7 @@ func (p *Parser) parseAsteriskInputExpr() (*asteriskInputExpr, bool, error) {
 	} else if !ok {
 		// Check for types with missing parentheses.
 		if _, ok, _ := p.parseInputMemberAccessor(); ok {
-			err = errorAt(fmt.Errorf(`missing parentheses around types after "VALUES"`), p.lineNum, parenCol, p.input)
+			err = errorAt(fmt.Errorf(`missing parentheses around types after "VALUES"`), parenLine, parenCol, p.input)
 		}
 		cp.restore()
 		return nil, false, err
@@ -838,6 +839,7 @@ func (p *Parser) parseColumnsInputExpr() (*columnsInputExpr, bool, error) {
 	p.skipBlanks()
 
 	parenCol := p.colNum()
+	parenLine := p.lineNum
 	// Ignore errors and leave them to be handled by
 	// parseMemberInputExpr later.
 	sources, ok, _ := parseList(p, (*Parser).parseInputMemberAccessor)
@@ -845,7 +847,7 @@ func (p *Parser) parseColumnsInputExpr() (*columnsInputExpr, bool, error) {
 		// Check for types with missing parentheses.
 		if _, ok, _ := p.parseTypeAndMember(); ok {
 			cp.restore()
-			return nil, false, errorAt(fmt.Errorf(`missing parentheses around types after "VALUES"`), p.lineNum, parenCol, p.input)
+			return nil, false, errorAt(fmt.Errorf(`missing parentheses around types after "VALUES"`), parenLine, parenCol, p.input)
 		}
 		cp.restore()
 		return nil, false, nil

--- a/internal/expr/parser.go
+++ b/internal/expr/parser.go
@@ -808,7 +808,7 @@ func (p *Parser) parseAsteriskInputExpr() (*asteriskInputExpr, bool, error) {
 	} else if !ok {
 		// Check for types with missing parentheses.
 		if _, ok, _ := p.parseInputMemberAccessor(); ok {
-			err = errorAt(fmt.Errorf(`missing parentheses around types after "VALUES"`), cp.colNum(), cp.lineNum, p.input)
+			err = errorAt(fmt.Errorf(`missing parentheses around types after "VALUES"`), cp.lineNum, cp.colNum(), p.input)
 		}
 		cp.restore()
 		return nil, false, err

--- a/internal/expr/parser.go
+++ b/internal/expr/parser.go
@@ -832,20 +832,14 @@ func (p *Parser) parseColumnsInputExpr() (*columnsInputExpr, bool, error) {
 		cp.restore()
 		return nil, false, nil
 	}
-	if len(sources) > 1 {
-		if starCountTypes(sources) > 0 {
-			err := errorAt(fmt.Errorf("got multiple types in insert expression with columns"), p.lineNum, parenCol, p.input)
-			cp.restore()
-			return nil, false, err
-		}
-	}
-	if sources[0].memberName != "*" {
-		// leave this case to be parsed by parseMemberInputExpr later.
+	if starCountTypes(sources) == 0 {
+		// If there are no asterisk accessors leave the accessors to be handled
+		// by parseMemberInputExpr later.
 		cp.restore()
 		return nil, false, nil
 	}
 
-	return &columnsInputExpr{columns: columns, typeName: sources[0].typeName, raw: p.input[cp.pos:p.pos]}, true, nil
+	return &columnsInputExpr{columns: columns, sources: sources, raw: p.input[cp.pos:p.pos]}, true, nil
 }
 
 // parseInputExpr parses all forms of input expressions, that is, expressions

--- a/internal/expr/parser.go
+++ b/internal/expr/parser.go
@@ -64,6 +64,8 @@ func (p *Parser) Parse(input string) (pe *ParsedExpr, err error) {
 			continue
 		}
 
+		// No expression found, advance the parser. This prevents
+		// advanceToNextExpression finding the same char again.
 		p.advanceByte()
 	}
 
@@ -779,11 +781,11 @@ func (p *Parser) parseMemberInputExpr() (*memberInputExpr, bool, error) {
 func (p *Parser) parseAsteriskInputExpr() (*asteriskInputExpr, bool, error) {
 	cp := p.save()
 
+	parenCol := p.colNum()
+	parenLine := p.lineNum
 	if !p.skipByte('(') {
 		return nil, false, nil
 	}
-	parenCol := p.colNum()
-	parenLine := p.lineNum
 	p.skipBlanks()
 	if !p.skipByte('*') {
 		cp.restore()

--- a/internal/expr/parser.go
+++ b/internal/expr/parser.go
@@ -759,7 +759,7 @@ func (p *Parser) parseInputExpr() (expression, bool, error) {
 		if sources, ok, err := parseList(p, (*Parser).parseInputMemberAccessor); err != nil {
 			return nil, false, err
 		} else if ok {
-			return &insertIntoAsteriskExpr{sources: sources, raw: p.input[cp.pos:p.pos]}, true, nil
+			return &insertToAsteriskExpr{sources: sources, raw: p.input[cp.pos:p.pos]}, true, nil
 		}
 		// Check for types with missing parentheses.
 		if _, ok, err := p.parseTypeAndMember(); err != nil {
@@ -791,7 +791,7 @@ func (p *Parser) parseInputExpr() (expression, bool, error) {
 					cp.restore()
 					return nil, false, nil
 				}
-				return &insertIntoColumnsExpr{
+				return &insertToColumnsExpr{
 					columns:  columns,
 					typeName: sources[0].typeName,
 					raw:      p.input[cp.pos:p.pos],

--- a/internal/expr/parser_helper_test.go
+++ b/internal/expr/parser_helper_test.go
@@ -263,7 +263,7 @@ func (s parseSuite) TestAdvanceToNextExpr(c *C) {
 		stopPos: []int{0},
 	}, {
 		input:   `word,&`,
-		stopPos: []int{5},
+		stopPos: []int{0, 5},
 	}, {
 		input:   ` ,&`,
 		stopPos: []int{2},
@@ -291,14 +291,15 @@ func (s parseSuite) TestAdvanceToNextExpr(c *C) {
 			err := p.advanceToNextExpression()
 			c.Assert(err, IsNil)
 			if p.pos >= len(p.input) {
+				c.Assert(currentStopPos, Equals, len(t.stopPos), Commentf("input: %q", t.input))
 				break
 			}
 
-			if len(t.stopPos) <= currentStopPos {
+			if currentStopPos >= len(t.stopPos) {
 				c.Fatalf("unexpected extra stop at position %d with input %s",
 					p.pos, t.input)
 			}
-			c.Assert(p.pos, Equals, t.stopPos[currentStopPos])
+			c.Assert(p.pos, Equals, t.stopPos[currentStopPos], Commentf("input: %q", t.input))
 			currentStopPos++
 
 			p.advanceByte()

--- a/internal/expr/parser_helper_test.go
+++ b/internal/expr/parser_helper_test.go
@@ -251,6 +251,17 @@ func (s parseSuite) TestAdvanceToNextExpr(c *C) {
 		input   string
 		stopPos []int
 	}{{
+		// advanceToNextExpr stops on the first char if it is the start of the
+		// expr.
+		input:   `col1`,
+		stopPos: []int{0},
+	}, {
+		input:   `&col`,
+		stopPos: []int{0},
+	}, {
+		input:   `$col`,
+		stopPos: []int{0},
+	}, {
 		input:   `word,&`,
 		stopPos: []int{5},
 	}, {

--- a/internal/expr/parser_helper_test.go
+++ b/internal/expr/parser_helper_test.go
@@ -243,3 +243,54 @@ func (s parseSuite) TestParseSliceRange(c *C) {
 		}
 	}
 }
+
+func (s parseSuite) TestAdvanceToNextExpr(c *C) {
+	var p = NewParser()
+
+	tests := []struct {
+		input   string
+		stopPos []int
+	}{{
+		input:   `word,&`,
+		stopPos: []int{5},
+	}, {
+		input:   ` ,&`,
+		stopPos: []int{2},
+	}, {
+		input:   ` col1`,
+		stopPos: []int{1},
+	}, {
+		input:   `/* &Person.* */`,
+		stopPos: []int{},
+	}, {
+		input:   `" &Person.*"`,
+		stopPos: []int{},
+	}, {
+		input:   ` ""`,
+		stopPos: []int{},
+	}, {
+		input:   ` /**/`,
+		stopPos: []int{},
+	}}
+
+	for _, t := range tests {
+		p.init(t.input)
+		currentStopPos := 0
+		for p.pos < len(p.input) {
+			err := p.advanceToNextExpression()
+			c.Assert(err, IsNil)
+			if p.pos >= len(p.input) {
+				break
+			}
+
+			if len(t.stopPos) <= currentStopPos {
+				c.Fatalf("unexpected extra stop at position %d with input %s",
+					p.pos, t.input)
+			}
+			c.Assert(p.pos, Equals, t.stopPos[currentStopPos])
+			currentStopPos++
+
+			p.advanceByte()
+		}
+	}
+}


### PR DESCRIPTION
This PR adds parsing support for two new forms of input expression. These will allow ergonomic type mapping with INSERT statements. The new forms match the existing forms of output expression. More information can be found in  [Spec PL014](https://docs.google.com/document/d/1DMKPS85msymrdbA5-EoP4Sf6b9blSAjtj367EuEmP7Y/edit#heading=h.jytz1gr6mmar).

The new forms of input expression are:

#### 1. Insert all Go values on the right hand side into the table.
```
INSERT INTO table (*) VALUES (<accessorList>)
```
`<accessorList>` is a comma separated list of Go object accessors. 

The object accessors are the form:
`$Struct.tag` - This will cause the value in the field with the “db” tag `tag` of Struct to be inserted into the column with the name `tag`.
`$Map.key` will cause the value at location `key` in Map to be inserted into the column `key`.
`$Struct.*` will cause all values in fields with “db” tags in Struct to be inserted into the column named by the tag.

This syntax allows columns from multiple Go objects to be inserted without separately enumerating the columns. It is expected to be used in the majority of situations.

#### 2. Insert specific columns from Go value.
The syntax makes it easy to insert a small subset of columns from types containing many.

```
INSERT INTO table (<colList>) VALUES (<accessorList>)
```
`<colList>` is a comma separated list of column names and <accessorList> is a comma separated list of Go object accessors.

The different object accessors having the following meanings:
`$Struct.tag` - The tag must match a column `<colList>`. The value in the struct will be inserted into the column tag.
`$Map.key` - The key must match a column `<colList>`. The value at key in the map will be inserted into the column key.
`$Struct.*` - Any values with tags matching a column in `<colList>` will be inserted.
`$Map.*` - columns in `<colList>` that are not captured by another object assessor are drawn from the map. It must be unambiguous which columns are to be found in Map  when the query is prepared or an error will be returned (e.g. a query with two $Map.* accessors is ambiguous).