### PR TITLE
Add support for nil slices

### DIFF
--- a/internal/expr/expr_test.go
+++ b/internal/expr/expr_test.go
@@ -401,7 +401,8 @@ AND z = @sqlair_0 -- The line with $Person.id on it
 	typeSamples:    []any{sqlair.S{}},
 	inputArgs:      []any{(sqlair.S)(nil)},
 	expectedParams: []any{},
-	expectedSQL:    "SELECT name FROM person WHERE id IN ()",
+	// This is valid in SQLite (though not in MySQL).
+	expectedSQL: "SELECT name FROM person WHERE id IN ()",
 }}
 
 func (s *ExprSuite) TestExprPkg(c *C) {

--- a/internal/expr/expr_test.go
+++ b/internal/expr/expr_test.go
@@ -803,17 +803,17 @@ func (s *ExprSuite) TestBindInputsError(c *C) {
 		query:       "SELECT street FROM t WHERE x = $Address.street, y = $Person.name",
 		typeSamples: []any{Address{}, Person{}},
 		inputArgs:   []any{nil, Person{Fullname: "Monty Bingles"}},
-		err:         "invalid input parameter: need supported value, got nil",
+		err:         "invalid input parameter: got nil argument",
 	}, {
 		query:       "SELECT street FROM t WHERE x = $M.x",
 		typeSamples: []any{sqlair.M{}},
 		inputArgs:   []any{(sqlair.M)(nil)},
-		err:         "invalid input parameter: need supported value, got nil",
+		err:         "invalid input parameter: got nil M",
 	}, {
 		query:       "SELECT street FROM t WHERE x = $Address.street, y = $Person.name",
 		typeSamples: []any{Address{}, Person{}},
 		inputArgs:   []any{(*Person)(nil)},
-		err:         "invalid input parameter: need supported value, got nil",
+		err:         "invalid input parameter: got nil pointer to Person",
 	}, {
 		query:       "SELECT street FROM t WHERE x = $Address.street",
 		typeSamples: []any{Address{}},
@@ -853,7 +853,7 @@ func (s *ExprSuite) TestBindInputsError(c *C) {
 		query:       "SELECT street FROM t WHERE x = $M.street",
 		typeSamples: []any{sqlair.M{}},
 		inputArgs:   []any{(sqlair.M)(nil)},
-		err:         `invalid input parameter: need supported value, got nil`,
+		err:         `invalid input parameter: got nil M`,
 	}}
 
 	outerP := Person{}

--- a/internal/expr/expr_test.go
+++ b/internal/expr/expr_test.go
@@ -390,6 +390,17 @@ AND z = @sqlair_0 -- The line with $Person.id on it
 	typeSamples:    []any{sqlair.S{}},
 	inputArgs:      []any{sqlair.S{}},
 	expectedParams: []any{},
+	// This is valid in SQLite (though not in MySQL).
+	expectedSQL: "SELECT name FROM person WHERE id IN ()",
+}, {
+	// The nil slice is used interchangeably with the empty slice so this is
+	// allowed as well.
+	summary:        "nil slice",
+	query:          "SELECT name FROM person WHERE id IN ($S[:])",
+	expectedParsed: "[Bypass[SELECT name FROM person WHERE id IN (] Input[S[:]] Bypass[)]]",
+	typeSamples:    []any{sqlair.S{}},
+	inputArgs:      []any{(sqlair.S)(nil)},
+	expectedParams: []any{},
 	expectedSQL:    "SELECT name FROM person WHERE id IN ()",
 }}
 
@@ -841,11 +852,6 @@ func (s *ExprSuite) TestBindInputsError(c *C) {
 		query:       "SELECT street FROM t WHERE x = $M.street",
 		typeSamples: []any{sqlair.M{}},
 		inputArgs:   []any{(sqlair.M)(nil)},
-		err:         `invalid input parameter: need supported value, got nil`,
-	}, {
-		query:       "SELECT street FROM t WHERE x IN ($S[:])",
-		typeSamples: []any{sqlair.S{}},
-		inputArgs:   []any{(sqlair.S)(nil)},
 		err:         `invalid input parameter: need supported value, got nil`,
 	}}
 

--- a/internal/typeinfo/validate.go
+++ b/internal/typeinfo/validate.go
@@ -17,7 +17,7 @@ func ValidateInputs(args []any) (TypeToValue, error) {
 	typeToValue := TypeToValue{}
 	for _, arg := range args {
 		v := reflect.ValueOf(arg)
-		if isNil(v) {
+		if isInvalidNil(v) {
 			return nil, fmt.Errorf("need supported value, got nil")
 		}
 		v = reflect.Indirect(v)
@@ -45,7 +45,7 @@ func ValidateOutputs(args []any) (TypeToValue, error) {
 	typeToValue := TypeToValue{}
 	for _, arg := range args {
 		v := reflect.ValueOf(arg)
-		if isNil(v) {
+		if isInvalidNil(v) {
 			return nil, fmt.Errorf("need map or pointer to struct, got nil")
 		}
 		k := v.Kind()
@@ -68,7 +68,7 @@ func ValidateOutputs(args []any) (TypeToValue, error) {
 	return typeToValue, nil
 }
 
-func isNil(v reflect.Value) bool {
+func isInvalidNil(v reflect.Value) bool {
 	switch v.Kind() {
 	case reflect.Invalid:
 		return true

--- a/internal/typeinfo/validate.go
+++ b/internal/typeinfo/validate.go
@@ -17,8 +17,8 @@ func ValidateInputs(args []any) (TypeToValue, error) {
 	typeToValue := TypeToValue{}
 	for _, arg := range args {
 		v := reflect.ValueOf(arg)
-		if isInvalidNil(v) {
-			return nil, fmt.Errorf("need supported value, got nil")
+		if err := validateValue(v); err != nil {
+			return nil, err
 		}
 		v = reflect.Indirect(v)
 		t := v.Type()
@@ -45,8 +45,8 @@ func ValidateOutputs(args []any) (TypeToValue, error) {
 	typeToValue := TypeToValue{}
 	for _, arg := range args {
 		v := reflect.ValueOf(arg)
-		if isInvalidNil(v) {
-			return nil, fmt.Errorf("need map or pointer to struct, got nil")
+		if err := validateValue(v); err != nil {
+			return nil, err
 		}
 		k := v.Kind()
 		if k != reflect.Map && k != reflect.Pointer {
@@ -68,12 +68,18 @@ func ValidateOutputs(args []any) (TypeToValue, error) {
 	return typeToValue, nil
 }
 
-func isInvalidNil(v reflect.Value) bool {
+func validateValue(v reflect.Value) error {
 	switch v.Kind() {
 	case reflect.Invalid:
-		return true
-	case reflect.Pointer, reflect.Map:
-		return v.IsNil()
+		return fmt.Errorf("got nil argument")
+	case reflect.Pointer:
+		if v.IsNil() {
+			return fmt.Errorf("got nil pointer to %s", v.Type().Elem().Name())
+		}
+	case reflect.Map:
+		if v.IsNil() {
+			return fmt.Errorf("got nil %s", v.Type().Name())
+		}
 	}
-	return false
+	return nil
 }

--- a/internal/typeinfo/validate.go
+++ b/internal/typeinfo/validate.go
@@ -72,7 +72,7 @@ func isNil(v reflect.Value) bool {
 	switch v.Kind() {
 	case reflect.Invalid:
 		return true
-	case reflect.Pointer, reflect.Map, reflect.Slice:
+	case reflect.Pointer, reflect.Map:
 		return v.IsNil()
 	}
 	return false

--- a/package_test.go
+++ b/package_test.go
@@ -291,14 +291,14 @@ func (s *PackageSuite) TestIterGetErrors(c *C) {
 		types:   []any{Person{}},
 		inputs:  []any{},
 		outputs: []any{nil},
-		err:     "cannot get result: need map or pointer to struct, got nil",
+		err:     "cannot get result: got nil argument",
 	}, {
 		summary: "nil pointer parameter",
 		query:   "SELECT * AS &Person.* FROM person",
 		types:   []any{Person{}},
 		inputs:  []any{},
 		outputs: []any{(*Person)(nil)},
-		err:     "cannot get result: need map or pointer to struct, got nil",
+		err:     "cannot get result: got nil pointer to Person",
 	}, {
 		summary: "non pointer parameter",
 		query:   "SELECT * AS &Person.* FROM person",
@@ -347,7 +347,7 @@ func (s *PackageSuite) TestIterGetErrors(c *C) {
 		types:   []any{sqlair.M{}},
 		inputs:  []any{},
 		outputs: []any{(sqlair.M)(nil)},
-		err:     `cannot get result: need map or pointer to struct, got nil`,
+		err:     `cannot get result: got nil M`,
 	}, {
 		summary: "type not in query",
 		query:   "SELECT * AS &Person.* FROM person",


### PR DESCRIPTION
The decision was made to allow the empty slice as a valid slice input in SQLair. When the slice is empty no input placeholders are generated for the slice (e.g. `... IN ($S[:])` => `... IN ()`). 

In Go, the nil slice is often used interchangeably with the empty slice (since append works on both) however, when a nil slice is passed to SQLair, it returns the error `"need supported value, got nil"`.

The behavior for `nil` slices should match that for empty slices to give a consistent user experience.