### PR TITLE
Return ErrNoRows when GetAll finds no results

### DIFF
--- a/package_test.go
+++ b/package_test.go
@@ -658,19 +658,19 @@ func (s *PackageSuite) TestValidGetAll(c *C) {
 		slices:   []any{&[]*Manager{}, &[]*Person{}, &[]*Address{}},
 		expected: []any{&[]*Manager{{30, "Fred", 1000}}, &[]*Person{{30, "Fred", 1000}}, &[]*Address{{1000, "Happy Land", "Main Street"}}},
 	}, {
-		summary:  "nothing returned",
-		query:    "SELECT &Person.* FROM person WHERE id = $Person.id",
-		types:    []any{Person{}},
-		inputs:   []any{Person{ID: 1243321}},
-		slices:   []any{&[]*Person{}},
-		expected: []any{&[]*Person{}},
-	}, {
 		summary:  "select into maps",
 		query:    "SELECT &M.name, &CustomMap.id FROM person WHERE name = 'Mark'",
 		types:    []any{sqlair.M{}, CustomMap{}},
 		inputs:   []any{},
 		slices:   []any{&[]sqlair.M{}, &[]CustomMap{}},
 		expected: []any{&[]sqlair.M{{"name": "Mark"}}, &[]CustomMap{{"id": int64(20)}}},
+	}, {
+		summary:  "run insert with GetAll",
+		query:    `INSERT INTO person (name) VALUES ($M.name)`,
+		types:    []any{sqlair.M{}},
+		inputs:   []any{sqlair.M{"name": "Joe"}},
+		slices:   []any{},
+		expected: []any{},
 	}}
 
 	tables, sqldb, err := personAndAddressDB(c)
@@ -766,6 +766,13 @@ func (s *PackageSuite) TestGetAllErrors(c *C) {
 		inputs:  []any{},
 		slices:  []any{&[]Person{}},
 		err:     `cannot populate slice: output variables provided but not referenced in query`,
+	}, {
+		summary: "nothing returned",
+		query:   "SELECT &Person.* FROM person WHERE id = $Person.id",
+		types:   []any{Person{}},
+		inputs:  []any{Person{ID: 1243321}},
+		slices:  []any{&[]*Person{}},
+		err:     "cannot populate slice: sql: no rows in result set",
 	}}
 
 	tables, sqldb, err := personAndAddressDB(c)

--- a/package_test.go
+++ b/package_test.go
@@ -617,8 +617,12 @@ func (s *PackageSuite) TestErrNoRows(c *C) {
 
 	stmt := sqlair.MustPrepare("SELECT * AS &Person.* FROM person WHERE id=12312", Person{})
 	err = db.Query(nil, stmt).Get(&Person{})
-	c.Assert(err, Equals, sqlair.ErrNoRows)
-	c.Assert(err, Equals, sql.ErrNoRows)
+	errors.Is(err, sqlair.ErrNoRows)
+	errors.Is(err, sql.ErrNoRows)
+
+	err = db.Query(nil, stmt).GetAll(&Person{})
+	errors.Is(err, sqlair.ErrNoRows)
+	errors.Is(err, sql.ErrNoRows)
 }
 
 func (s *PackageSuite) TestValidGetAll(c *C) {

--- a/package_test.go
+++ b/package_test.go
@@ -665,7 +665,7 @@ func (s *PackageSuite) TestValidGetAll(c *C) {
 		slices:   []any{&[]sqlair.M{}, &[]CustomMap{}},
 		expected: []any{&[]sqlair.M{{"name": "Mark"}}, &[]CustomMap{{"id": int64(20)}}},
 	}, {
-		summary:  "run insert with GetAll",
+		summary:  "GetAll returns no error when there are no outputs",
 		query:    `INSERT INTO person (name) VALUES ($M.name)`,
 		types:    []any{sqlair.M{}},
 		inputs:   []any{sqlair.M{"name": "Joe"}},

--- a/sqlair.go
+++ b/sqlair.go
@@ -302,10 +302,10 @@ func (q *Query) GetAll(sliceArgs ...any) (err error) {
 		sliceVals = append(sliceVals, sliceVal)
 	}
 
-	noRows := true
+	rowsReturned := false
 	iter := q.Iter()
 	for iter.Next() {
-		noRows = false
+		rowsReturned = true
 		var outputArgs = []any{}
 		for _, sliceVal := range sliceVals {
 			elemType := sliceVal.Type().Elem()
@@ -346,7 +346,7 @@ func (q *Query) GetAll(sliceArgs ...any) (err error) {
 	err = iter.Close()
 	if err != nil {
 		return err
-	} else if noRows && q.pq.HasOutputs() {
+	} else if !rowsReturned && q.pq.HasOutputs() {
 		return ErrNoRows
 	}
 

--- a/sqlair.go
+++ b/sqlair.go
@@ -262,6 +262,8 @@ func (o *Outcome) Result() sql.Result {
 // GetAll iterates over the query and scans all rows into the provided slices.
 // sliceArgs must contain pointers to slices of each of the output types.
 // An &Outcome{} variable may be provided as the first output variable.
+//
+// ErrNoRows will be returned if no rows are found.
 func (q *Query) GetAll(sliceArgs ...any) (err error) {
 	if q.err != nil {
 		return q.err
@@ -300,8 +302,10 @@ func (q *Query) GetAll(sliceArgs ...any) (err error) {
 		sliceVals = append(sliceVals, sliceVal)
 	}
 
+	noRows := true
 	iter := q.Iter()
 	for iter.Next() {
+		noRows = false
 		var outputArgs = []any{}
 		for _, sliceVal := range sliceVals {
 			elemType := sliceVal.Type().Elem()
@@ -342,6 +346,8 @@ func (q *Query) GetAll(sliceArgs ...any) (err error) {
 	err = iter.Close()
 	if err != nil {
 		return err
+	} else if noRows && q.pq.HasOutputs() {
+		return ErrNoRows
 	}
 
 	for i, ptrVal := range slicePtrVals {


### PR DESCRIPTION
If `GetAll` finds no results in the database it is currently a no-op. In the interests of safety it would be better if this function returned the `ErrNoRows` error. If no results is not an error case the user can explicitly match against and ignore the error.