### PR TITLE
Use vars for database entries and add INSERT tests

### DIFF
--- a/package_test.go
+++ b/package_test.go
@@ -533,7 +533,7 @@ func (s *PackageSuite) TestValidGetAll(c *C) {
 		types:    []any{Person{}, Address{}},
 		inputs:   []any{},
 		slices:   []any{&[]*Person{}, &[]*Address{}},
-		expected: []any{&[]*Person{&Person{ID: fred.ID}, &Person{ID: fred.ID}, &Person{ID: fred.ID}, &Person{ID: mark.ID}, &Person{ID: mark.ID}, &Person{ID: mark.ID}, &Person{ID: mary.ID}, &Person{ID: mary.ID}, &Person{ID: mary.ID}, &Person{ID: dave.ID}, &Person{ID: dave.ID}, &Person{ID: dave.ID}}, &[]*Address{&Address{ID: mainStreet.ID}, &Address{ID: churchRoad.ID}, &Address{ID: stationLane.ID}, &Address{ID: mainStreet.ID}, &Address{ID: churchRoad.ID}, &Address{ID: stationLane.ID}, &Address{ID: mainStreet.ID}, &Address{ID: churchRoad.ID}, &Address{ID: stationLane.ID}, &Address{ID: mainStreet.ID}, &Address{ID: churchRoad.ID}, &Address{ID: stationLane.ID}}},
+		expected: []any{&[]*Person{{ID: fred.ID}, {ID: fred.ID}, {ID: fred.ID}, {ID: mark.ID}, {ID: mark.ID}, {ID: mark.ID}, {ID: mary.ID}, {ID: mary.ID}, {ID: mary.ID}, {ID: dave.ID}, {ID: dave.ID}, {ID: dave.ID}}, &[]*Address{{ID: mainStreet.ID}, {ID: churchRoad.ID}, {ID: stationLane.ID}, {ID: mainStreet.ID}, {ID: churchRoad.ID}, {ID: stationLane.ID}, {ID: mainStreet.ID}, {ID: churchRoad.ID}, {ID: stationLane.ID}, {ID: mainStreet.ID}, {ID: churchRoad.ID}, {ID: stationLane.ID}}},
 	}, {
 		summary:  "select all columns into person",
 		query:    "SELECT * AS &Person.* FROM person",

--- a/package_test.go
+++ b/package_test.go
@@ -8,6 +8,7 @@ import (
 	"database/sql"
 	"errors"
 	"fmt"
+	"strconv"
 	"testing"
 
 	_ "github.com/mattn/go-sqlite3"
@@ -23,20 +24,12 @@ type PackageSuite struct{}
 
 var _ = Suite(&PackageSuite{})
 
-func setupDB() (*sql.DB, error) {
-	return sql.Open("sqlite3", "file:test.db?cache=shared&mode=memory")
-}
-
-func createExampleDB(c *C, createTables string, inserts []string) (*sql.DB, error) {
-	db, err := setupDB()
-	c.Assert(err, IsNil)
-
-	_, err = db.Exec(createTables)
-	c.Assert(err, IsNil)
-	for _, insert := range inserts {
-		_, err := db.Exec(insert)
-		c.Assert(err, IsNil)
+func openTestDB() (*sqlair.DB, error) {
+	sqldb, err := sql.Open("sqlite3", "file:test.db?cache=shared&mode=memory")
+	if err != nil {
+		return nil, err
 	}
+	db := sqlair.NewDB(sqldb)
 	return db, nil
 }
 
@@ -57,9 +50,9 @@ type Address struct {
 }
 
 type Person struct {
-	ID         int    `db:"id"`
-	Fullname   string `db:"name"`
-	PostalCode int    `db:"address_id"`
+	ID       int    `db:"id"`
+	Name     string `db:"name"`
+	Postcode int    `db:"address_id"`
 }
 
 type Manager Person
@@ -72,48 +65,53 @@ type unexportedStruct struct {
 	X int `db:"id"`
 }
 
+var fred = Person{Name: "Fred", ID: 30, Postcode: 1000}
+var mark = Person{Name: "Mark", ID: 20, Postcode: 1500}
+var mary = Person{Name: "Mary", ID: 40, Postcode: 3500}
+var dave = Person{Name: "Dave", ID: 35, Postcode: 4500}
+var allPeople = []Person{fred, mark, mary, dave}
+
+var mainStreet = Address{Street: "Main Street", District: "Happy Land", ID: 1000}
+var churchRoad = Address{Street: "Church Road", District: "Sad World", ID: 1500}
+var stationLane = Address{Street: "Station Lane", District: "Ambivalent Commons", ID: 3500}
+var allAddresses = []Address{mainStreet, churchRoad, stationLane}
+
 func personAndAddressDB(c *C) ([]string, *sqlair.DB, error) {
-	createTables := `
-CREATE TABLE person (
-	name text,
-	id integer,
-	address_id integer,
-	email text
-);
-CREATE TABLE address (
-	id integer,
-	district text,
-	street text
-);
-`
+	db, err := openTestDB()
+	c.Assert(err, IsNil)
 
-	sqldb, err := setupDB()
+	createPerson, err := sqlair.Prepare(`
+		CREATE TABLE person (
+			name text,
+			id integer,
+			address_id integer,
+			email text
+		);
+	`)
 	c.Assert(err, IsNil)
-	_, err = sqldb.Exec(createTables)
+	createAddress, err := sqlair.Prepare(`
+		CREATE TABLE address (
+			id integer,
+			district text,
+			street text
+		);
+	`)
 	c.Assert(err, IsNil)
-	db := sqlair.NewDB(sqldb)
 
-	people := []Person{
-		{Fullname: "Fred", ID: 30, PostalCode: 1000},
-		{Fullname: "Mark", ID: 20, PostalCode: 1500},
-		{Fullname: "Mary", ID: 40, PostalCode: 3500},
-		{Fullname: "James", ID: 35, PostalCode: 4500},
-	}
-	addresses := []Address{
-		{ID: 1000, District: "Happy Land", Street: "Main Street"},
-		{ID: 1500, District: "Sad World", Street: "Church Road"},
-		{ID: 3500, District: "Ambivalent Commons", Street: "Station Lane"},
-	}
-	personInsert, err := sqlair.Prepare("INSERT INTO person (*) VALUES ($Person.*);", Person{})
+	err = db.Query(nil, createPerson).Run()
 	c.Assert(err, IsNil)
-	for _, person := range people {
-		err := db.Query(nil, personInsert, person).Run()
+	err = db.Query(nil, createAddress).Run()
+	c.Assert(err, IsNil)
+
+	insertPerson, err := sqlair.Prepare("INSERT INTO person (*) VALUES ($Person.*)", Person{})
+	for _, person := range allPeople {
+		err := db.Query(nil, insertPerson, person).Run()
 		c.Assert(err, IsNil)
 	}
-	addressInsert, err := sqlair.Prepare("INSERT INTO address (*) VALUES ($Address.*)", Address{})
-	c.Assert(err, IsNil)
-	for _, address := range addresses {
-		err := db.Query(nil, addressInsert, address).Run()
+
+	insertAddress, err := sqlair.Prepare("INSERT INTO address (*) VALUES ($Address.*)", Address{})
+	for _, address := range allAddresses {
+		err := db.Query(nil, insertAddress, address).Run()
 		c.Assert(err, IsNil)
 	}
 
@@ -141,70 +139,70 @@ func (s *PackageSuite) TestValidIterGet(c *C) {
 		types:    []any{Person{}, Address{}},
 		inputs:   []any{},
 		outputs:  [][]any{{&Person{}, &Address{}}, {&Person{}, &Address{}}, {&Person{}, &Address{}}, {&Person{}, &Address{}}, {&Person{}, &Address{}}, {&Person{}, &Address{}}, {&Person{}, &Address{}}, {&Person{}, &Address{}}, {&Person{}, &Address{}}, {&Person{}, &Address{}}, {&Person{}, &Address{}}, {&Person{}, &Address{}}},
-		expected: [][]any{{&Person{ID: 30}, &Address{ID: 1000}}, {&Person{ID: 30}, &Address{ID: 1500}}, {&Person{ID: 30}, &Address{ID: 3500}}, {&Person{ID: 20}, &Address{ID: 1000}}, {&Person{ID: 20}, &Address{ID: 1500}}, {&Person{ID: 20}, &Address{ID: 3500}}, {&Person{ID: 40}, &Address{ID: 1000}}, {&Person{ID: 40}, &Address{ID: 1500}}, {&Person{ID: 40}, &Address{ID: 3500}}, {&Person{ID: 35}, &Address{ID: 1000}}, {&Person{ID: 35}, &Address{ID: 1500}}, {&Person{ID: 35}, &Address{ID: 3500}}},
+		expected: [][]any{{&Person{ID: fred.ID}, &Address{ID: mainStreet.ID}}, {&Person{ID: fred.ID}, &Address{ID: churchRoad.ID}}, {&Person{ID: fred.ID}, &Address{ID: stationLane.ID}}, {&Person{ID: mark.ID}, &Address{ID: mainStreet.ID}}, {&Person{ID: mark.ID}, &Address{ID: churchRoad.ID}}, {&Person{ID: mark.ID}, &Address{ID: stationLane.ID}}, {&Person{ID: mary.ID}, &Address{ID: mainStreet.ID}}, {&Person{ID: mary.ID}, &Address{ID: churchRoad.ID}}, {&Person{ID: mary.ID}, &Address{ID: stationLane.ID}}, {&Person{ID: dave.ID}, &Address{ID: mainStreet.ID}}, {&Person{ID: dave.ID}, &Address{ID: churchRoad.ID}}, {&Person{ID: dave.ID}, &Address{ID: stationLane.ID}}},
 	}, {
 		summary:  "simple select person",
 		query:    "SELECT * AS &Person.* FROM person",
 		types:    []any{Person{}},
 		inputs:   []any{},
 		outputs:  [][]any{{&Person{}}, {&Person{}}, {&Person{}}, {&Person{}}},
-		expected: [][]any{{&Person{30, "Fred", 1000}}, {&Person{20, "Mark", 1500}}, {&Person{40, "Mary", 3500}}, {&Person{35, "James", 4500}}},
+		expected: [][]any{{&fred}, {&mark}, {&mary}, {&dave}},
 	}, {
 		summary:  "select multiple with extras",
 		query:    "SELECT email, * AS &Person.*, address_id AS &Address.id, * AS &Manager.*, id FROM person WHERE id = $Address.id",
 		types:    []any{Person{}, Address{}, Manager{}},
-		inputs:   []any{Address{ID: 30}},
+		inputs:   []any{Address{ID: fred.ID}},
 		outputs:  [][]any{{&Person{}, &Address{}, &Manager{}}},
-		expected: [][]any{{&Person{30, "Fred", 1000}, &Address{ID: 1000}, &Manager{30, "Fred", 1000}}},
+		expected: [][]any{{&fred, &Address{ID: mainStreet.ID}, &Manager{fred.ID, fred.Name, fred.Postcode}}},
 	}, {
 		summary:  "select with renaming",
 		query:    "SELECT (name, address_id) AS (&Address.street, &Address.id) FROM person WHERE id = $Manager.id",
 		types:    []any{Address{}, Manager{}},
-		inputs:   []any{Manager{ID: 30}},
+		inputs:   []any{Manager{ID: fred.ID}},
 		outputs:  [][]any{{&Address{}}},
-		expected: [][]any{{&Address{Street: "Fred", ID: 1000}}},
+		expected: [][]any{{&Address{Street: fred.Name, ID: fred.Postcode}}},
 	}, {
 		summary:  "select into star struct",
 		query:    "SELECT (name, address_id) AS (&Person.*) FROM person WHERE address_id IN ( $Manager.address_id, $Address.district )",
 		types:    []any{Person{}, Address{}, Manager{}},
-		inputs:   []any{Manager{PostalCode: 1000}, Address{ID: 2000}},
+		inputs:   []any{Manager{Postcode: fred.Postcode}, Address{}},
 		outputs:  [][]any{{&Person{}}},
-		expected: [][]any{{&Person{Fullname: "Fred", PostalCode: 1000}}},
+		expected: [][]any{{&Person{Name: fred.Name, Postcode: fred.Postcode}}},
 	}, {
 		summary:  "select into map",
 		query:    "SELECT &M.name FROM person WHERE address_id = $M.p1 OR address_id = $M.p2",
 		types:    []any{sqlair.M{}},
-		inputs:   []any{sqlair.M{"p1": 1000, "p2": 1500}},
+		inputs:   []any{sqlair.M{"p1": fred.Postcode, "p2": mark.Postcode}},
 		outputs:  [][]any{{sqlair.M{}}, {sqlair.M{}}},
-		expected: [][]any{{sqlair.M{"name": "Fred"}}, {sqlair.M{"name": "Mark"}}},
+		expected: [][]any{{sqlair.M{"name": fred.Name}}, {sqlair.M{"name": mark.Name}}},
 	}, {
 		summary:  "select into star map",
 		query:    "SELECT (name, address_id) AS (&M.*) FROM person WHERE address_id = $M.p1",
 		types:    []any{sqlair.M{}},
-		inputs:   []any{sqlair.M{"p1": 1000}},
+		inputs:   []any{sqlair.M{"p1": fred.Postcode}},
 		outputs:  [][]any{{&sqlair.M{"address_id": 0}}},
-		expected: [][]any{{&sqlair.M{"name": "Fred", "address_id": int64(1000)}}},
+		expected: [][]any{{&sqlair.M{"name": fred.Name, "address_id": int64(fred.Postcode)}}},
 	}, {
 		summary:  "select into custom map",
 		query:    "SELECT (name, address_id) AS (&CustomMap.*) FROM person WHERE address_id IN ( $CustomMap.address_id, $CustomMap.district)",
 		types:    []any{CustomMap{}},
-		inputs:   []any{CustomMap{"address_id": 1000, "district": 2000}},
+		inputs:   []any{CustomMap{"address_id": fred.Postcode, "district": "Lala land"}},
 		outputs:  [][]any{{&CustomMap{"address_id": 0}}},
-		expected: [][]any{{&CustomMap{"name": "Fred", "address_id": int64(1000)}}},
+		expected: [][]any{{&CustomMap{"name": fred.Name, "address_id": int64(fred.Postcode)}}},
 	}, {
 		summary:  "multiple maps",
 		query:    "SELECT name AS &StringMap.*, id AS &CustomMap.* FROM person WHERE address_id = $M.address_id AND id = $StringMap.id",
 		types:    []any{StringMap{}, sqlair.M{}, CustomMap{}},
 		inputs:   []any{sqlair.M{"address_id": "1000"}, &StringMap{"id": "30"}},
 		outputs:  [][]any{{&StringMap{}, CustomMap{}}},
-		expected: [][]any{{&StringMap{"name": "Fred"}, CustomMap{"id": int64(30)}}},
+		expected: [][]any{{&StringMap{"name": fred.Name}, CustomMap{"id": int64(30)}}},
 	}, {
 		summary:  "lower case map",
 		query:    "SELECT name AS &unexportedMap.*, id AS &unexportedMap.* FROM person WHERE address_id = $unexportedMap.address_id",
 		types:    []any{unexportedMap{}},
 		inputs:   []any{unexportedMap{"address_id": "1000"}},
 		outputs:  [][]any{{&unexportedMap{}}},
-		expected: [][]any{{&unexportedMap{"name": "Fred", "id": int64(30)}}},
+		expected: [][]any{{&unexportedMap{"name": fred.Name, "id": int64(fred.ID)}}},
 	}, {
 		summary:  "insert",
 		query:    "INSERT INTO address VALUES ($Address.id, $Address.district, $Address.street);",
@@ -223,23 +221,23 @@ func (s *PackageSuite) TestValidIterGet(c *C) {
 		summary:  "simple in",
 		query:    "SELECT * AS &Person.* FROM person WHERE id IN ($S[:])",
 		types:    []any{Person{}, sqlair.S{}},
-		inputs:   []any{sqlair.S{30, 35, 36, 37, 38, 39, 40}},
+		inputs:   []any{sqlair.S{30, 35, 36, 37, 38, 39, 40, fred.ID, mary.ID, dave.ID}},
 		outputs:  [][]any{{&Person{}}, {&Person{}}, {&Person{}}},
-		expected: [][]any{{&Person{30, "Fred", 1000}}, {&Person{40, "Mary", 3500}}, {&Person{35, "James", 4500}}},
+		expected: [][]any{{&fred}, {&mary}, {&dave}},
 	}, {
 		summary:  "complex in",
 		query:    "SELECT * AS &Person.* FROM person WHERE id IN ($Person.id, $S[:], $Manager.id, $IntSlice[:], $StringSlice[:])",
 		types:    []any{Person{}, sqlair.S{}, Manager{}, IntSlice{}, StringSlice{}},
-		inputs:   []any{Person{ID: 20}, sqlair.S{21, 23, 24, 25, 26, 27, 28, 29}, IntSlice{31, 32, 33, 34, 35}, &Manager{ID: 30}, StringSlice{"36", "37", "38", "39", "40"}},
+		inputs:   []any{mark, sqlair.S{21, 23, 24, 25, 26, 27, 28, 29}, IntSlice{31, 32, 33, 34, dave.ID}, &Manager{ID: fred.ID}, StringSlice{"36", "37", "38", "39", strconv.Itoa(mary.ID)}},
 		outputs:  [][]any{{&Person{}}, {&Person{}}, {&Person{}}, {&Person{}}},
-		expected: [][]any{{&Person{30, "Fred", 1000}}, {&Person{20, "Mark", 1500}}, {&Person{40, "Mary", 3500}}, {&Person{35, "James", 4500}}},
+		expected: [][]any{{&fred}, {&mark}, {&mary}, {&dave}},
 	}}
 
 	// A Person struct that shadows the one in tests above and has different int types.
 	type Person struct {
-		ID         int32  `db:"id"`
-		Fullname   string `db:"name"`
-		PostalCode int32  `db:"address_id"`
+		ID       int32  `db:"id"`
+		Name     string `db:"name"`
+		Postcode int32  `db:"address_id"`
 	}
 
 	var testsWithShadowPerson = []struct {
@@ -255,7 +253,7 @@ func (s *PackageSuite) TestValidIterGet(c *C) {
 		types:    []any{Person{}},
 		inputs:   []any{},
 		outputs:  [][]any{{&Person{}}, {&Person{}}, {&Person{}}, {&Person{}}},
-		expected: [][]any{{&Person{30, "Fred", 1000}}, {&Person{20, "Mark", 1500}}, {&Person{40, "Mary", 3500}}, {&Person{35, "James", 4500}}},
+		expected: [][]any{{&Person{30, "Fred", 1000}}, {&Person{20, "Mark", 1500}}, {&Person{40, "Mary", 3500}}, {&Person{35, "Dave", 4500}}},
 	}}
 
 	tests = append(tests, testsWithShadowPerson...)
@@ -439,19 +437,19 @@ func (s *PackageSuite) TestNulls(c *C) {
 	type J = int
 	type S = string
 	type PersonWithStrangeTypes struct {
-		ID         I `db:"id"`
-		Fullname   S `db:"name"`
-		PostalCode J `db:"address_id"`
+		ID       I `db:"id"`
+		Name     S `db:"name"`
+		Postcode J `db:"address_id"`
 	}
 	type NullGuy struct {
-		ID         sql.NullInt64  `db:"id"`
-		Fullname   sql.NullString `db:"name"`
-		PostalCode sql.NullInt64  `db:"address_id"`
+		ID       sql.NullInt64  `db:"id"`
+		Name     sql.NullString `db:"name"`
+		Postcode sql.NullInt64  `db:"address_id"`
 	}
 	type ScannerDude struct {
-		ID         ScannerInt    `db:"id"`
-		Fullname   ScannerString `db:"name"`
-		PostalCode ScannerInt    `db:"address_id"`
+		ID       ScannerInt    `db:"id"`
+		Name     ScannerString `db:"name"`
+		Postcode ScannerInt    `db:"address_id"`
 	}
 
 	var tests = []struct {
@@ -466,29 +464,29 @@ func (s *PackageSuite) TestNulls(c *C) {
 		query:    `SELECT &Person.* FROM person WHERE name = "Nully"`,
 		types:    []any{Person{}},
 		inputs:   []any{},
-		outputs:  []any{&Person{ID: 5, PostalCode: 10}},
-		expected: []any{&Person{Fullname: "Nully", ID: 0, PostalCode: 0}},
+		outputs:  []any{&Person{ID: 5, Postcode: 10}},
+		expected: []any{&Person{Name: "Nully", ID: 0, Postcode: 0}},
 	}, {
 		summary:  "reading nulls with custom types",
 		query:    `SELECT &PersonWithStrangeTypes.* FROM person WHERE name = "Nully"`,
 		types:    []any{PersonWithStrangeTypes{}},
 		inputs:   []any{},
-		outputs:  []any{&PersonWithStrangeTypes{ID: 5, PostalCode: 10}},
-		expected: []any{&PersonWithStrangeTypes{Fullname: "Nully", ID: 0, PostalCode: 0}},
+		outputs:  []any{&PersonWithStrangeTypes{ID: 5, Postcode: 10}},
+		expected: []any{&PersonWithStrangeTypes{Name: "Nully", ID: 0, Postcode: 0}},
 	}, {
 		summary:  "regular nulls",
 		query:    `SELECT &NullGuy.* FROM person WHERE name = "Nully"`,
 		types:    []any{NullGuy{}},
 		inputs:   []any{},
 		outputs:  []any{&NullGuy{}},
-		expected: []any{&NullGuy{Fullname: sql.NullString{Valid: true, String: "Nully"}, ID: sql.NullInt64{Valid: false}, PostalCode: sql.NullInt64{Valid: false}}},
+		expected: []any{&NullGuy{Name: sql.NullString{Valid: true, String: "Nully"}, ID: sql.NullInt64{Valid: false}, Postcode: sql.NullInt64{Valid: false}}},
 	}, {
 		summary:  "nulls with custom scan type",
 		query:    `SELECT &ScannerDude.* FROM person WHERE name = "Nully"`,
 		types:    []any{ScannerDude{}},
 		inputs:   []any{},
 		outputs:  []any{&ScannerDude{}},
-		expected: []any{&ScannerDude{Fullname: ScannerString{SS: "ScannerString scanned well!"}, ID: ScannerInt{SI: 666}, PostalCode: ScannerInt{SI: 666}}},
+		expected: []any{&ScannerDude{Name: ScannerString{SS: "ScannerString scanned well!"}, ID: ScannerInt{SI: 666}, Postcode: ScannerInt{SI: 666}}},
 	}}
 
 	tables, db, err := personAndAddressDB(c)
@@ -529,14 +527,21 @@ func (s *PackageSuite) TestValidGet(c *C) {
 		types:    []any{Person{}, Address{}},
 		inputs:   []any{},
 		outputs:  []any{&Person{}, &Address{}},
-		expected: []any{&Person{ID: 30}, &Address{ID: 1000}},
+		expected: []any{&Person{ID: fred.ID}, &Address{ID: mainStreet.ID}},
 	}, {
 		summary:  "select into multiple structs, with input conditions",
 		query:    "SELECT p.* AS &Person.*, a.* AS &Address.*, p.* AS &Manager.* FROM person AS p, address AS a WHERE p.id = $Person.id AND a.id = $Address.id ",
 		types:    []any{Person{}, Address{}, Manager{}},
-		inputs:   []any{Address{ID: 1000}, Person{ID: 30}},
+		inputs:   []any{mainStreet, fred},
 		outputs:  []any{&Person{}, &Address{}, &Manager{}},
-		expected: []any{&Person{30, "Fred", 1000}, &Address{1000, "Happy Land", "Main Street"}, &Manager{30, "Fred", 1000}},
+		expected: []any{&fred, &mainStreet, &Manager{fred.ID, fred.Name, fred.Postcode}},
+	}, {
+		summary:  "select into map",
+		query:    "SELECT &M.name FROM person WHERE address_id = $M.p1",
+		types:    []any{sqlair.M{}},
+		inputs:   []any{sqlair.M{"p1": fred.Postcode}},
+		outputs:  []any{sqlair.M{}},
+		expected: []any{sqlair.M{"name": fred.Name}},
 	}, {
 		summary:  "lower case struct",
 		query:    "SELECT &unexportedStruct.* FROM person",
@@ -544,13 +549,6 @@ func (s *PackageSuite) TestValidGet(c *C) {
 		inputs:   []any{},
 		outputs:  []any{&unexportedStruct{}},
 		expected: []any{&unexportedStruct{X: 30}},
-	}, {
-		summary:  "select into map",
-		query:    "SELECT &M.name FROM person WHERE address_id = $M.p1",
-		types:    []any{sqlair.M{}},
-		inputs:   []any{sqlair.M{"p1": 1000}},
-		outputs:  []any{sqlair.M{}},
-		expected: []any{sqlair.M{"name": "Fred"}},
 	}, {
 		summary:  "sql functions",
 		query:    `SELECT (max(AVG(id), AVG(address_id), length("((((''""((")), IFNULL(name, "Mr &Person.id of $M.name")) AS (&M.avg, &M.name), round(24.5234) AS other_col FROM person`,
@@ -658,35 +656,35 @@ func (s *PackageSuite) TestValidGetAll(c *C) {
 		types:    []any{Person{}, Address{}},
 		inputs:   []any{},
 		slices:   []any{&[]*Person{}, &[]*Address{}},
-		expected: []any{&[]*Person{{ID: 30}, {ID: 30}, {ID: 30}, {ID: 20}, {ID: 20}, {ID: 20}, {ID: 40}, {ID: 40}, {ID: 40}, {ID: 35}, {ID: 35}, {ID: 35}}, &[]*Address{{ID: 1000}, {ID: 1500}, {ID: 3500}, {ID: 1000}, {ID: 1500}, {ID: 3500}, {ID: 1000}, {ID: 1500}, {ID: 3500}, {ID: 1000}, {ID: 1500}, {ID: 3500}}},
+		expected: []any{&[]*Person{&Person{ID: fred.ID}, &Person{ID: fred.ID}, &Person{ID: fred.ID}, &Person{ID: mark.ID}, &Person{ID: mark.ID}, &Person{ID: mark.ID}, &Person{ID: mary.ID}, &Person{ID: mary.ID}, &Person{ID: mary.ID}, &Person{ID: dave.ID}, &Person{ID: dave.ID}, &Person{ID: dave.ID}}, &[]*Address{&Address{ID: mainStreet.ID}, &Address{ID: churchRoad.ID}, &Address{ID: stationLane.ID}, &Address{ID: mainStreet.ID}, &Address{ID: churchRoad.ID}, &Address{ID: stationLane.ID}, &Address{ID: mainStreet.ID}, &Address{ID: churchRoad.ID}, &Address{ID: stationLane.ID}, &Address{ID: mainStreet.ID}, &Address{ID: churchRoad.ID}, &Address{ID: stationLane.ID}}},
 	}, {
 		summary:  "select all columns into person",
 		query:    "SELECT * AS &Person.* FROM person",
 		types:    []any{Person{}},
 		inputs:   []any{},
 		slices:   []any{&[]*Person{}},
-		expected: []any{&[]*Person{{30, "Fred", 1000}, {20, "Mark", 1500}, {40, "Mary", 3500}, {35, "James", 4500}}},
+		expected: []any{&[]*Person{&fred, &mark, &mary, &dave}},
 	}, {
 		summary:  "select all columns into person with no pointers",
 		query:    "SELECT * AS &Person.* FROM person",
 		types:    []any{Person{}},
 		inputs:   []any{},
 		slices:   []any{&[]Person{}},
-		expected: []any{&[]Person{{30, "Fred", 1000}, {20, "Mark", 1500}, {40, "Mary", 3500}, {35, "James", 4500}}},
+		expected: []any{&[]Person{fred, mark, mary, dave}},
 	}, {
 		summary:  "single line of query with inputs",
 		query:    "SELECT p.* AS &Person.*, a.* AS &Address.*, p.* AS &Manager.* FROM person AS p, address AS a WHERE p.id = $Person.id AND a.id = $Address.id ",
 		types:    []any{Person{}, Address{}, Manager{}},
-		inputs:   []any{Address{ID: 1000}, Person{ID: 30}},
+		inputs:   []any{Address{ID: mainStreet.ID}, Person{ID: fred.ID}},
 		slices:   []any{&[]*Manager{}, &[]*Person{}, &[]*Address{}},
-		expected: []any{&[]*Manager{{30, "Fred", 1000}}, &[]*Person{{30, "Fred", 1000}}, &[]*Address{{1000, "Happy Land", "Main Street"}}},
+		expected: []any{&[]*Manager{{fred.ID, fred.Name, fred.Postcode}}, &[]*Person{&fred}, &[]*Address{&mainStreet}},
 	}, {
 		summary:  "select into maps",
-		query:    "SELECT &M.name, &CustomMap.id FROM person WHERE name = 'Mark'",
-		types:    []any{sqlair.M{}, CustomMap{}},
-		inputs:   []any{},
+		query:    "SELECT &M.name, &CustomMap.id FROM person WHERE name = $Person.name",
+		types:    []any{sqlair.M{}, CustomMap{}, Person{}},
+		inputs:   []any{mark},
 		slices:   []any{&[]sqlair.M{}, &[]CustomMap{}},
-		expected: []any{&[]sqlair.M{{"name": "Mark"}}, &[]CustomMap{{"id": int64(20)}}},
+		expected: []any{&[]sqlair.M{{"name": mark.Name}}, &[]CustomMap{{"id": int64(mark.ID)}}},
 	}, {
 		summary:  "GetAll returns no error when there are no outputs",
 		query:    `INSERT INTO person (name) VALUES ($M.name)`,
@@ -817,9 +815,9 @@ func (s *PackageSuite) TestRun(c *C) {
 	defer dropTables(c, db, tables...)
 
 	var jim = Person{
-		ID:         70,
-		Fullname:   "Jim",
-		PostalCode: 500,
+		ID:       70,
+		Name:     "Jim",
+		Postcode: 500,
 	}
 
 	// Insert Jim.
@@ -834,9 +832,9 @@ func (s *PackageSuite) TestRun(c *C) {
 	c.Assert(err, IsNil)
 
 	joe := Person{
-		ID:         34,
-		Fullname:   "Joe",
-		PostalCode: 55555,
+		ID:       34,
+		Name:     "Joe",
+		Postcode: 55555,
 	}
 	// Insert Joe.
 	err = db.Query(nil, insertStmt, &joe).Run()
@@ -856,9 +854,9 @@ func (s *PackageSuite) TestOutcome(c *C) {
 	defer dropTables(c, db, tables...)
 
 	var jim = Person{
-		ID:         70,
-		Fullname:   "Jim",
-		PostalCode: 500,
+		ID:       70,
+		Name:     "Jim",
+		Postcode: 500,
 	}
 
 	var outcome = sqlair.Outcome{}
@@ -928,13 +926,13 @@ func (s *PackageSuite) TestQueryMultipleRuns(c *C) {
 	// Note: Query structs are not designed to be reused (hence why they store a context as a struct field).
 	//       It is, however, possible.
 	allOutput := &[]*Person{}
-	allExpected := &[]*Person{{30, "Fred", 1000}, {20, "Mark", 1500}, {40, "Mary", 3500}, {35, "James", 4500}}
+	allExpected := &[]*Person{&fred, &mark, &mary, &dave}
 
 	iterOutputs := []any{&Person{}, &Person{}, &Person{}, &Person{}}
-	iterExpected := []any{&Person{30, "Fred", 1000}, &Person{20, "Mark", 1500}, &Person{40, "Mary", 3500}, &Person{35, "James", 4500}}
+	iterExpected := []any{&fred, &mark, &mary, &dave}
 
 	oneOutput := &Person{}
-	oneExpected := &Person{30, "Fred", 1000}
+	oneExpected := &fred
 
 	tables, db, err := personAndAddressDB(c)
 	c.Assert(err, IsNil)
@@ -976,7 +974,7 @@ func (s *PackageSuite) TestTransactions(c *C) {
 
 	selectStmt := sqlair.MustPrepare("SELECT &Person.* FROM person WHERE address_id = $Person.address_id", Person{})
 	insertStmt := sqlair.MustPrepare("INSERT INTO person VALUES ( $Person.name, $Person.id, $Person.address_id, 'fred@email.com');", Person{})
-	var derek = Person{ID: 85, Fullname: "Derek", PostalCode: 8000}
+	var derek = Person{ID: 85, Name: "Derek", Postcode: 8000}
 	ctx := context.Background()
 
 	tx, err := db.Begin(ctx, nil)
@@ -1021,7 +1019,7 @@ func (s *PackageSuite) TestTransactionErrors(c *C) {
 	defer dropTables(c, db, tables...)
 
 	insertStmt := sqlair.MustPrepare("INSERT INTO person VALUES ($Person.name, $Person.id, $Person.address_id, 'fred@email.com');", Person{})
-	var derek = Person{ID: 85, Fullname: "Derek", PostalCode: 8000}
+	var derek = Person{ID: 85, Name: "Derek", Postcode: 8000}
 	ctx := context.Background()
 
 	// Test running query after commit.
@@ -1145,8 +1143,7 @@ func (s *PackageSuite) TestIterMethodOrder(c *C) {
 }
 
 func (s *PackageSuite) TestOmitOnEmpty(c *C) {
-	sqldb, err := setupDB()
-	db := sqlair.NewDB(sqldb)
+	db, err := openTestDB()
 	c.Assert(err, IsNil)
 	createTables, err := sqlair.Prepare(`
 CREATE TABLE person (
@@ -1181,4 +1178,97 @@ CREATE TABLE person (
 	err = db.Query(nil, selectStmt, &jim).Get(&jimCheck)
 	c.Assert(err, IsNil)
 	c.Assert(jimCheck, Equals, Person{Fullname: "Jim", PostalCode: 500, ID: 1})
+}
+
+func (s *PackageSuite) TestInsert(c *C) {
+	insertPersonStmt, err := sqlair.Prepare("INSERT INTO person (*) VALUES ($Person.*)", Person{})
+	c.Assert(err, IsNil)
+
+	insertNameIDStmt, err := sqlair.Prepare("INSERT INTO person (name, id) VALUES ($Person.*)", Person{})
+	c.Assert(err, IsNil)
+
+	insertAddressIDStmt, err := sqlair.Prepare("INSERT INTO address (id) VALUES ($Person.address_id)", Person{})
+	c.Assert(err, IsNil)
+
+	insertAddressStmt, err := sqlair.Prepare("INSERT INTO address (*) VALUES ($Address.id, $Address.street, $Address.district)", Person{}, Address{})
+	c.Assert(err, IsNil)
+
+	// RETURNING clauses are supported by SQLite with syntax taken from
+	// postgresql. The inserted values are returned as query results.
+	returningStmt, err := sqlair.Prepare("INSERT INTO address(*) VALUES($Address.*) RETURNING &Address.*", Person{}, Address{})
+	c.Assert(err, IsNil)
+
+	// SELECT statements to check the inserts have worked correctly.
+	selectPerson, err := sqlair.Prepare("SELECT &Person.* FROM person WHERE id = $Person.id", Person{})
+	c.Assert(err, IsNil)
+
+	selectAddress, err := sqlair.Prepare("SELECT &Address.* FROM address WHERE id = $Address.id", Address{})
+	c.Assert(err, IsNil)
+
+	// DELETE statements to remove the inserted rows.
+	deletePersonStmt, err := sqlair.Prepare("DELETE FROM person WHERE id = $Person.id", Person{})
+	c.Assert(err, IsNil)
+
+	deleteAddressStmt, err := sqlair.Prepare("DELETE FROM address WHERE id = $Address.id", Address{})
+	c.Assert(err, IsNil)
+
+	deleteAddressStmtReturning, err := sqlair.Prepare("DELETE FROM address WHERE id = $Address.id RETURNING &Address.*", Address{})
+	c.Assert(err, IsNil)
+
+	tables, db, err := personAndAddressDB(c)
+	c.Assert(err, IsNil)
+	defer dropTables(c, db, tables...)
+
+	p := Person{}
+	a := Address{}
+	outcome := sqlair.Outcome{}
+	eric := Person{Name: "Eric", ID: 60, Postcode: 7000}
+	millLane := Address{Street: "Mill Lane", District: "Crazy County", ID: 7000}
+
+	// Each block follows the sequence:
+	// - Insert value
+	// - Select value from DB
+	// - Check the selected value matches the inserted one
+	// - Delete the value from the database
+	// - Check that one row was deleted
+
+	c.Assert(db.Query(nil, insertPersonStmt, eric).Run(), IsNil)
+	c.Assert(db.Query(nil, selectPerson, eric).Get(&p), IsNil)
+	c.Assert(p, Equals, eric)
+	c.Assert(db.Query(nil, deletePersonStmt, eric).Get(&outcome), IsNil)
+	i, err := outcome.Result().RowsAffected()
+	c.Assert(err, IsNil)
+	c.Assert(i, Equals, int64(1))
+
+	c.Assert(db.Query(nil, insertNameIDStmt, eric).Run(), IsNil)
+	c.Assert(db.Query(nil, selectPerson, eric).Get(&p), IsNil)
+	c.Assert(p.ID, Equals, eric.ID)
+	c.Assert(db.Query(nil, deletePersonStmt, eric).Get(&outcome), IsNil)
+	i, err = outcome.Result().RowsAffected()
+	c.Assert(err, IsNil)
+	c.Assert(i, Equals, int64(1))
+
+	c.Assert(db.Query(nil, insertAddressIDStmt, eric).Run(), IsNil)
+	c.Assert(db.Query(nil, selectAddress, millLane).Get(&a), IsNil)
+	c.Assert(eric.Postcode, Equals, a.ID)
+	c.Assert(db.Query(nil, deleteAddressStmt, millLane).Get(&outcome), IsNil)
+	i, err = outcome.Result().RowsAffected()
+	c.Assert(err, IsNil)
+	c.Assert(i, Equals, int64(1))
+
+	c.Assert(db.Query(nil, insertAddressStmt, millLane).Run(), IsNil)
+	c.Assert(db.Query(nil, selectAddress, millLane).Get(&a), IsNil)
+	c.Assert(millLane, Equals, a)
+	c.Assert(db.Query(nil, deleteAddressStmt, millLane).Get(&outcome), IsNil)
+	i, err = outcome.Result().RowsAffected()
+	c.Assert(err, IsNil)
+	c.Assert(i, Equals, int64(1))
+
+	// The RETURNING clause in this statement returns the inserted data.
+	c.Assert(db.Query(nil, returningStmt, millLane).Get(&a), IsNil)
+	c.Assert(a.Street, Equals, millLane.Street)
+	c.Assert(a.District, Equals, millLane.District)
+	var a0 = Address{}
+	c.Assert(db.Query(nil, deleteAddressStmtReturning, a).Get(&a0), IsNil)
+	c.Assert(a, Equals, a0)
 }


### PR DESCRIPTION
The tests currently check query results against expected literals. With INSERT statement support we can now easily insert variables into the database. We can simply check the results against these variables instead to make the tests more standard. This PR also generally cleans up the tests.

- Add variables for rows in the database
- Clear up DB creation function
- Add test for INSERT statements
- Change the order of the tests to group tests of core functions together vs tests of types of query
- Remove redundant Juju lease tests