### PR TITLE
Allow omitempty flag to be used with INSERT statements

### DIFF
--- a/internal/expr/bindinputs.go
+++ b/internal/expr/bindinputs.go
@@ -49,10 +49,10 @@ func (tbe *TypeBoundExpr) BindInputs(args ...any) (pq *PrimedQuery, err error) {
 			if err != nil {
 				return nil, err
 			}
-
 			if omit {
 				return nil, omitEmptyInputError(te.input.Desc())
 			}
+
 			argTypeUsed[te.input.ArgType()] = true
 			sqlBuilder.writeInput(inputCount, len(vals))
 			for _, val := range vals {
@@ -142,6 +142,7 @@ type insertColumn struct {
 	explicit bool
 }
 
+// newInsertColumn builds an insert column.
 func newInsertColumn(input typeinfo.Input, column string, explicit bool) insertColumn {
 	return insertColumn{
 		input:    input,
@@ -162,6 +163,8 @@ type typedOutputExpr struct {
 	outputColumns []outputColumn
 }
 
+// sqlBuilder is used to generate SQL string piece by piece using the struct
+// methods.
 type sqlBuilder struct {
 	buf bytes.Buffer
 }
@@ -211,7 +214,7 @@ func (b *sqlBuilder) write(sql string) {
 	b.buf.WriteString(sql)
 }
 
-// write writes the SQL to the sqlBuilder.
+// getSQL returns the generated SQL string
 func (b *sqlBuilder) getSQL() string {
 	return b.buf.String()
 }

--- a/internal/expr/bindtypes.go
+++ b/internal/expr/bindtypes.go
@@ -150,22 +150,16 @@ func (e *asteriskInsertExpr) bindTypes(argInfo typeinfo.ArgInfo) (tie any, err e
 				return nil, err
 			}
 			for i, input := range inputs {
-				cols = append(cols, insertColumn{
-					column:   tags[i],
-					input:    input,
-					explicit: false,
-				})
+				c := newInsertColumn(input, tags[i], false)
+				cols = append(cols, c)
 			}
 		} else {
 			input, err := argInfo.InputMember(source.typeName, source.memberName)
 			if err != nil {
 				return nil, err
 			}
-			cols = append(cols, insertColumn{
-				column:   source.memberName,
-				input:    input,
-				explicit: true,
-			})
+			c := newInsertColumn(input, source.memberName, true)
+			cols = append(cols, c)
 		}
 	}
 	return &typedInsertExpr{insertColumns: cols}, nil
@@ -258,11 +252,9 @@ func (e *columnsInsertExpr) bindTypes(argInfo typeinfo.ArgInfo) (tie any, err er
 		if len(input) > 1 {
 			return nil, fmt.Errorf("more than one type provides column %q", columnStr)
 		}
-		cols = append(cols, insertColumn{
-			column:   columnStr,
-			input:    input[0],
-			explicit: true,
-		})
+
+		c := newInsertColumn(input[0], columnStr, true)
+		cols = append(cols, c)
 	}
 	return &typedInsertExpr{insertColumns: cols}, nil
 }

--- a/internal/expr/bindtypes.go
+++ b/internal/expr/bindtypes.go
@@ -142,26 +142,33 @@ func (e *asteriskInsertExpr) bindTypes(argInfo typeinfo.ArgInfo) (tie any, err e
 		}
 	}()
 
-	var inputs []typeinfo.Input
-	var columns []string
+	var cols []insertColumn
 	for _, source := range e.sources {
 		if source.memberName == "*" {
-			inps, tags, err := argInfo.AllStructInputs(source.typeName)
+			inputs, tags, err := argInfo.AllStructInputs(source.typeName)
 			if err != nil {
 				return nil, err
 			}
-			columns = append(columns, tags...)
-			inputs = append(inputs, inps...)
+			for i, input := range inputs {
+				cols = append(cols, insertColumn{
+					column:   tags[i],
+					input:    input,
+					explicit: false,
+				})
+			}
 		} else {
-			inp, err := argInfo.InputMember(source.typeName, source.memberName)
+			input, err := argInfo.InputMember(source.typeName, source.memberName)
 			if err != nil {
 				return nil, err
 			}
-			columns = append(columns, source.memberName)
-			inputs = append(inputs, inp)
+			cols = append(cols, insertColumn{
+				column:   source.memberName,
+				input:    input,
+				explicit: true,
+			})
 		}
 	}
-	return &typedInsertExpr{inputs: inputs, columns: columns}, nil
+	return &typedInsertExpr{insertColumns: cols}, nil
 }
 
 // columnsInsertExpr is an input expression occurring within an INSERT statement
@@ -233,8 +240,7 @@ func (e *columnsInsertExpr) bindTypes(argInfo typeinfo.ArgInfo) (tie any, err er
 	// and match them against the columns provided by the types on the right.
 	// If a map with an asterisk is present, we use it to supply the spare
 	// columns. If it is not present, a spare column is an error.
-	var columns []string
-	var inputs []typeinfo.Input
+	var cols []insertColumn
 	for _, column := range e.columns {
 		columnStr := column.String()
 		input, ok := colToInput[columnStr]
@@ -252,10 +258,13 @@ func (e *columnsInsertExpr) bindTypes(argInfo typeinfo.ArgInfo) (tie any, err er
 		if len(input) > 1 {
 			return nil, fmt.Errorf("more than one type provides column %q", columnStr)
 		}
-		columns = append(columns, columnStr)
-		inputs = append(inputs, input[0])
+		cols = append(cols, insertColumn{
+			column:   columnStr,
+			input:    input[0],
+			explicit: true,
+		})
 	}
-	return &typedInsertExpr{inputs: inputs, columns: columns}, nil
+	return &typedInsertExpr{insertColumns: cols}, nil
 }
 
 // sliceInputExpr is an input expression of the form "$S[:]" that represents a

--- a/internal/typeinfo/arginfo.go
+++ b/internal/typeinfo/arginfo.go
@@ -296,7 +296,7 @@ func parseTag(tag string) (string, bool, error) {
 	var omitEmpty bool
 	if len(options) > 1 {
 		for _, flag := range options[1:] {
-			if flag == "omitempty" {
+			if strings.TrimSpace(flag) == "omitempty" {
 				omitEmpty = true
 			} else {
 				return "", omitEmpty, fmt.Errorf("unsupported flag %q in tag %q", flag, tag)


### PR DESCRIPTION
When inserting a into a table with unique primary keys the user needs to specify the primary key in their object every time. If it is left to its default zero value it will most likely break the unique constraint. In some tables, the primary key can is auto when a new row is inserted. In this case the user may want to insert a full struct using the asterisk notation but omitting the primary key.

To automatically omit a primary key, the user can set a flag in the `db` tag after the column name for the field e.g. 
```
type Person struct {
	ID        int    `db:"id, omitempty"`
	Name      string `db:"name"`
	PostCode  int    `db:"address_id"`
}
```
This will indicate to SQLair that if this value is zero when the parameter is passed for execution, it should not be inserted into the database.

As specified in the [INSERT statement support specification](https://docs.google.com/document/d/1DMKPS85msymrdbA5-EoP4Sf6b9blSAjtj367EuEmP7Y/edit), the omit empty flag should only work for struct fields being inserted via an asterisk. If the field is inserted explicitly, e.g. `INSERT INTO t (id) VALUES ($Person.id)` then we should throw an error. Similarly, if a tag with `omitempty` set is used in an input expression elsewhere, an error should also be thrown e.g. `SELECT &Person.* FROM person WHERE id = $Person.id`.