### PR TITLE
Add support for parsing unicode chars in column names and tags

### DIFF
--- a/internal/expr/expr_test.go
+++ b/internal/expr/expr_test.go
@@ -53,7 +53,7 @@ type NumberLiteralColumn struct {
 
 type M map[string]any
 
-type lowerCaseMap map[string]any
+type unexportedMap map[string]any
 
 type IntMap map[string]int
 
@@ -84,8 +84,8 @@ var tests = []struct {
 	typeSamples:    []any{Person{}},
 	expectedSQL:    "SELECT p.address_id AS _sqlair_0, p.id AS _sqlair_1, p.name AS _sqlair_2",
 }, {
-	summary: "spaces and tabs",
-	query: "SELECT p.* 	AS 		   &Person.*",
+	summary:        "spaces and tabs",
+	query:          "SELECT p.* 	AS 		   &Person.*",
 	expectedParsed: "[Bypass[SELECT ] Output[[p.*] [Person.*]]]",
 	typeSamples:    []any{Person{}},
 	expectedSQL:    "SELECT p.address_id AS _sqlair_0, p.id AS _sqlair_1, p.name AS _sqlair_2",
@@ -535,9 +535,9 @@ AND z = @sqlair_0 -- The line with $Person.id on it
 	expectedSQL:    "INSERT INTO arr VALUES (ARRAY[[1,2],[@sqlair_0,4]], ARRAY[[5,6],[@sqlair_1,8]]);",
 }, {
 	summary:        "lower case struct",
-	query:          "SELECT &lowerCaseMap.x FROM person",
-	expectedParsed: "[Bypass[SELECT ] Output[[] [lowerCaseMap.x]] Bypass[ FROM person]]",
-	typeSamples:    []any{lowerCaseMap{}},
+	query:          "SELECT &unexportedMap.x FROM person",
+	expectedParsed: "[Bypass[SELECT ] Output[[] [unexportedMap.x]] Bypass[ FROM person]]",
+	typeSamples:    []any{unexportedMap{}},
 	expectedSQL:    "SELECT x AS _sqlair_0 FROM person",
 }, {
 	summary:        "unicode asterisk",

--- a/internal/expr/parser.go
+++ b/internal/expr/parser.go
@@ -419,9 +419,11 @@ func (p *Parser) skipBlanks() bool {
 // In that case returns true, false otherwise.
 // This function is case insensitive.
 func (p *Parser) skipString(s string) bool {
+	// EqualFold is used here because it is case insensitive.
 	if p.pos+len(s) <= len(p.input) &&
 		strings.EqualFold(p.input[p.pos:p.pos+len(s)], s) {
-		// Manually advance the parser to the end of the string.
+		// EqualFold does not advnace the parser, so we must manually advance
+		// the parser to the end of the string.
 		p.pos += len(s)
 		var size int
 		p.char, size = utf8.DecodeRuneInString(p.input[p.pos:])
@@ -437,7 +439,7 @@ func isNameChar(c rune) bool {
 	return unicode.IsLetter(c) || unicode.IsDigit(c) || c == '_'
 }
 
-// isNameInitialChar returns true if the given char can appear at the start of a
+// isInitialNameChar returns true if the given char can appear at the start of a
 // name. It returns false otherwise.
 func isInitialNameChar(c rune) bool {
 	return unicode.IsLetter(c) || c == '_'

--- a/internal/expr/parser.go
+++ b/internal/expr/parser.go
@@ -19,7 +19,8 @@ type Parser struct {
 	pos   int
 	// nextPos is start of the next char.
 	nextPos int
-	// char is the rune starting at pos. char is set to 0 at the end of input.
+	// char is the rune starting at pos. char is set to 0 when pos reaches the
+	// end of input.
 	char rune
 	// prevExprEnd is the value of pos when we last finished parsing a
 	// expression.
@@ -27,8 +28,8 @@ type Parser struct {
 	// currentExprStart is the value of pos just before we started parsing the
 	// expression under pos. We maintain currentExprStart >= prevExprEnd.
 	currentExprStart int
-	// exprs are the output of the parser. The parsed expressions are added as
-	// they are parsed.
+	// exprs are the output of the parser. Expressions are added as they are
+	// parsed.
 	exprs []expression
 	// lineNum is the number of the current line of the input.
 	lineNum int
@@ -159,8 +160,9 @@ func (p *Parser) colNum() int {
 	return p.pos - p.lineStart + 1
 }
 
-// advanceChar moves the parser to the next rune in the input. It also takes
-// care of updating the line and column numbers if it encounters line breaks.
+// advanceChar moves the parser to the next character in the input. It also
+// takes care of updating the line and column numbers if it encounters line
+// breaks.
 func (p *Parser) advanceChar() bool {
 	if p.nextPos >= len(p.input) {
 		p.char = 0
@@ -294,8 +296,8 @@ func (p *Parser) skipComment() bool {
 // advanceToNextExpression advances the parser until it finds a character that
 // could be the start of an expression.
 func (p *Parser) advanceToNextExpression() error {
-	// If the first char of input is an InitalNameChar then return as it could
-	// be an expression. This case is not covered below.
+	// If very the first char of the whole input is a nameChar then return as
+	// it could be an expression. This case is not covered below.
 	if p.pos < len(p.input) && p.pos == 0 && isNameChar(p.char) {
 		return nil
 	}
@@ -311,7 +313,7 @@ loop:
 		}
 
 		switch p.char {
-		// These chars may be the start of an expression.
+		// These characters may be the start of an expression.
 		case '(', '*', '$', '&':
 			break loop
 		// An expression can also start with a name char, e.g. an expression
@@ -520,9 +522,9 @@ func (p *Parser) parseIdentifierAsterisk() (string, bool, error) {
 	return p.parseIdentifier()
 }
 
-// parseIdentifier parses either a name made up of alphanumeric chars and
-// underscores or any quoted name. This matches allowed SQL identifiers and
-// db tags allowed by SQLair.
+// parseIdentifier parses either a name made up of letters, digits and
+// underscores or any quoted name. This matches allowed SQL identifiers and db
+// tags allowed by SQLair.
 func (p *Parser) parseIdentifier() (string, bool, error) {
 	mark := p.pos
 
@@ -563,10 +565,8 @@ func (p *Parser) parseTypeName() (string, bool) {
 	return "", false
 }
 
-// parseColumnAccessor parses either a column made up of name chars optionally
-// dot-prefixed by its table name or a SQL function call used in place of a
-// column.
-// parseColumnAccessor returns an error so that it can be used with parseList.
+// parseColumnAccessor parses either a column optionally dot-prefixed by its
+// table name, or, a SQL function call used in place of a column.
 func (p *Parser) parseColumnAccessor() (columnAccessor, bool, error) {
 	cp := p.save()
 

--- a/internal/expr/parser_helper_test.go
+++ b/internal/expr/parser_helper_test.go
@@ -5,7 +5,7 @@ import (
 )
 
 type parseHelperTest struct {
-	bytef    func(byte) bool
+	charf    func(rune) bool
 	stringf  func(string) bool
 	stringf0 func() bool
 	result   []bool
@@ -17,17 +17,17 @@ func (s *ExprInternalSuite) TestRunTable(c *C) {
 	var p = NewParser()
 	var parseTests = []parseHelperTest{
 
-		{bytef: p.peekByte, result: []bool{false}, input: "", data: []string{"a"}},
-		{bytef: p.peekByte, result: []bool{false}, input: "b", data: []string{"a"}},
-		{bytef: p.peekByte, result: []bool{true}, input: "a", data: []string{"a"}},
+		{charf: p.peekChar, result: []bool{false}, input: "", data: []string{"a"}},
+		{charf: p.peekChar, result: []bool{false}, input: "b", data: []string{"a"}},
+		{charf: p.peekChar, result: []bool{true}, input: "a", data: []string{"a"}},
 
-		{bytef: p.skipByte, result: []bool{false}, input: "", data: []string{"a"}},
-		{bytef: p.skipByte, result: []bool{false}, input: "abc", data: []string{"b"}},
-		{bytef: p.skipByte, result: []bool{true, true}, input: "abc", data: []string{"a", "b"}},
+		{charf: p.skipChar, result: []bool{false}, input: "", data: []string{"a"}},
+		{charf: p.skipChar, result: []bool{false}, input: "abc", data: []string{"b"}},
+		{charf: p.skipChar, result: []bool{true, true}, input: "abc", data: []string{"a", "b"}},
 
-		{bytef: p.skipByteFind, result: []bool{false}, input: "", data: []string{"a"}},
-		{bytef: p.skipByteFind, result: []bool{false, true, true}, input: "abcde", data: []string{"x", "b", "c"}},
-		{bytef: p.skipByteFind, result: []bool{true, false}, input: "abcde ", data: []string{" ", " "}},
+		{charf: p.skipCharFind, result: []bool{false}, input: "", data: []string{"a"}},
+		{charf: p.skipCharFind, result: []bool{false, true, true}, input: "abcde", data: []string{"x", "b", "c"}},
+		{charf: p.skipCharFind, result: []bool{true, false}, input: "abcde ", data: []string{" ", " "}},
 
 		{stringf0: p.skipBlanks, result: []bool{false}, input: "", data: []string{}},
 		{stringf0: p.skipBlanks, result: []bool{false}, input: "abc    d", data: []string{}},
@@ -43,19 +43,14 @@ func (s *ExprInternalSuite) TestRunTable(c *C) {
 		{stringf: p.skipString, result: []bool{false}, input: "", data: []string{"a"}},
 		{stringf: p.skipString, result: []bool{true, true}, input: "helloworld", data: []string{"hElLo", "w"}},
 		{stringf: p.skipString, result: []bool{true, true}, input: "hello world", data: []string{"hello", " "}},
-
-		{stringf0: p.skipName, result: []bool{false}, input: " hi", data: []string{}},
-		{stringf0: p.skipName, result: []bool{false}, input: "*", data: []string{}},
-		{stringf0: p.skipName, result: []bool{true}, input: "hello", data: []string{}},
-		{stringf0: p.skipName, result: []bool{false}, input: "2d3d", data: []string{}},
 	}
 	for _, v := range parseTests {
 		// Reset the input.
 		p.init(v.input)
 		for i, _ := range v.result {
 			var result bool
-			if v.bytef != nil {
-				result = v.bytef(v.data[i][0])
+			if v.charf != nil {
+				result = v.charf(rune(v.data[i][0]))
 			}
 			if v.stringf != nil {
 				result = v.stringf(v.data[i])

--- a/internal/expr/typeinfo_test.go
+++ b/internal/expr/typeinfo_test.go
@@ -111,9 +111,6 @@ func (s *ExprInternalSuite) TestReflectBadTagError(c *C) {
 
 	var invalidColumn = []any{
 		struct {
-			ID int64 `db:"5id"`
-		}{99},
-		struct {
 			ID int64 `db:"+id"`
 		}{99},
 		struct {

--- a/internal/typeinfo/arginfo.go
+++ b/internal/typeinfo/arginfo.go
@@ -322,16 +322,16 @@ func parseTag(tag string) (string, bool, error) {
 	char, size := utf8.DecodeRuneInString(name)
 	nextPos := size
 	var checker func(rune) bool
-	if unicode.IsDigit(char) {
+	switch {
+	case unicode.IsDigit(char):
 		// If it starts with a digit, check the tag is a number.
-		checker = func(char rune) bool {
-			return unicode.IsDigit(char)
-		}
-	} else if unicode.IsLetter(char) || char == '_' {
+		checker = unicode.IsDigit
+	case unicode.IsLetter(char) || char == '_':
+		// Otherwise make sure it is alphanumeric plus underscore.
 		checker = func(char rune) bool {
 			return unicode.IsLetter(char) || unicode.IsDigit(char) || char == '_'
 		}
-	} else {
+	default:
 		return "", false, fmt.Errorf("invalid column name in 'db' tag: %q", name)
 	}
 	for nextPos < len(name) {

--- a/internal/typeinfo/arginfo.go
+++ b/internal/typeinfo/arginfo.go
@@ -327,7 +327,7 @@ func parseTag(tag string) (string, bool, error) {
 		// If it starts with a digit, check the tag is a number.
 		checker = unicode.IsDigit
 	case unicode.IsLetter(char) || char == '_':
-		// Otherwise make sure it is alphanumeric plus underscore.
+		// Otherwise make sure it is made up of letters, digits and underscore.
 		checker = func(char rune) bool {
 			return unicode.IsLetter(char) || unicode.IsDigit(char) || char == '_'
 		}

--- a/package_test.go
+++ b/package_test.go
@@ -59,6 +59,10 @@ type Manager Person
 
 type District struct{}
 
+type lowerCaseStruct struct {
+	X int `db:"id"`
+}
+
 func personAndAddressDB() (string, *sql.DB, error) {
 	createTables := `
 CREATE TABLE person (
@@ -397,6 +401,13 @@ func (s *PackageSuite) TestValidGet(c *C) {
 		inputs:   []any{Address{ID: 1000}, Person{ID: 30}},
 		outputs:  []any{&Person{}, &Address{}, &Manager{}},
 		expected: []any{&Person{30, "Fred", 1000}, &Address{1000, "Happy Land", "Main Street"}, &Manager{30, "Fred", 1000}},
+	}, {
+		summary:  "lower case struct",
+		query:    "SELECT &lowerCaseStruct.* FROM person",
+		types:    []any{lowerCaseStruct{}},
+		inputs:   []any{},
+		outputs:  []any{&lowerCaseStruct{}},
+		expected: []any{&lowerCaseStruct{X: 30}},
 	}}
 
 	dropTables, sqldb, err := personAndAddressDB()

--- a/package_test.go
+++ b/package_test.go
@@ -68,7 +68,7 @@ type District struct{}
 
 type CustomMap map[string]any
 
-type lowerCaseStruct struct {
+type unexportedStruct struct {
 	X int `db:"id"`
 }
 
@@ -122,7 +122,7 @@ CREATE TABLE address (
 
 func (s *PackageSuite) TestValidIterGet(c *C) {
 	type StringMap map[string]string
-	type lowerCaseMap map[string]any
+	type unexportedMap map[string]any
 	type M struct {
 		F string `db:"id"`
 	}
@@ -200,11 +200,11 @@ func (s *PackageSuite) TestValidIterGet(c *C) {
 		expected: [][]any{{&StringMap{"name": "Fred"}, CustomMap{"id": int64(30)}}},
 	}, {
 		summary:  "lower case map",
-		query:    "SELECT name AS &lowerCaseMap.*, id AS &lowerCaseMap.* FROM person WHERE address_id = $lowerCaseMap.address_id",
-		types:    []any{lowerCaseMap{}},
-		inputs:   []any{lowerCaseMap{"address_id": "1000"}},
-		outputs:  [][]any{{&lowerCaseMap{}}},
-		expected: [][]any{{&lowerCaseMap{"name": "Fred", "id": int64(30)}}},
+		query:    "SELECT name AS &unexportedMap.*, id AS &unexportedMap.* FROM person WHERE address_id = $unexportedMap.address_id",
+		types:    []any{unexportedMap{}},
+		inputs:   []any{unexportedMap{"address_id": "1000"}},
+		outputs:  [][]any{{&unexportedMap{}}},
+		expected: [][]any{{&unexportedMap{"name": "Fred", "id": int64(30)}}},
 	}, {
 		summary:  "insert",
 		query:    "INSERT INTO address VALUES ($Address.id, $Address.district, $Address.street);",
@@ -539,11 +539,11 @@ func (s *PackageSuite) TestValidGet(c *C) {
 		expected: []any{&Person{30, "Fred", 1000}, &Address{1000, "Happy Land", "Main Street"}, &Manager{30, "Fred", 1000}},
 	}, {
 		summary:  "lower case struct",
-		query:    "SELECT &lowerCaseStruct.* FROM person",
-		types:    []any{lowerCaseStruct{}},
+		query:    "SELECT &unexportedStruct.* FROM person",
+		types:    []any{unexportedStruct{}},
 		inputs:   []any{},
-		outputs:  []any{&lowerCaseStruct{}},
-		expected: []any{&lowerCaseStruct{X: 30}},
+		outputs:  []any{&unexportedStruct{}},
+		expected: []any{&unexportedStruct{X: 30}},
 	}, {
 		summary:  "select into map",
 		query:    "SELECT &M.name FROM person WHERE address_id = $M.p1",


### PR DESCRIPTION
The SQLair parser does not currently recognise unicode characters in column names. It also doesn't support a way to select numbers into outputs, or to select column names with quotes into outputs. Adding these features will increase the reliability and polish of SQLair.

The parser is changed to check runes rather than bytes, it also allows for numbers and quoted names to be parsed as column names. The validation for tag names is also changed to include the above so that these columns can be parsed directly into structs.

You will now be able to write SQLair queries such as:
```
SELECT 世界 AS &S.* FROM t
SELECT 1 AS &M.doesExist FROM t
SELECT "string or column name!" AS $M.quoted FROM t
```

Also tidied up use of go check in some of the tests, and added tests for lower case structs.

P.S. sorry for the poor commit history, this will all get squashed away.