### PR TITLE
Add bindTypes method to expression

### DIFF
--- a/internal/expr/bindtypes.go
+++ b/internal/expr/bindtypes.go
@@ -49,31 +49,19 @@ func (pe *ParsedExpr) BindTypes(args ...any) (tbe *TypeBoundExpr, err error) {
 	// Bind types to each expression.
 	var typedExprs TypeBoundExpr
 	outputUsed := map[string]bool{}
-	var te any
 	for _, expr := range pe.exprs {
-		switch e := expr.(type) {
-		case *inputExpr:
-			te, err = bindInputTypes(e, argInfo)
-			if err != nil {
-				return nil, err
-			}
-		case *outputExpr:
-			toe, err := bindOutputTypes(e, argInfo)
-			if err != nil {
-				return nil, err
-			}
+		te, err := expr.bindTypes(argInfo)
+		if err != nil {
+			return nil, err
+		}
 
+		if toe, ok := te.(*typedOutputExpr); ok {
 			for _, oc := range toe.outputColumns {
 				if ok := outputUsed[oc.output.Identifier()]; ok {
 					return nil, fmt.Errorf("%s appears more than once in output expressions", oc.output.Desc())
 				}
 				outputUsed[oc.output.Identifier()] = true
 			}
-			te = toe
-		case *bypass:
-			te = e
-		default:
-			return nil, fmt.Errorf("internal error: unknown query expr type %T", expr)
 		}
 		typedExprs = append(typedExprs, te)
 	}
@@ -81,37 +69,77 @@ func (pe *ParsedExpr) BindTypes(args ...any) (tbe *TypeBoundExpr, err error) {
 	return &typedExprs, nil
 }
 
-// bindInputTypes binds the input expression to a query type and returns a typed
-// input expression.
-func bindInputTypes(e *inputExpr, argInfo typeinfo.ArgInfo) (te *typedInputExpr, err error) {
-	defer func() {
-		if err != nil {
-			err = fmt.Errorf("input expression: %s: %s", err, e.raw)
-		}
-	}()
+// expression represents a parsed node of the SQLair query's AST.
+type expression interface {
+	// String returns a text representation for debugging and testing purposes.
+	String() string
 
-	var input typeinfo.Input
-	switch a := e.sourceType.(type) {
-	case memberAccessor:
-		input, err = argInfo.InputMember(a.typeName, a.memberName)
-		if err != nil {
-			return nil, err
-		}
-	case sliceAccessor:
-		input, err = argInfo.InputSlice(a.typeName)
-		if err != nil {
-			return nil, err
-		}
-	default:
-		return nil, fmt.Errorf("internal error: unknown type %T", a)
+	// bindTypes binds the types to the expression to generate either a
+	// *typedInputExpr or *typedOutputExpr.
+	bindTypes(typeinfo.ArgInfo) (any, error)
+}
+
+// memberInputExpr is an input expression of the form "$Type.member" which
+// represents a query parameter contained in a member of a type.
+type memberInputExpr struct {
+	raw string
+	ma  memberAccessor
+}
+
+// String returns a text representation for debugging and testing purposes.
+func (e *memberInputExpr) String() string {
+	return fmt.Sprintf("Input[%+v]", e.ma)
+}
+
+// bindTypes generates a *typedInputExpr containing type information about the
+// Go object and its member.
+func (e *memberInputExpr) bindTypes(argInfo typeinfo.ArgInfo) (any, error) {
+	input, err := argInfo.InputMember(e.ma.typeName, e.ma.memberName)
+	if err != nil {
+		return nil, fmt.Errorf("input expression: %s: %s", err, e.raw)
 	}
 	return &typedInputExpr{input}, nil
 }
 
-// bindOutputTypes binds the output expression to concrete types. It then checks the
-// expression valid with respect to its bound types and generates a typed output
-// expression.
-func bindOutputTypes(e *outputExpr, argInfo typeinfo.ArgInfo) (te *typedOutputExpr, err error) {
+// sliceInputExpr is an input expression of the form "$S[:]" that represents a
+// slice of query parameters.
+type sliceInputExpr struct {
+	raw           string
+	sliceTypeName string
+}
+
+// String returns a text representation for debugging and testing purposes.
+func (e *sliceInputExpr) String() string {
+	return fmt.Sprintf("Input[%s[:]]", e.sliceTypeName)
+}
+
+// bindTypes generates a *typedInputExpr containing type information about the
+// slice.
+func (e *sliceInputExpr) bindTypes(argInfo typeinfo.ArgInfo) (any, error) {
+	input, err := argInfo.InputSlice(e.sliceTypeName)
+	if err != nil {
+		return nil, fmt.Errorf("input expression: %s: %s", err, e.raw)
+	}
+	return &typedInputExpr{input}, nil
+}
+
+// outputExpr represents columns to be read from the database and Go values to
+// scan them into.
+type outputExpr struct {
+	sourceColumns []columnAccessor
+	targetTypes   []memberAccessor
+	raw           string
+}
+
+// String returns a text representation for debugging and testing purposes.
+func (e *outputExpr) String() string {
+	return fmt.Sprintf("Output[%+v %+v]", e.sourceColumns, e.targetTypes)
+}
+
+// bindTypes binds the output expression to concrete types. It then checks the
+// expression valid with respect to its bound types and returns a
+// *typedOutputExpr.
+func (e *outputExpr) bindTypes(argInfo typeinfo.ArgInfo) (te any, err error) {
 	defer func() {
 		if err != nil {
 			err = fmt.Errorf("output expression: %s: %s", err, e.raw)

--- a/internal/expr/bindtypes.go
+++ b/internal/expr/bindtypes.go
@@ -79,6 +79,23 @@ type expression interface {
 	bindTypes(typeinfo.ArgInfo) (any, error)
 }
 
+// bypass represents part of the expression that we want to pass to the backend
+// database verbatim.
+type bypass struct {
+	chunk string
+}
+
+// String returns a text representation for debugging and testing purposes.
+func (b *bypass) String() string {
+	return "Bypass[" + b.chunk + "]"
+}
+
+// bindTypes returns the bypass part itself since it contains no references to
+// types.
+func (b *bypass) bindTypes(typeinfo.ArgInfo) (any, error) {
+	return b, nil
+}
+
 // memberInputExpr is an input expression of the form "$Type.member" which
 // represents a query parameter contained in a member of a type.
 type memberInputExpr struct {
@@ -137,7 +154,7 @@ func (e *outputExpr) String() string {
 }
 
 // bindTypes binds the output expression to concrete types. It then checks the
-// expression valid with respect to its bound types and returns a
+// expression is valid with respect to its bound types and returns a
 // *typedOutputExpr.
 func (e *outputExpr) bindTypes(argInfo typeinfo.ArgInfo) (te any, err error) {
 	defer func() {

--- a/internal/expr/parser.go
+++ b/internal/expr/parser.go
@@ -563,7 +563,7 @@ func (p *Parser) parseTargetType() (memberAccessor, bool, error) {
 
 // parseSliceAccessor parses a slice accessor. A slice accessor is of the form
 // "SliceType[:]". It returns the parsed slice type name.
-func (p *Parser) parseSliceAccessor() (string, bool, error) {
+func (p *Parser) parseSliceAccessor() (typeName string, ok bool, err error) {
 	cp := p.save()
 
 	id, ok := p.parseIdentifier()

--- a/internal/expr/parser.go
+++ b/internal/expr/parser.go
@@ -561,7 +561,8 @@ func (p *Parser) parseTargetType() (memberAccessor, bool, error) {
 	return memberAccessor{}, false, nil
 }
 
-// parseSliceAccessor parses a slice range composed of the form "[:]".
+// parseSliceAccessor parses a slice accessor. A slice accessor is of the form
+// "SliceType[:]". It returns the parsed slice type name.
 func (p *Parser) parseSliceAccessor() (string, bool, error) {
 	cp := p.save()
 

--- a/internal/expr/parser.go
+++ b/internal/expr/parser.go
@@ -6,6 +6,8 @@ package expr
 import (
 	"fmt"
 	"strings"
+
+	"github.com/canonical/sqlair/internal/typeinfo"
 )
 
 func NewParser() *Parser {
@@ -71,22 +73,6 @@ func (p *Parser) Parse(input string) (pe *ParsedExpr, err error) {
 	return &ParsedExpr{exprs: p.exprs}, nil
 }
 
-// expression represents a parsed node of the SQLair query's AST.
-type expression interface {
-	// String returns a text representation for debugging and testing purposes.
-	String() string
-
-	// marker method
-	expr()
-}
-
-// valueAccessor stores information about how to access a Go value. For example:
-// by index, by key, or by slice syntax.
-type valueAccessor interface {
-	fmt.Stringer
-	getTypeName() string
-}
-
 // memberAccessor stores information for accessing a keyed Go value. It consists
 // of a type name and some value within it to be accessed. For example: a field
 // of a struct, or a key of a map.
@@ -100,20 +86,6 @@ func (ma memberAccessor) String() string {
 
 func (ma memberAccessor) getTypeName() string {
 	return ma.typeName
-}
-
-// sliceAccessor stores information for accessing a slice using the
-// expression "typeName[:]".
-type sliceAccessor struct {
-	typeName string
-}
-
-func (st sliceAccessor) String() string {
-	return fmt.Sprintf("%s[:]", st.typeName)
-}
-
-func (sa sliceAccessor) getTypeName() string {
-	return sa.typeName
 }
 
 type columnAccessor interface {
@@ -159,44 +131,22 @@ func (sfc sqlFunctionCall) String() string {
 	return sfc.raw
 }
 
-// inputExpr represents a named parameter that will be sent to the database
-// while performing the query.
-type inputExpr struct {
-	sourceType valueAccessor
-	raw        string
-}
-
-func (p *inputExpr) String() string {
-	return fmt.Sprintf("Input[%+v]", p.sourceType)
-}
-
-func (p *inputExpr) expr() {}
-
-// outputExpr represents a named target output variable in the SQL expression,
-// as well as the source table and column where it will be read from.
-type outputExpr struct {
-	sourceColumns []columnAccessor
-	targetTypes   []memberAccessor
-	raw           string
-}
-
-func (p *outputExpr) String() string {
-	return fmt.Sprintf("Output[%+v %+v]", p.sourceColumns, p.targetTypes)
-}
-
-func (p *outputExpr) expr() {}
-
 // bypass represents part of the expression that we want to pass to the backend
 // database verbatim.
 type bypass struct {
 	chunk string
 }
 
-func (p *bypass) String() string {
-	return "Bypass[" + p.chunk + "]"
+// String returns a text representation for debugging and testing purposes.
+func (b *bypass) String() string {
+	return "Bypass[" + b.chunk + "]"
 }
 
-func (p *bypass) expr() {}
+// bindTypes returns the bypass part itself since it contains no references to
+// types.
+func (b *bypass) bindTypes(typeinfo.ArgInfo) (any, error) {
+	return b, nil
+}
 
 // init resets the state of the parser and sets the input string.
 func (p *Parser) init(input string) {
@@ -601,7 +551,7 @@ func (p *Parser) parseTargetType() (memberAccessor, bool, error) {
 		// Using a slice as an output is an error, we add the case here to
 		// improve the error message.
 		if st, ok, err := p.parseSliceAccessor(); ok {
-			return memberAccessor{}, false, errorAt(fmt.Errorf("cannot use slice syntax %q in output expression", st), startLine, startCol, p.input)
+			return memberAccessor{}, false, errorAt(fmt.Errorf(`cannot use slice syntax "%s[:]" in output expression`, st), startLine, startCol, p.input)
 		} else if err != nil {
 			return memberAccessor{}, false, errorAt(fmt.Errorf("cannot use slice syntax in output expression"), startLine, startCol, p.input)
 		}
@@ -612,26 +562,26 @@ func (p *Parser) parseTargetType() (memberAccessor, bool, error) {
 }
 
 // parseSliceAccessor parses a slice range composed of the form "[:]".
-func (p *Parser) parseSliceAccessor() (sa sliceAccessor, ok bool, err error) {
+func (p *Parser) parseSliceAccessor() (string, bool, error) {
 	cp := p.save()
 
 	id, ok := p.parseIdentifier()
 	if !ok {
-		return sliceAccessor{}, false, nil
+		return "", false, nil
 	}
 	if !p.skipByte('[') {
 		cp.restore()
-		return sliceAccessor{}, false, nil
+		return "", false, nil
 	}
 	p.skipBlanks()
 	if !p.skipByte(':') {
-		return sliceAccessor{}, false, errorAt(fmt.Errorf("invalid slice: expected '%s[:]'", id), cp.lineNum, cp.colNum(), p.input)
+		return "", false, errorAt(fmt.Errorf("invalid slice: expected '%s[:]'", id), cp.lineNum, cp.colNum(), p.input)
 	}
 	p.skipBlanks()
 	if !p.skipByte(']') {
-		return sliceAccessor{}, false, errorAt(fmt.Errorf("invalid slice: expected '%s[:]'", id), cp.lineNum, cp.colNum(), p.input)
+		return "", false, errorAt(fmt.Errorf("invalid slice: expected '%s[:]'", id), cp.lineNum, cp.colNum(), p.input)
 	}
-	return sliceAccessor{typeName: id}, true, nil
+	return id, true, nil
 }
 
 // parseTypeAndMember parses a Go type name qualified by a tag name (or asterisk)
@@ -785,7 +735,7 @@ func (p *Parser) parseOutputExpr() (*outputExpr, bool, error) {
 }
 
 // parseInputExpr parses an input expression of the form "$Type.name".
-func (p *Parser) parseInputExpr() (*inputExpr, bool, error) {
+func (p *Parser) parseInputExpr() (expression, bool, error) {
 	cp := p.save()
 	if !p.skipByte('$') {
 		return nil, false, nil
@@ -795,15 +745,15 @@ func (p *Parser) parseInputExpr() (*inputExpr, bool, error) {
 	if st, ok, err := p.parseSliceAccessor(); err != nil {
 		return nil, false, err
 	} else if ok {
-		return &inputExpr{sourceType: st, raw: p.input[cp.pos:p.pos]}, true, nil
+		return &sliceInputExpr{sliceTypeName: st, raw: p.input[cp.pos:p.pos]}, true, nil
 	}
 
 	// Case 2: Struct or map, "Type.something".
-	if tn, ok, err := p.parseTypeAndMember(); ok {
-		if tn.memberName == "*" {
-			return nil, false, errorAt(fmt.Errorf("asterisk not allowed in input expression %q", "$"+tn.String()), cp.lineNum, cp.colNum(), p.input)
+	if ma, ok, err := p.parseTypeAndMember(); ok {
+		if ma.memberName == "*" {
+			return nil, false, errorAt(fmt.Errorf("asterisk not allowed in input expression %q", "$"+ma.String()), cp.lineNum, cp.colNum(), p.input)
 		}
-		return &inputExpr{sourceType: tn, raw: p.input[cp.pos:p.pos]}, true, nil
+		return &memberInputExpr{ma: ma, raw: p.input[cp.pos:p.pos]}, true, nil
 	} else if err != nil {
 		return nil, false, err
 	}

--- a/internal/expr/parser.go
+++ b/internal/expr/parser.go
@@ -6,8 +6,6 @@ package expr
 import (
 	"fmt"
 	"strings"
-
-	"github.com/canonical/sqlair/internal/typeinfo"
 )
 
 func NewParser() *Parser {
@@ -129,23 +127,6 @@ func (sfc sqlFunctionCall) tableName() string {
 
 func (sfc sqlFunctionCall) String() string {
 	return sfc.raw
-}
-
-// bypass represents part of the expression that we want to pass to the backend
-// database verbatim.
-type bypass struct {
-	chunk string
-}
-
-// String returns a text representation for debugging and testing purposes.
-func (b *bypass) String() string {
-	return "Bypass[" + b.chunk + "]"
-}
-
-// bindTypes returns the bypass part itself since it contains no references to
-// types.
-func (b *bypass) bindTypes(typeinfo.ArgInfo) (any, error) {
-	return b, nil
 }
 
 // init resets the state of the parser and sets the input string.

--- a/internal/expr/parser_helper_test.go
+++ b/internal/expr/parser_helper_test.go
@@ -204,11 +204,11 @@ func (s parseSuite) TestRemoveComments(c *C) {
 func (s parseSuite) TestParseSliceRange(c *C) {
 	sliceRangeTests := []struct {
 		input    string
-		expected valueAccessor
+		expected string
 		err      string
 	}{
-		{input: "mySlice[:]", expected: sliceAccessor{typeName: "mySlice"}},
-		{input: "mySlice[ : ]", expected: sliceAccessor{typeName: "mySlice"}},
+		{input: "mySlice[:]", expected: "mySlice"},
+		{input: "mySlice[ : ]", expected: "mySlice"},
 		{input: "mySlice[]", err: "column 1: invalid slice: expected 'mySlice[:]'"},
 		{input: "mySlice[1:10]", err: "column 1: invalid slice: expected 'mySlice[:]'"},
 		{input: "mySlice[1:]", err: "column 1: invalid slice: expected 'mySlice[:]'"},


### PR DESCRIPTION
This PR adds a `bindTypes` method to expression. The functions `bindInputExpr` and `bindOutputExpr` are refactored into this new method. This PR also separates the `inputExpr` into two separate expressions, `memberInputExpr` and `sliceInputExpr`.

The `valueAccessor` interface is removed as it is no longer a useful abstraction with the addition of the separate input expression types above.

This PR is motivated by the upcoming support for input expressions in INSERT statements which will require a new kind in input expression. Rather than overload the current `inputExpr` it makes sense to split it into three types. `insertInputExpr`, `sliceInputExpr` and `memberInputExpr`. These types can then each have their own `bindTypes` function which will handle the type samples from the user appropriately depending on the type of expression.

Going forward, it would also be natural to split the `outputExpr` into three separate types of expression. Currently `bindOutputTypes` has three separate cases (defined in comments rather than by separate methods) for the different forms output expressions. By codifying these as three different types it would make the code far more maintainable.
