### PR TITLE
bugfix: ignore SQL function calls in output expressions 

### DIFF
--- a/internal/expr/bindtypes.go
+++ b/internal/expr/bindtypes.go
@@ -125,7 +125,7 @@ func bindOutputTypes(e *outputExpr, argInfo typeinfo.ArgInfo) (te *typedOutputEx
 		pref := ""
 		// Prepend table name. E.g. "t" in "t.* AS &P.*".
 		if numColumns > 0 {
-			pref = e.sourceColumns[0].tableName
+			pref = e.sourceColumns[0].tableName()
 		}
 
 		for _, t := range e.targetTypes {
@@ -157,11 +157,11 @@ func bindOutputTypes(e *outputExpr, argInfo typeinfo.ArgInfo) (te *typedOutputEx
 	// Case 2: Explicit columns, single asterisk type e.g. "(col1, t.col2) AS &P.*".
 	if starTypes == 1 && numTypes == 1 {
 		for _, c := range e.sourceColumns {
-			output, err := argInfo.OutputMember(e.targetTypes[0].typeName, c.columnName)
+			output, err := argInfo.OutputMember(e.targetTypes[0].typeName, c.columnName())
 			if err != nil {
 				return nil, err
 			}
-			oc := newOutputColumn(c.tableName, c.columnName, output)
+			oc := newOutputColumn(c.tableName(), c.columnName(), output)
 			toe.outputColumns = append(toe.outputColumns, oc)
 		}
 		return toe, nil
@@ -177,7 +177,7 @@ func bindOutputTypes(e *outputExpr, argInfo typeinfo.ArgInfo) (te *typedOutputEx
 			if err != nil {
 				return nil, err
 			}
-			oc := newOutputColumn(c.tableName, c.columnName, output)
+			oc := newOutputColumn(c.tableName(), c.columnName(), output)
 			toe.outputColumns = append(toe.outputColumns, oc)
 		}
 	} else {
@@ -191,7 +191,7 @@ func bindOutputTypes(e *outputExpr, argInfo typeinfo.ArgInfo) (te *typedOutputEx
 func starCountColumns(cs []columnAccessor) int {
 	s := 0
 	for _, c := range cs {
-		if c.columnName == "*" {
+		if c.columnName() == "*" {
 			s++
 		}
 	}

--- a/internal/expr/expr_test.go
+++ b/internal/expr/expr_test.go
@@ -337,6 +337,14 @@ AND z = @sqlair_0 -- The line with $Person.id on it
 	inputArgs:      []any{HardMaths{X: 1, Y: 2}},
 	expectedParams: []any{1, 2},
 	expectedSQL:    "INSERT INTO arr VALUES (ARRAY[[1,2],[@sqlair_0,4]], ARRAY[[5,6],[@sqlair_1,8]]);",
+}, {
+	summary:        "functions",
+	query:          `SELECT (max(AVG(id), AVG(address_id), length("((((''""((")), IFNULL(name, "Mr &Person.id of $M.name")) AS (&M.avg, &M.name), random() AS &M.random FROM person`,
+	expectedParsed: `[Bypass[SELECT ] Output[[max(AVG(id), AVG(address_id), length("((((''""((")) IFNULL(name, "Mr &Person.id of $M.name")] [M.avg M.name]] Bypass[, ] Output[[random()] [M.random]] Bypass[ FROM person]]`,
+	typeSamples:    []any{sqlair.M{}},
+	inputArgs:      []any{},
+	expectedParams: []any{},
+	expectedSQL:    `SELECT max(AVG(id), AVG(address_id), length("((((''""((")) AS _sqlair_0, IFNULL(name, "Mr &Person.id of $M.name") AS _sqlair_1, random() AS _sqlair_2 FROM person`,
 }}
 
 func (s *ExprSuite) TestExprPkg(c *C) {
@@ -494,6 +502,12 @@ of three lines' AND id = $Person.*`,
 	}, {
 		query: "SELECT * FROM t WHERE id = $ids[]",
 		err:   `cannot parse expression: column 29: invalid slice: expected 'ids[:]'`,
+	}, {
+		query: "SELECT count(*) AS &M.* FROM t",
+		err:   `cannot parse expression: column 8: cannot read function call "count(*)" into asterisk`,
+	}, {
+		query: "SELECT (id, count(*)) AS (&M.*) FROM t",
+		err:   `cannot parse expression: column 8: cannot read function call "count(*)" into asterisk`,
 	}}
 
 	for _, t := range tests {

--- a/internal/expr/parser.go
+++ b/internal/expr/parser.go
@@ -522,7 +522,7 @@ func (p *Parser) parseIdentifier() (string, bool) {
 }
 
 // skipEnclosedParentheses starts from a opening parenthesis '(' and skips until
-// its enclosing ')', taking into account comments and string literals in between.
+// its closing ')', taking into account comments and string literals in between.
 func (p *Parser) skipEnclosedParentheses() (bool, error) {
 	initialCol, initialLine := p.colNum(), p.lineNum
 

--- a/internal/expr/parser_helper_test.go
+++ b/internal/expr/parser_helper_test.go
@@ -11,6 +11,10 @@ type parseSuite struct{}
 
 var _ = Suite(&parseSuite{})
 
+// Type assertions.
+var _ columnAccessor = sqlFunctionCall{}
+var _ columnAccessor = basicColumn{}
+
 type parseHelperTest struct {
 	bytef    func(byte) bool
 	stringf  func(string) bool

--- a/internal/expr/parser_helper_test.go
+++ b/internal/expr/parser_helper_test.go
@@ -15,9 +15,11 @@ type parseHelperTest struct {
 	bytef    func(byte) bool
 	stringf  func(string) bool
 	stringf0 func() bool
+	stringf1 func() (bool, error)
 	result   []bool
 	input    string
 	data     []string
+	err      string
 }
 
 func (s parseSuite) TestRunTable(c *C) {
@@ -55,12 +57,24 @@ func (s parseSuite) TestRunTable(c *C) {
 		{stringf0: p.skipName, result: []bool{false}, input: "*", data: []string{}},
 		{stringf0: p.skipName, result: []bool{true}, input: "hello", data: []string{}},
 		{stringf0: p.skipName, result: []bool{false}, input: "2d3d", data: []string{}},
+
+		{stringf1: p.skipEnclosedParentheses, result: []bool{false}, input: `count *`},
+		{stringf1: p.skipEnclosedParentheses, result: []bool{false}, input: `)`},
+		{stringf1: p.skipEnclosedParentheses, result: []bool{false}, input: `(")"`, err: `column 1: missing closing parenthesis`},
+		{stringf1: p.skipEnclosedParentheses, result: []bool{false}, input: `(--)`, err: `column 1: missing closing parenthesis`},
+		{stringf1: p.skipEnclosedParentheses, result: []bool{false}, input: `(/*)*/`, err: `column 1: missing closing parenthesis`},
+		{stringf1: p.skipEnclosedParentheses, result: []bool{true}, input: `()`},
+		{stringf1: p.skipEnclosedParentheses, result: []bool{true}, input: `(columnName)`},
+		{stringf1: p.skipEnclosedParentheses, result: []bool{true}, input: `(/*)(""*/)`},
+		{stringf1: p.skipEnclosedParentheses, result: []bool{true}, input: `(")")`},
+		{stringf1: p.skipEnclosedParentheses, result: []bool{true}, input: `("/*)*/")`},
 	}
 	for _, v := range parseTests {
 		// Reset the input.
 		p.init(v.input)
 		for i, _ := range v.result {
 			var result bool
+			var err error
 			if v.bytef != nil {
 				result = v.bytef(v.data[i][0])
 			}
@@ -70,8 +84,14 @@ func (s parseSuite) TestRunTable(c *C) {
 			if v.stringf0 != nil {
 				result = v.stringf0()
 			}
+			if v.stringf1 != nil {
+				result, err = v.stringf1()
+			}
 			if v.result[i] != result {
 				c.Errorf("Test %#v failed. Expected: '%t', got '%t'\n", v, v.result[i], result)
+			}
+			if v.err != "" {
+				c.Check(err, ErrorMatches, v.err)
 			}
 		}
 	}

--- a/package_test.go
+++ b/package_test.go
@@ -512,6 +512,13 @@ func (s *PackageSuite) TestValidGet(c *C) {
 		inputs:   []any{sqlair.M{"p1": 1000}},
 		outputs:  []any{sqlair.M{}},
 		expected: []any{sqlair.M{"name": "Fred"}},
+	}, {
+		summary:  "sql functions",
+		query:    `SELECT (max(AVG(id), AVG(address_id), length("((((''""((")), IFNULL(name, "Mr &Person.id of $M.name")) AS (&M.avg, &M.name), round(24.5234) AS other_col FROM person`,
+		types:    []any{sqlair.M{}},
+		inputs:   []any{},
+		outputs:  []any{sqlair.M{}},
+		expected: []any{sqlair.M{"avg": float64(2625), "name": "Fred"}},
 	}}
 
 	tables, sqldb, err := personAndAddressDB(c)


### PR DESCRIPTION
The parser now works when using SQL functions instead of column names in
output expressions.