### PR TITLE
Add embedded struct support

### DIFF
--- a/internal/typeinfo/arginfo.go
+++ b/internal/typeinfo/arginfo.go
@@ -345,8 +345,11 @@ func getStructFields(structType reflect.Type) ([]*structField, error) {
 		tag := field.Tag.Get("db")
 
 		// If Anonymous is true, the field is embedded.
-		// If the embedded struct is tagged, treat it as a regular field.
 		if field.Anonymous && tag == "" {
+			// If the embedded struct is tagged then we do not look inside it and
+			// we pass it straight to the driver. This means it must implement the
+			// Valuer or Scanner interface (for inputs/outputs respectively) or the
+			// driver will reject it with a panic.
 			if !field.IsExported() {
 				continue
 			}

--- a/internal/typeinfo/arginfo.go
+++ b/internal/typeinfo/arginfo.go
@@ -245,29 +245,19 @@ func getArgInfo(t reflect.Type) (arg, error) {
 		}
 		tags := []string{}
 
-		for i := 0; i < t.NumField(); i++ {
-			f := t.Field(i)
-			// Fields without a "db" tag are outside of SQLAir's remit.
-			tag := f.Tag.Get("db")
-			if tag == "" {
-				continue
-			}
-			if !f.IsExported() {
-				return nil, fmt.Errorf("field %q of struct %s not exported", f.Name, t.Name())
-			}
+		fields, err := getStructFields(t)
+		if err != nil {
+			return nil, err
+		}
 
-			tag, omitEmpty, err := parseTag(tag)
-			if err != nil {
-				return nil, fmt.Errorf("cannot parse tag for field %s.%s: %s", t.Name(), f.Name, err)
+		// Check for duplicate tags.
+		for _, field := range fields {
+			tags = append(tags, field.tag)
+			if dup, ok := info.tagToField[field.tag]; ok {
+				return nil, fmt.Errorf("db tag %q appears in both field %q and field %q of struct %q",
+					field.tag, field.name, dup.name, t.Name())
 			}
-			tags = append(tags, tag)
-			info.tagToField[tag] = &structField{
-				name:       f.Name,
-				index:      i,
-				omitEmpty:  omitEmpty,
-				tag:        tag,
-				structType: t,
-			}
+			info.tagToField[field.tag] = field
 		}
 
 		sort.Strings(tags)
@@ -343,6 +333,65 @@ func parseTag(tag string) (string, bool, error) {
 	}
 
 	return name, omitEmpty, nil
+}
+
+// getStructFields returns relevant reflection information about all struct
+// fields included embedded fields. The caller must check that structType is a
+// struct.
+func getStructFields(structType reflect.Type) ([]*structField, error) {
+	var fields []*structField
+	for i := 0; i < structType.NumField(); i++ {
+		field := structType.Field(i)
+		tag := field.Tag.Get("db")
+
+		// If Anonymous is true, the field is embedded.
+		// If the embedded struct is tagged, treat it as a regular field.
+		if field.Anonymous && tag == "" {
+			if !field.IsExported() {
+				continue
+			}
+
+			fieldType := field.Type
+			if fieldType.Kind() == reflect.Pointer {
+				fieldType = fieldType.Elem()
+			}
+			if fieldType.Kind() != reflect.Struct {
+				continue
+			}
+			// Promote the embedded struct fields into the current parent struct
+			// scope, making sure to update the Index list for navigation back
+			// to the original nested location.
+			nestedFields, err := getStructFields(fieldType)
+			if err != nil {
+				return nil, err
+			}
+			for _, nestedField := range nestedFields {
+				nestedField.index = append([]int{i}, nestedField.index...)
+				nestedField.structType = structType
+			}
+			fields = append(fields, nestedFields...)
+		} else {
+			// Fields without a "db" tag are outside of SQLair's remit.
+			if tag == "" {
+				continue
+			}
+			if !field.IsExported() {
+				return nil, fmt.Errorf("field %q of struct %s not exported", field.Name, structType.Name())
+			}
+			tag, omitEmpty, err := parseTag(tag)
+			if err != nil {
+				return nil, fmt.Errorf("cannot parse tag for field %s.%s: %s", structType.Name(), field.Name, err)
+			}
+			fields = append(fields, &structField{
+				name:       field.Name,
+				index:      field.Index,
+				omitEmpty:  omitEmpty,
+				tag:        tag,
+				structType: structType,
+			})
+		}
+	}
+	return fields, nil
 }
 
 // nameNotFoundError generates the arguments present and returns a typeMissingError

--- a/internal/typeinfo/arginfo_test.go
+++ b/internal/typeinfo/arginfo_test.go
@@ -139,7 +139,9 @@ func (s *typeInfoSuite) TestArgInfoMap(c *C) {
 
 func (s *typeInfoSuite) TestArgInfoEmbeddedStruct(c *C) {
 	type EmbeddedString string
-	type StructWithTag struct{}
+	type TaggedStruct struct {
+		FX int `db:"shouldntberead"`
+	}
 	type Embedded3 struct {
 		F3 int `db:"col3"`
 	}
@@ -152,7 +154,7 @@ func (s *typeInfoSuite) TestArgInfoEmbeddedStruct(c *C) {
 	}
 	type Embeddings struct {
 		EmbeddedString
-		StructWithTag `db:"col4"`
+		TaggedStruct `db:"col4"`
 		Embedded1
 		Embedded2
 		F0 int `db:"col0"`
@@ -190,7 +192,7 @@ func (s *typeInfoSuite) TestArgInfoEmbeddedStruct(c *C) {
 		tag:        "col3",
 		omitEmpty:  false,
 	}, {
-		name:       "StructWithTag",
+		name:       "TaggedStruct",
 		structType: structType,
 		index:      []int{1},
 		tag:        "col4",

--- a/internal/typeinfo/arginfo_test.go
+++ b/internal/typeinfo/arginfo_test.go
@@ -39,42 +39,42 @@ func (s *typeInfoSuite) TestArgInfoStruct(c *C) {
 	// AllStructOutputs.
 	structFields := []struct {
 		fieldName string
-		index     int
+		index     []int
 		omitEmpty bool
 		tag       string
 	}{{
 		fieldName: "ValidTag3",
-		index:     4,
+		index:     []int{4},
 		omitEmpty: false,
 		tag:       "\"£&**\"",
 	}, {
 		fieldName: "ValidTag4",
-		index:     5,
+		index:     []int{5},
 		omitEmpty: false,
 		tag:       "'!£$%^&*('",
 	}, {
 		fieldName: "ValidTag5",
-		index:     6,
+		index:     []int{6},
 		omitEmpty: false,
 		tag:       "99",
 	}, {
 		fieldName: "ValidTag2",
-		index:     3,
+		index:     []int{3},
 		omitEmpty: false,
 		tag:       "IdENT99",
 	}, {
 		fieldName: "ValidTag1",
-		index:     2,
+		index:     []int{2},
 		omitEmpty: false,
 		tag:       "_i_d_55_",
 	}, {
 		fieldName: "ID",
-		index:     0,
+		index:     []int{0},
 		omitEmpty: false,
 		tag:       "id",
 	}, {
 		fieldName: "Name",
-		index:     1,
+		index:     []int{1},
 		omitEmpty: true,
 		tag:       "name",
 	}}
@@ -135,6 +135,76 @@ func (s *typeInfoSuite) TestArgInfoMap(c *C) {
 	kind, err := argInfo.Kind("myMap")
 	c.Assert(err, IsNil)
 	c.Check(kind, DeepEquals, reflect.Map)
+}
+
+func (s *typeInfoSuite) TestArgInfoEmbeddedStruct(c *C) {
+	type EmbeddedString string
+	type StructWithTag struct{}
+	type Embedded3 struct {
+		F3 int `db:"col3"`
+	}
+	type Embedded2 struct {
+		F2 int `db:"col2"`
+		Embedded3
+	}
+	type Embedded1 struct {
+		F1 int `db:"col1"`
+	}
+	type Embeddings struct {
+		EmbeddedString
+		StructWithTag `db:"col4"`
+		Embedded1
+		Embedded2
+		F0 int `db:"col0"`
+	}
+	structType := reflect.TypeOf(Embeddings{})
+
+	argInfo, err := GenerateArgInfo([]any{Embeddings{}})
+	c.Assert(err, IsNil)
+
+	// The struct fields in this list are ordered according to how sort.Strings
+	// orders the tag names. This matches the order of the tags in
+	// structInfo.tags
+	expectedStructFields := []*structField{{
+		name:       "F0",
+		structType: structType,
+		index:      []int{4},
+		tag:        "col0",
+		omitEmpty:  false,
+	}, {
+		name:       "F1",
+		structType: structType,
+		index:      []int{2, 0},
+		tag:        "col1",
+		omitEmpty:  false,
+	}, {
+		name:       "F2",
+		structType: structType,
+		index:      []int{3, 0},
+		tag:        "col2",
+		omitEmpty:  false,
+	}, {
+		name:       "F3",
+		structType: structType,
+		index:      []int{3, 1, 0},
+		tag:        "col3",
+		omitEmpty:  false,
+	}, {
+		name:       "StructWithTag",
+		structType: structType,
+		index:      []int{1},
+		tag:        "col4",
+		omitEmpty:  false,
+	}}
+
+	si, err := argInfo.getAllStructMembers("Embeddings")
+	var fields []*structField
+	for _, tag := range si.tags {
+		fields = append(fields, si.tagToField[tag])
+	}
+	c.Assert(err, IsNil)
+	c.Check(fields, HasLen, len(expectedStructFields))
+	c.Check(fields, DeepEquals, expectedStructFields)
 }
 
 // This struct is used to test shadowed types in TestGenerateArgInfoInvalidTypeErrors

--- a/internal/typeinfo/valuelocator.go
+++ b/internal/typeinfo/valuelocator.go
@@ -115,8 +115,8 @@ type structField struct {
 	// structType is the reflected type of the struct containing this field.
 	structType reflect.Type
 
-	// index for Type.Field.
-	index int
+	// index for Type.FieldByIndex.
+	index []int
 
 	// tag is the struct tag associated with this field.
 	tag string
@@ -139,11 +139,11 @@ func (f *structField) LocateParams(typeToValue TypeToValue) (vals []reflect.Valu
 	if !ok {
 		return nil, false, valueNotFoundError(typeToValue, f.structType)
 	}
-	val := s.Field(f.index)
+	val := s.FieldByIndex(f.index)
 	if val.IsZero() && f.omitEmpty {
 		omitempty = true
 	}
-	return []reflect.Value{s.Field(f.index)}, omitempty, nil
+	return []reflect.Value{val}, omitempty, nil
 }
 
 // Desc returns a natural language description of the struct field for use in
@@ -167,7 +167,7 @@ func (f *structField) LocateScanTarget(typeToValue TypeToValue) (any, *ScanProxy
 	if !ok {
 		return nil, nil, valueNotFoundError(typeToValue, f.structType)
 	}
-	val := s.Field(f.index)
+	val := s.FieldByIndex(f.index)
 	if !val.CanSet() {
 		return nil, nil, fmt.Errorf("internal error: cannot set field %s of struct %s", f.name, f.structType.Name())
 	}


### PR DESCRIPTION
Embedded structs in Go are not automatically promoted to the containing struct. No explicit support for them has been added to SQLair before so they are not currently supported.

This PR adds support for arbitrary levels of embedded structs. All fields in the embedded structs will be promoted to the top level.

You will now be able to do:
```
type Embedded struct {
  F int `db:"embeddedColName"`
}

type S struct {
  Embedded
}

stmt, err := sqlair.Prepare("SELECT &S.embeddedColName FROM t", S{})
```


Also:
- Add check for repeated tags.
- Add some tests for scanner/valuer interfaces