### PR TITLE
Move input and output argument validation to typeinfo package

### DIFF
--- a/internal/expr/expr_test.go
+++ b/internal/expr/expr_test.go
@@ -62,8 +62,8 @@ var tests = []struct {
 	typeSamples:    []any{Person{}},
 	expectedSQL:    "SELECT p.address_id AS _sqlair_0, p.id AS _sqlair_1, p.name AS _sqlair_2",
 }, {
-	summary: "spaces and tabs",
-	query: "SELECT p.* 	AS 		   &Person.*",
+	summary:        "spaces and tabs",
+	query:          "SELECT p.* 	AS 		   &Person.*",
 	expectedParsed: "[Bypass[SELECT ] Output[[p.*] [Person.*]]]",
 	typeSamples:    []any{Person{}},
 	expectedSQL:    "SELECT p.address_id AS _sqlair_0, p.id AS _sqlair_1, p.name AS _sqlair_2",

--- a/internal/expr/expr_test.go
+++ b/internal/expr/expr_test.go
@@ -62,8 +62,8 @@ var tests = []struct {
 	typeSamples:    []any{Person{}},
 	expectedSQL:    "SELECT p.address_id AS _sqlair_0, p.id AS _sqlair_1, p.name AS _sqlair_2",
 }, {
-	summary:        "spaces and tabs",
-	query:          "SELECT p.* 	AS 		   &Person.*",
+	summary: "spaces and tabs",
+	query: "SELECT p.* 	AS 		   &Person.*",
 	expectedParsed: "[Bypass[SELECT ] Output[[p.*] [Person.*]]]",
 	typeSamples:    []any{Person{}},
 	expectedSQL:    "SELECT p.address_id AS _sqlair_0, p.id AS _sqlair_1, p.name AS _sqlair_2",
@@ -708,6 +708,11 @@ func (s *ExprSuite) TestBindInputsError(c *C) {
 		inputArgs:   []any{nil, Person{Fullname: "Monty Bingles"}},
 		err:         "invalid input parameter: need struct or map, got nil",
 	}, {
+		query:       "SELECT street FROM t WHERE x = $M.x",
+		typeSamples: []any{sqlair.M{}},
+		inputArgs:   []any{(sqlair.M)(nil)},
+		err:         "invalid input parameter: need struct or map, got nil",
+	}, {
 		query:       "SELECT street FROM t WHERE x = $Address.street, y = $Person.name",
 		typeSamples: []any{Address{}, Person{}},
 		inputArgs:   []any{(*Person)(nil)},
@@ -726,7 +731,7 @@ func (s *ExprSuite) TestBindInputsError(c *C) {
 		query:       "SELECT street FROM t WHERE x = $Address.street",
 		typeSamples: []any{Address{}},
 		inputArgs:   []any{Address{}, Person{}},
-		err:         "invalid input parameter: Person not referenced in query",
+		err:         `invalid input parameter: "Person" not referenced in query`,
 	}, {
 		query:       "SELECT * AS &Address.* FROM t WHERE x = $M.Fullname",
 		typeSamples: []any{Address{}, sqlair.M{}},

--- a/internal/typeinfo/validate.go
+++ b/internal/typeinfo/validate.go
@@ -1,0 +1,64 @@
+package typeinfo
+
+import (
+	"fmt"
+	"reflect"
+)
+
+func ValidateInputs(args []any) (map[reflect.Type]reflect.Value, error) {
+	typeToValue := map[reflect.Type]reflect.Value{}
+	for _, arg := range args {
+		v := reflect.ValueOf(arg)
+		if isNil(v) {
+			return nil, fmt.Errorf("need struct or map, got nil")
+		}
+		v = reflect.Indirect(v)
+		k := v.Kind()
+		if k != reflect.Struct && k != reflect.Map {
+			return nil, fmt.Errorf("need struct or map, got %s", k)
+		}
+		t := v.Type()
+		if _, ok := typeToValue[t]; ok {
+			return nil, fmt.Errorf("type %q provided more than once", t.Name())
+		}
+		typeToValue[t] = v
+	}
+	return typeToValue, nil
+}
+
+func ValidateOutputs(args []any) (map[reflect.Type]reflect.Value, error) {
+	typeToValue := map[reflect.Type]reflect.Value{}
+	for _, arg := range args {
+		v := reflect.ValueOf(arg)
+		if isNil(v) {
+			return nil, fmt.Errorf("need map or pointer to struct, got nil")
+		}
+		k := v.Kind()
+		if k != reflect.Map && k != reflect.Pointer {
+			return nil, fmt.Errorf("need map or pointer to struct, got %s", k)
+		}
+		if k == reflect.Pointer {
+			v = v.Elem()
+			k = v.Kind()
+			if k != reflect.Struct && k != reflect.Map {
+				return nil, fmt.Errorf("need map or pointer to struct, got pointer to %s", k)
+			}
+		}
+		t := v.Type()
+		if _, ok := typeToValue[t]; ok {
+			return nil, fmt.Errorf("type %q provided more than once", t.Name())
+		}
+		typeToValue[t] = v
+	}
+	return typeToValue, nil
+}
+
+func isNil(v reflect.Value) bool {
+	switch v.Kind() {
+	case reflect.Invalid:
+		return true
+	case reflect.Pointer, reflect.Map:
+		return v.IsNil()
+	}
+	return false
+}

--- a/internal/typeinfo/validate.go
+++ b/internal/typeinfo/validate.go
@@ -8,7 +8,7 @@ import (
 	"reflect"
 )
 
-type TypeToValue map[reflect.Type]reflect.Value
+type TypeToValue = map[reflect.Type]reflect.Value
 
 // ValidateInputs takes the raw SQLair input arguments from the user and uses
 // reflection to check that they are valid. It returns a TypeToValue containing

--- a/internal/typeinfo/validate.go
+++ b/internal/typeinfo/validate.go
@@ -1,3 +1,6 @@
+// Copyright 2023 Canonical Ltd.
+// Licensed under Apache 2.0, see LICENCE file for details.
+
 package typeinfo
 
 import (

--- a/internal/typeinfo/validate.go
+++ b/internal/typeinfo/validate.go
@@ -8,8 +8,13 @@ import (
 	"reflect"
 )
 
-func ValidateInputs(args []any) (map[reflect.Type]reflect.Value, error) {
-	typeToValue := map[reflect.Type]reflect.Value{}
+type TypeToValue map[reflect.Type]reflect.Value
+
+// ValidateInputs takes the raw SQLair input arguments from the user and uses
+// reflection to check that they are valid. It returns a TypeToValue containing
+// the reflect.Value of the input arguments.
+func ValidateInputs(args []any) (TypeToValue, error) {
+	typeToValue := TypeToValue{}
 	for _, arg := range args {
 		v := reflect.ValueOf(arg)
 		if isNil(v) {
@@ -29,8 +34,11 @@ func ValidateInputs(args []any) (map[reflect.Type]reflect.Value, error) {
 	return typeToValue, nil
 }
 
-func ValidateOutputs(args []any) (map[reflect.Type]reflect.Value, error) {
-	typeToValue := map[reflect.Type]reflect.Value{}
+// ValidateOutputs takes the raw SQLair output arguments from the user and uses
+// reflection to check that they are valid. It returns a TypeToValue containing
+// the reflect.Value of the output arguments.
+func ValidateOutputs(args []any) (TypeToValue, error) {
+	typeToValue := TypeToValue{}
 	for _, arg := range args {
 		v := reflect.ValueOf(arg)
 		if isNil(v) {

--- a/package_test.go
+++ b/package_test.go
@@ -286,7 +286,7 @@ func (s *PackageSuite) TestIterGetErrors(c *C) {
 		types:   []any{Person{}},
 		inputs:  []any{},
 		outputs: []any{(*Person)(nil)},
-		err:     "cannot get result: got nil pointer",
+		err:     "cannot get result: need map or pointer to struct, got nil",
 	}, {
 		summary: "non pointer parameter",
 		query:   "SELECT * AS &Person.* FROM person",
@@ -300,7 +300,7 @@ func (s *PackageSuite) TestIterGetErrors(c *C) {
 		types:   []any{Person{}},
 		inputs:  []any{},
 		outputs: []any{&Address{}},
-		err:     `cannot get result: type "Address" does not appear in query, have: Person`,
+		err:     `cannot get result: parameter with type "Person" missing \(have "Address"\)`,
 	}, {
 		summary: "not a struct",
 		query:   "SELECT * AS &Person.* FROM person",
@@ -321,14 +321,21 @@ func (s *PackageSuite) TestIterGetErrors(c *C) {
 		types:   []any{Person{}},
 		inputs:  []any{},
 		outputs: []any{&Person{}, &Person{}},
-		err:     `cannot get result: type "Person" provided more than once, rename one of them`,
+		err:     `cannot get result: type "Person" provided more than once`,
 	}, {
 		summary: "multiple of the same type",
 		query:   "SELECT name AS &M.* FROM person",
 		types:   []any{sqlair.M{}},
 		inputs:  []any{},
 		outputs: []any{&sqlair.M{}, sqlair.M{}},
-		err:     `cannot get result: type "M" provided more than once, rename one of them`,
+		err:     `cannot get result: type "M" provided more than once`,
+	}, {
+		summary: "type not in query",
+		query:   "SELECT * AS &Person.* FROM person",
+		types:   []any{Person{}},
+		inputs:  []any{},
+		outputs: []any{&Person{}, &Address{}},
+		err:     `cannot get result: "Address" not referenced in query`,
 	}, {
 		summary: "output expr in a with clause",
 		query: `WITH averageID(avgid) AS (SELECT &Person.id FROM person)
@@ -736,7 +743,7 @@ func (s *PackageSuite) TestGetAllErrors(c *C) {
 		types:   []any{Person{}},
 		inputs:  []any{},
 		slices:  []any{&[]*Address{}},
-		err:     `cannot populate slice: cannot get result: type "Address" does not appear in query, have: Person`,
+		err:     `cannot populate slice: cannot get result: parameter with type "Person" missing \(have "Address"\)`,
 	}, {
 		summary: "wrong slice type (int)",
 		query:   "SELECT * AS &Person.* FROM person",

--- a/package_test.go
+++ b/package_test.go
@@ -330,6 +330,13 @@ func (s *PackageSuite) TestIterGetErrors(c *C) {
 		outputs: []any{&sqlair.M{}, sqlair.M{}},
 		err:     `cannot get result: type "M" provided more than once`,
 	}, {
+		summary: "nil map output",
+		query:   "SELECT name AS &M.* FROM person",
+		types:   []any{sqlair.M{}},
+		inputs:  []any{},
+		outputs: []any{(sqlair.M)(nil)},
+		err:     `cannot get result: need map or pointer to struct, got nil`,
+	}, {
 		summary: "type not in query",
 		query:   "SELECT * AS &Person.* FROM person",
 		types:   []any{Person{}},


### PR DESCRIPTION
This PR moves the sections of `BindInputs` and `ScanArgs` that validate the arguments from the user to the `typeinfo` package. The new functions return the `typeToValue` map that is used by `BindInputs` and `ScanArgs`.

The error messages returned by the two validation functions are made consistent and the two functions are changed to match in shape even though they are subtly different.

A test is also added for nil maps as arguments, since this was not previously checked.