### PR TITLE
Add bulk insert support

### DIFF
--- a/internal/expr/bindinputs.go
+++ b/internal/expr/bindinputs.go
@@ -175,6 +175,8 @@ func (ic insertColumn) bindInputs(tv typeinfo.TypeToValue, ia *inputAssigner) (*
 	}
 	var firstInputNum int
 	if !params.Omit {
+		// Reserve input numbers for all values that are getting inserted in the
+		// boundColumn.
 		firstInputNum = ia.assignInputs(len(params.Vals))
 	}
 	bc := &boundInsertColumn{

--- a/internal/expr/bindtypes.go
+++ b/internal/expr/bindtypes.go
@@ -272,7 +272,7 @@ type basicInsertExpr struct {
 
 // String returns a text representation for debugging and testing purposes.
 func (e *basicInsertExpr) String() string {
-	return fmt.Sprintf("RenamingInsert[%v %v]", e.columns, e.sources)
+	return fmt.Sprintf("BasicInsert[%v %v]", e.columns, e.sources)
 }
 
 // bindTypes generates a *typedInsertExpr containing type information about the
@@ -284,7 +284,7 @@ func (e *basicInsertExpr) bindTypes(argInfo typeinfo.ArgInfo) (tie any, err erro
 		}
 	}()
 	if len(e.columns) != len(e.sources) {
-		return nil, fmt.Errorf("mismatched number of columns and values (%d!=%d)", len(e.columns), len(e.sources))
+		return nil, fmt.Errorf("mismatched number of columns and values: %d != %d", len(e.columns), len(e.sources))
 	}
 	var cols []typedColumn
 	for i, source := range e.sources {
@@ -419,6 +419,8 @@ func (e *outputExpr) bindTypes(argInfo typeinfo.ArgInfo) (te any, err error) {
 // valueAccessor defines an accessor that can be used to generate a typedColumn
 // with the given column name.
 type valueAccessor interface {
+	// typedColumn generates a typedColumn that associates the given colum name
+	// with the value specified by the valueAccessor.
 	typedColumn(argInfo typeinfo.ArgInfo, columnName string) (typedColumn, error)
 }
 

--- a/internal/expr/bindtypes.go
+++ b/internal/expr/bindtypes.go
@@ -97,8 +97,8 @@ func (b *bypass) bindTypes(typeinfo.ArgInfo) (typedExpr, error) {
 	return b, nil
 }
 
-// addToQueryBuilder adds the bypass part to the query builder.
-func (b *bypass) addToQueryBuilder(qb *queryBuilder) error {
+// addToQuery adds the bypass part to the query builder.
+func (b *bypass) addToQuery(qb *queryBuilder, _ typeinfo.TypeToValue) error {
 	return qb.addBypass(b)
 }
 

--- a/internal/expr/expr_test.go
+++ b/internal/expr/expr_test.go
@@ -562,13 +562,14 @@ AND z = @sqlair_0 -- The line with $Person.id on it
 	expectedParams: []any{"Sydney", 34, "Wallaby Way"},
 	expectedSQL:    "INSERT INTO address(district, id, street) VALUES (@sqlair_0, @sqlair_1, @sqlair_2) RETURNING (district AS _sqlair_0, id AS _sqlair_1, street AS _sqlair_2)",
 }, {
-	summary:        "insert rename columns with standalone inputs",
-	query:          `INSERT INTO person (id, random_string, random_thing, number, street) VALUES ($Person.address_id, "random string", rand(), 1000, $Address.street)`,
-	expectedParsed: `[Bypass[INSERT INTO person ] RenamingInsert[[id random_string random_thing number street] [Person.address_id "random string" rand() 1000 Address.street]]]`,
+	summary: "insert rename columns with standalone inputs",
+	query: `INSERT INTO person (id, random_string, random_thing, number, equation, street) VALUES ($Person.address_id, "random string", rand(), 1000, 
+						1+2+3, $Address.street)`,
+	expectedParsed: `[Bypass[INSERT INTO person ] RenamingInsert[[id random_string random_thing number equation street] [Person.address_id "random string" rand() 1000 1+2+3 Address.street]]]`,
 	typeSamples:    []any{Address{}, Person{}},
 	inputArgs:      []any{Address{Street: "Wallaby Way"}, Person{PostalCode: 11111}},
 	expectedParams: []any{11111, "Wallaby Way"},
-	expectedSQL:    `INSERT INTO person (id, random_string, random_thing, number, street) VALUES (@sqlair_0, "random string", rand(), 1000, @sqlair_1)`,
+	expectedSQL:    `INSERT INTO person (id, random_string, random_thing, number, equation, street) VALUES (@sqlair_0, "random string", rand(), 1000, 1+2+3, @sqlair_1)`,
 }, {
 	summary:        "insert single value",
 	query:          "INSERT INTO person (name) VALUES ($Person.name)",
@@ -723,6 +724,14 @@ AND z = @sqlair_0 -- The line with $Person.id on it
 	inputArgs:      []any{[]Person{{ID: 0, Fullname: "Al"}, {ID: 1, Fullname: "Albert"}}},
 	expectedParams: []any{"Al", 0, "Albert", 1},
 	expectedSQL:    `INSERT INTO person (col1, col2, col3) VALUES (@sqlair_0, "literally", @sqlair_1), (@sqlair_2, "literally", @sqlair_3)`,
+}, {
+	summary:        "bulk insert rename columns with standalone inputs",
+	query:          `INSERT INTO person (id, random_string, random_thing, number, street) VALUES ($Person.address_id, "random string", rand(), 1000, $Address.street)`,
+	expectedParsed: `[Bypass[INSERT INTO person ] RenamingInsert[[id random_string random_thing number street] [Person.address_id "random string" rand() 1000 Address.street]]]`,
+	typeSamples:    []any{Address{}, Person{}},
+	inputArgs:      []any{[]Address{{Street: "Wallaby Way"}, {Street: "Platypus Place"}}, []Person{{PostalCode: 11111}, {PostalCode: 22222}}},
+	expectedParams: []any{11111, "Wallaby Way", 22222, "Platypus Place"},
+	expectedSQL:    `INSERT INTO person (id, random_string, random_thing, number, street) VALUES (@sqlair_0, "random string", rand(), 1000, @sqlair_1), (@sqlair_2, "random string", rand(), 1000, @sqlair_3)`,
 }}
 
 func (s *ExprSuite) TestExprPkg(c *C) {

--- a/internal/expr/expr_test.go
+++ b/internal/expr/expr_test.go
@@ -7,6 +7,7 @@ import (
 	"database/sql"
 	"database/sql/driver"
 	"strconv"
+	"strings"
 	"testing"
 
 	"github.com/canonical/sqlair"
@@ -361,14 +362,6 @@ AND z = @sqlair_0 -- The line with $Person.id on it
 	typeSamples:    []any{},
 	expectedSQL:    "SELECT person.*, address.district FROM person JOIN address ON person.address_id = address.id WHERE person.name = 'Fred'",
 }, {
-	summary:        "insert",
-	query:          "INSERT INTO person (name) VALUES $Person.name",
-	expectedParsed: "[Bypass[INSERT INTO person (name) VALUES ] Input[Person.name]]",
-	typeSamples:    []any{Person{}},
-	inputArgs:      []any{Person{Fullname: "Foo"}},
-	expectedParams: []any{"Foo"},
-	expectedSQL:    `INSERT INTO person (name) VALUES @sqlair_0`,
-}, {
 	summary:        "ignore dollar",
 	query:          "SELECT $, dollerrow$ FROM moneytable$",
 	expectedParsed: "[Bypass[SELECT $, dollerrow$ FROM moneytable$]]",
@@ -565,7 +558,7 @@ AND z = @sqlair_0 -- The line with $Person.id on it
 	summary: "insert rename columns with standalone inputs",
 	query: `INSERT INTO person (id, random_string, random_thing, number, equation, street) VALUES ($Person.address_id, "random string", rand(), 1000, 
 						1+2+3, $Address.street)`,
-	expectedParsed: `[Bypass[INSERT INTO person ] RenamingInsert[[id random_string random_thing number equation street] [Person.address_id "random string" rand() 1000 1+2+3 Address.street]]]`,
+	expectedParsed: `[Bypass[INSERT INTO person ] BasicInsert[[id random_string random_thing number equation street] [Person.address_id "random string" rand() 1000 1+2+3 Address.street]]]`,
 	typeSamples:    []any{Address{}, Person{}},
 	inputArgs:      []any{Address{Street: "Wallaby Way"}, Person{PostalCode: 11111}},
 	expectedParams: []any{11111, "Wallaby Way"},
@@ -573,7 +566,7 @@ AND z = @sqlair_0 -- The line with $Person.id on it
 }, {
 	summary:        "insert single value",
 	query:          "INSERT INTO person (name) VALUES ($Person.name)",
-	expectedParsed: "[Bypass[INSERT INTO person ] RenamingInsert[[name] [Person.name]]]",
+	expectedParsed: "[Bypass[INSERT INTO person ] BasicInsert[[name] [Person.name]]]",
 	typeSamples:    []any{Person{}},
 	inputArgs:      []any{Person{Fullname: "John Doe"}},
 	expectedParams: []any{"John Doe"},
@@ -674,40 +667,48 @@ AND z = @sqlair_0 -- The line with $Person.id on it
 	expectedParsed: `[Bypass[INSERT INTO person ] AsteriskInsert[[*] [Person.*]]]`,
 	typeSamples:    []any{Person{}},
 	inputArgs:      []any{[]Person{{ID: 0, Fullname: "Al", PostalCode: 1000}, {ID: 1, Fullname: "Albert", PostalCode: 2000}, {ID: 2, Fullname: "Joe", PostalCode: 3000}}},
-	expectedParams: []any{1000, 0, "Al", 2000, 1, "Albert", 3000, 2, "Joe"},
-	expectedSQL:    `INSERT INTO person (address_id, id, name) VALUES (@sqlair_0, @sqlair_1, @sqlair_2), (@sqlair_3, @sqlair_4, @sqlair_5), (@sqlair_6, @sqlair_7, @sqlair_8)`,
+	expectedParams: []any{1000, 2000, 3000, 0, 1, 2, "Al", "Albert", "Joe"},
+	expectedSQL:    `INSERT INTO person (address_id, id, name) VALUES (@sqlair_0, @sqlair_3, @sqlair_6), (@sqlair_1, @sqlair_4, @sqlair_7), (@sqlair_2, @sqlair_5, @sqlair_8)`,
 }, {
 	summary:        "bulk insert with explicit columns and constants",
 	query:          `INSERT INTO person (name, mapKey, street) VALUES ($Person.*, $Address.*, $M.*)`,
 	expectedParsed: `[Bypass[INSERT INTO person ] ColumnInsert[[name mapKey street] [Person.* Address.* M.*]]]`,
 	typeSamples:    []any{Person{}, Address{}, M{}},
 	inputArgs:      []any{[]Person{{Fullname: "Al"}, {Fullname: "Albert"}}, M{"mapKey": "const map"}, Address{Street: "const street"}},
-	expectedParams: []any{"Al", "const map", "const street", "Albert", "const map", "const street"},
-	expectedSQL:    `INSERT INTO person (name, mapKey, street) VALUES (@sqlair_0, @sqlair_1, @sqlair_2), (@sqlair_3, @sqlair_4, @sqlair_5)`,
+	expectedParams: []any{"Al", "Albert", "const map", "const street"},
+	expectedSQL:    `INSERT INTO person (name, mapKey, street) VALUES (@sqlair_0, @sqlair_2, @sqlair_3), (@sqlair_1, @sqlair_2, @sqlair_3)`,
 }, {
 	summary:        "bulk insert with omit empty struct not inserted at all",
 	query:          `INSERT INTO person (*) VALUES ($OmitEmptyID.*, $M.key)`,
 	expectedParsed: `[Bypass[INSERT INTO person ] AsteriskInsert[[*] [OmitEmptyID.* M.key]]]`,
 	typeSamples:    []any{OmitEmptyID{}, M{}},
 	inputArgs:      []any{[]OmitEmptyID{{ID: 0}, {ID: 0}}, M{"key": "val"}},
-	expectedParams: []any{"val", "val"},
-	expectedSQL:    `INSERT INTO person (key) VALUES (@sqlair_0), (@sqlair_1)`,
+	expectedParams: []any{"val"},
+	expectedSQL:    `INSERT INTO person (key) VALUES (@sqlair_0), (@sqlair_0)`,
+}, {
+	summary:        "bulk insert with inserted omit empty struct",
+	query:          `INSERT INTO person (*) VALUES ($OmitEmptyID.*, $M.key)`,
+	expectedParsed: `[Bypass[INSERT INTO person ] AsteriskInsert[[*] [OmitEmptyID.* M.key]]]`,
+	typeSamples:    []any{OmitEmptyID{}, M{}},
+	inputArgs:      []any{[]OmitEmptyID{{ID: 1}, {ID: 2}}, M{"key": "val"}},
+	expectedParams: []any{1, 2, "val"},
+	expectedSQL:    `INSERT INTO person (id, key) VALUES (@sqlair_0, @sqlair_2), (@sqlair_1, @sqlair_2)`,
 }, {
 	summary:        "bulk insert with multiple bulk inputs",
 	query:          `INSERT INTO person (*) VALUES ($Person.id, $M.key, $Address.street)`,
 	expectedParsed: `[Bypass[INSERT INTO person ] AsteriskInsert[[*] [Person.id M.key Address.street]]]`,
 	typeSamples:    []any{Person{}, M{}, Address{}},
 	inputArgs:      []any{[]Person{{ID: 1}, {ID: 2}}, M{"key": "val"}, []Address{{Street: "Main Street"}, {Street: "Church Road"}}},
-	expectedParams: []any{1, "val", "Main Street", 2, "val", "Church Road"},
-	expectedSQL:    `INSERT INTO person (id, key, street) VALUES (@sqlair_0, @sqlair_1, @sqlair_2), (@sqlair_3, @sqlair_4, @sqlair_5)`,
+	expectedParams: []any{1, 2, "val", "Main Street", "Church Road"},
+	expectedSQL:    `INSERT INTO person (id, key, street) VALUES (@sqlair_0, @sqlair_2, @sqlair_3), (@sqlair_1, @sqlair_2, @sqlair_4)`,
 }, {
 	summary:        "bulk insert with pointers",
 	query:          `INSERT INTO person (*) VALUES ($Person.id, $M.key)`,
 	expectedParsed: `[Bypass[INSERT INTO person ] AsteriskInsert[[*] [Person.id M.key]]]`,
 	typeSamples:    []any{Person{}, M{}},
 	inputArgs:      []any{[]*Person{{ID: 1}, {ID: 2}}, []*M{{"key": "val1"}, {"key": "val2"}}},
-	expectedParams: []any{1, "val1", 2, "val2"},
-	expectedSQL:    `INSERT INTO person (id, key) VALUES (@sqlair_0, @sqlair_1), (@sqlair_2, @sqlair_3)`,
+	expectedParams: []any{1, 2, "val1", "val2"},
+	expectedSQL:    `INSERT INTO person (id, key) VALUES (@sqlair_0, @sqlair_2), (@sqlair_1, @sqlair_3)`,
 }, {
 	summary:        "bulk insert with slices of length 1",
 	query:          `INSERT INTO person (*) VALUES ($Person.id, $M.key, $Address.street)`,
@@ -718,20 +719,20 @@ AND z = @sqlair_0 -- The line with $Person.id on it
 	expectedSQL:    `INSERT INTO person (id, key, street) VALUES (@sqlair_0, @sqlair_1, @sqlair_2)`,
 }, {
 	summary:        "bulk insert with explicit columns and literal",
-	query:          `INSERT INTO person (col1, col2, col3) VALUES ($Person.name, "literally", $Person.id)`,
-	expectedParsed: `[Bypass[INSERT INTO person ] RenamingInsert[[col1 col2 col3] [Person.name "literally" Person.id]]]`,
+	query:          `INSERT INTO person (col1, col2) VALUES ($Person.name, "literally")`,
+	expectedParsed: `[Bypass[INSERT INTO person ] BasicInsert[[col1 col2] [Person.name "literally"]]]`,
 	typeSamples:    []any{Person{}},
-	inputArgs:      []any{[]Person{{ID: 0, Fullname: "Al"}, {ID: 1, Fullname: "Albert"}}},
-	expectedParams: []any{"Al", 0, "Albert", 1},
-	expectedSQL:    `INSERT INTO person (col1, col2, col3) VALUES (@sqlair_0, "literally", @sqlair_1), (@sqlair_2, "literally", @sqlair_3)`,
+	inputArgs:      []any{[]Person{{Fullname: "Al"}, {Fullname: "Albert"}}},
+	expectedParams: []any{"Al", "Albert"},
+	expectedSQL:    `INSERT INTO person (col1, col2) VALUES (@sqlair_0, "literally"), (@sqlair_1, "literally")`,
 }, {
 	summary:        "bulk insert rename columns with standalone inputs",
 	query:          `INSERT INTO person (id, random_string, random_thing, number, street) VALUES ($Person.address_id, "random string", rand(), 1000, $Address.street)`,
-	expectedParsed: `[Bypass[INSERT INTO person ] RenamingInsert[[id random_string random_thing number street] [Person.address_id "random string" rand() 1000 Address.street]]]`,
+	expectedParsed: `[Bypass[INSERT INTO person ] BasicInsert[[id random_string random_thing number street] [Person.address_id "random string" rand() 1000 Address.street]]]`,
 	typeSamples:    []any{Address{}, Person{}},
 	inputArgs:      []any{[]Address{{Street: "Wallaby Way"}, {Street: "Platypus Place"}}, []Person{{PostalCode: 11111}, {PostalCode: 22222}}},
-	expectedParams: []any{11111, "Wallaby Way", 22222, "Platypus Place"},
-	expectedSQL:    `INSERT INTO person (id, random_string, random_thing, number, street) VALUES (@sqlair_0, "random string", rand(), 1000, @sqlair_1), (@sqlair_2, "random string", rand(), 1000, @sqlair_3)`,
+	expectedParams: []any{11111, 22222, "Wallaby Way", "Platypus Place"},
+	expectedSQL:    `INSERT INTO person (id, random_string, random_thing, number, street) VALUES (@sqlair_0, "random string", rand(), 1000, @sqlair_2), (@sqlair_1, "random string", rand(), 1000, @sqlair_3)`,
 }}
 
 func (s *ExprSuite) TestExprPkg(c *C) {
@@ -767,11 +768,15 @@ func (s *ExprSuite) TestExprPkg(c *C) {
 			params := primedQuery.Params()
 			c.Assert(params, HasLen, len(t.expectedParams),
 				Commentf("test %d failed (Query Params):\nsummary: %s\nquery: %s\n", i, t.summary, t.query))
-			for paramIndex, param := range params {
+			for _, param := range params {
 				param := param.(sql.NamedArg)
-				c.Check(param.Name, Equals, "sqlair_"+strconv.Itoa(paramIndex),
-					Commentf("test %d failed (Query Params):\nsummary: %s\nquery: %s\n", i, t.summary, t.query))
-				c.Check(param.Value, Equals, t.expectedParams[paramIndex],
+				name := param.Name
+				var n int
+				if strings.HasPrefix(name, "sqlair_") {
+					n, err = strconv.Atoi(name[len("sqlair_"):])
+					c.Assert(err, IsNil)
+				}
+				c.Check(param.Value, Equals, t.expectedParams[n],
 					Commentf("test %d failed (Query Params):\nsummary: %s\nquery: %s\n", i, t.summary, t.query))
 			}
 		}
@@ -901,10 +906,10 @@ of three lines' AND id = $Person.*`,
 		err:   `cannot parse expression: column 8: cannot read function call "count(*)" into asterisk`,
 	}, {
 		query: "INSERT INTO person (*) VALUES $Address.*",
-		err:   `cannot parse expression: column 20: missing parentheses around types after "VALUES"`,
+		err:   `cannot parse expression: column 31: missing parentheses around types after "VALUES"`,
 	}, {
 		query: "INSERT INTO person (*) VALUES $M.col1",
-		err:   `cannot parse expression: column 20: missing parentheses around types after "VALUES"`,
+		err:   `cannot parse expression: column 31: missing parentheses around types after "VALUES"`,
 	}, {
 		query: "INSERT INTO person * VALUES $Address.*",
 		err:   `cannot parse expression: column 29: invalid asterisk placement in input "$Address.*"`,
@@ -1127,6 +1132,14 @@ func (s *ExprSuite) TestBindTypesErrors(c *C) {
 		query:       "SELECT &AmbiguousEmbeddedTags.* FROM t",
 		typeSamples: []any{AmbiguousEmbeddedTags{}},
 		err:         `cannot prepare statement: db tag "id" appears in both field "ID2" and field "ID1" of struct "AmbiguousEmbeddedTags"`,
+	}, {
+		query:       "INSERT INTO t (id) VALUES ($Person.id, $Address.street)",
+		typeSamples: []any{Person{}, Address{}},
+		err:         `cannot prepare statement: input expression: mismatched number of columns and values: 1 != 2: (id) VALUES ($Person.id, $Address.street)`,
+	}, {
+		query:       "INSERT INTO t (id, street) VALUES ($Person.id)",
+		typeSamples: []any{Person{}, Address{}},
+		err:         `cannot prepare statement: input expression: mismatched number of columns and values: 2 != 1: (id, street) VALUES ($Person.id)`,
 	}}
 
 	for i, test := range tests {
@@ -1224,7 +1237,7 @@ func (s *ExprSuite) TestBindInputsError(c *C) {
 		query:       "SELECT street FROM t WHERE x = $Address.street",
 		typeSamples: []any{Address{}},
 		inputArgs:   []any{Address{}, Person{}},
-		err:         `invalid input parameter: "Person" not referenced in query`,
+		err:         `invalid input parameter: argument of type "Person" not used by query`,
 	}, {
 		query:       "SELECT * AS &Address.* FROM t WHERE x = $M.Fullname",
 		typeSamples: []any{Address{}, sqlair.M{}},
@@ -1279,22 +1292,47 @@ func (s *ExprSuite) TestBindInputsError(c *C) {
 		query:       "INSERT INTO person (*) VALUES ($Person.id, $Address.street)",
 		typeSamples: []any{Person{}, Address{}},
 		inputArgs:   []any{[]Person{{ID: 0}}, []Address{{Street: "S1"}, {Street: "S2"}}},
-		err:         `invalid input parameter: different slices sizes in bulk insert: slice of "Person" has length 1 but slice of "Address" has length 2`,
+		err:         `invalid input parameter: expected slices of matching length in bulk insert: slice of "Person" has length 1 but slice of "Address" has length 2`,
 	}, {
 		query:       "INSERT INTO person (*) VALUES ($Person.id, $M.key, $Address.street)",
 		typeSamples: []any{Person{}, Address{}, M{}},
 		inputArgs:   []any{[]Address{{Street: "S2"}}, []Person{{ID: 0}, {ID: 1}}, M{"key": "value"}},
-		err:         `invalid input parameter: different slices sizes in bulk insert: slice of "Person" has length 2 but slice of "Address" has length 1`,
+		err:         `invalid input parameter: expected slices of matching length in bulk insert: slice of "Person" has length 2 but slice of "Address" has length 1`,
 	}, {
 		query:       "INSERT INTO person (*) VALUES ($Person.id)",
 		typeSamples: []any{Person{}},
 		inputArgs:   []any{[]*Person{nil}},
-		err:         `invalid input parameter: got nil pointer in slice of "Person" at position 0`,
+		err:         `invalid input parameter: got nil pointer in slice of "Person" at index 0`,
 	}, {
 		query:       "INSERT INTO person (*) VALUES ($Person.id)",
 		typeSamples: []any{Person{}},
 		inputArgs:   []any{[]Person{}},
 		err:         `invalid input parameter: got slice of "Person" with length 0`,
+	}, {
+		query:       "INSERT INTO person (*) VALUES ($Person.id)",
+		typeSamples: []any{Person{}},
+		inputArgs:   []any{[]Person{{ID: 1}}, Person{ID: 2}},
+		err:         `invalid input parameter: type "[]Person" and its slice type "Person" provided, unclear if bulk insert intended`,
+	}, {
+		query:       "INSERT INTO person (*) VALUES ($Person.id)",
+		typeSamples: []any{Person{}},
+		inputArgs:   []any{Person{ID: 2}, []Person{{ID: 1}}},
+		err:         `invalid input parameter: type "[]Person" and its slice type "Person" provided, unclear if bulk insert intended`,
+	}, {
+		query:       "INSERT INTO person (*) VALUES ($Person.id)",
+		typeSamples: []any{Person{}},
+		inputArgs:   []any{[]*Person{{ID: 1}}, Person{ID: 2}},
+		err:         `invalid input parameter: type "[]*Person" and its slice type "Person" provided, unclear if bulk insert intended`,
+	}, {
+		query:       "INSERT INTO person (*) VALUES ($Person.id)",
+		typeSamples: []any{Person{}},
+		inputArgs:   []any{Person{ID: 2}, []*Person{{ID: 1}}},
+		err:         `invalid input parameter: type "[]*Person" and its slice type "Person" provided, unclear if bulk insert intended`,
+	}, {
+		query:       `INSERT INTO person (*) VALUES ($OmitEmptyID.*, $M.key)`,
+		typeSamples: []any{OmitEmptyID{}, M{}},
+		inputArgs:   []any{[]OmitEmptyID{{ID: 0}, {ID: 1}}, M{"key": "val"}},
+		err:         `invalid input parameter: got mix of zero and none zero values in tag "id" of struct "OmitEmptyID" which has the omitempty flag set, in a bulk insert, values must be all zero or all none zero`,
 	}}
 
 	outerP := Person{}
@@ -1330,7 +1368,7 @@ func (s *ExprSuite) TestBindInputsError(c *C) {
 
 		_, err = typedExpr.BindInputs(t.inputArgs...)
 		if err != nil {
-			c.Assert(err.Error(), Equals, t.err,
+			c.Check(err.Error(), Equals, t.err,
 				Commentf("test %d failed:\nquery: %s", i, t.query))
 		} else {
 			c.Errorf("test %d failed:\nexpected err: %q but got nil\nquery: %q", i, t.err, t.query)

--- a/internal/expr/parser_helper_test.go
+++ b/internal/expr/parser_helper_test.go
@@ -346,9 +346,17 @@ func (s parseSuite) TestParseRenamingInsertValues(c *C) {
 }
 
 func (s parseSuite) TestParseRenamingInsertValuesFalse(c *C) {
+	inputs := []string{
+		`( CAST(1 as text) , "literal" , 1+7/2)`,
+		`()`,
+		`("literal")`,
+		``,
+	}
 	var p = NewParser()
-	p.init(`( CAST(1 as text) , "literal" , 1+7/2)`)
-	_, ok, err := p.parseBasicInsertValues()
-	c.Assert(err, IsNil)
-	c.Assert(ok, Equals, false)
+	for _, input := range inputs {
+		p.init(input)
+		_, ok, err := p.parseBasicInsertValues()
+		c.Assert(err, IsNil)
+		c.Assert(ok, Equals, false)
+	}
 }

--- a/internal/expr/parser_helper_test.go
+++ b/internal/expr/parser_helper_test.go
@@ -338,7 +338,7 @@ func (s parseSuite) TestParseRenamingInsertValues(c *C) {
 	var p = NewParser()
 	for _, t := range tests {
 		p.init(t.input)
-		vs, ok, err := p.parseRenamingInsertValues()
+		vs, ok, err := p.parseBasicInsertValues()
 		c.Assert(err, IsNil)
 		c.Assert(ok, Equals, true)
 		c.Assert(vs, DeepEquals, t.expected)
@@ -348,7 +348,7 @@ func (s parseSuite) TestParseRenamingInsertValues(c *C) {
 func (s parseSuite) TestParseRenamingInsertValuesFalse(c *C) {
 	var p = NewParser()
 	p.init(`( CAST(1 as text) , "literal" , 1+7/2)`)
-	_, ok, err := p.parseRenamingInsertValues()
+	_, ok, err := p.parseBasicInsertValues()
 	c.Assert(err, IsNil)
 	c.Assert(ok, Equals, false)
 }

--- a/internal/expr/querybuilder.go
+++ b/internal/expr/querybuilder.go
@@ -1,0 +1,253 @@
+// Copyright 2024 Canonical Ltd.
+// Licensed under the AGPLv3, see LICENCE file for details.
+
+package expr
+
+import (
+	"bytes"
+	"database/sql"
+	"fmt"
+	"reflect"
+	"strconv"
+	"strings"
+
+	"github.com/canonical/sqlair/internal/typeinfo"
+)
+
+// queryBuilder is used to build up a query to be passed to the database from a
+// type bound expression
+type queryBuilder struct {
+	// inputCount tracks the number of query inputs.
+	inputCount int
+	// outputCount tracks the number of query outputs.
+	outputCount int
+	// argUsed is used to check that all the arguments provided by the caller of
+	// BindInputs are referenced in the query.
+	argUsed map[reflect.Type]bool
+
+	// sqlBuilder is used to accumulate the generated SQL.
+	sqlBuilder sqlBuilder
+	// namedInputs are the named input values corresponding to the placeholders
+	// in the SQL. They will be passed to the database at query time.
+	namedInputs []any
+	// outputs are the output value locators to be used when the SQL is scanned.
+	outputs []typeinfo.Output
+}
+
+// newQueryBuilder builds a new queryBuilder with the inputs in typeToValue.
+func newQueryBuilder() *queryBuilder {
+	return &queryBuilder{
+		sqlBuilder:  sqlBuilder{},
+		inputCount:  0,
+		outputCount: 0,
+		argUsed:     map[reflect.Type]bool{},
+		namedInputs: []any{},
+		outputs:     []typeinfo.Output{},
+	}
+}
+
+// markArgUsed marks the argument passed by the caller of BindInputs as used.
+func (qb *queryBuilder) markArgUsed(t reflect.Type) {
+	qb.argUsed[t] = true
+}
+
+func (qb *queryBuilder) getInputCount() int {
+	return qb.inputCount
+}
+
+func (qb *queryBuilder) incrementInputCount(i int) {
+	qb.inputCount += i
+}
+
+// addInputs adds input placeholders and argument values to the query.
+func (qb *queryBuilder) addInputs(inputVals []any) {
+	qb.sqlBuilder.writeInputs(qb.inputCount, len(inputVals))
+	for _, val := range inputVals {
+		namedInput := sql.Named("sqlair_"+strconv.Itoa(qb.inputCount), val)
+		qb.namedInputs = append(qb.namedInputs, namedInput)
+		qb.inputCount++
+	}
+}
+
+// addInput adds a typedInsertExpr to the queryBuilder
+func (qb *queryBuilder) addInsert(boundColumns []*boundInsertColumn, numRows int) error {
+	var rowsSQL [][]string
+	var columnNames []string
+	for rowNum := 0; rowNum < numRows; rowNum++ {
+		var rowSQL []string
+		for _, bc := range boundColumns {
+			if !bc.omit {
+				valueSQL, namedInput, newParam, err := bc.parameter(rowNum)
+				if err != nil {
+					return err
+				}
+				rowSQL = append(rowSQL, valueSQL)
+				if newParam {
+					qb.namedInputs = append(qb.namedInputs, namedInput)
+				}
+			}
+		}
+		rowsSQL = append(rowsSQL, rowSQL)
+	}
+	for _, bc := range boundColumns {
+		if !bc.omit {
+			columnNames = append(columnNames, bc.column)
+		}
+	}
+	qb.sqlBuilder.writeInsert(columnNames, rowsSQL)
+	return nil
+}
+
+// addOutput adds a typedOutputExpr to the queryBuilder
+func (qb *queryBuilder) addOutput(columns []string, outputs []typeinfo.Output) {
+	qb.sqlBuilder.writeOutput(qb.outputCount, columns)
+	qb.outputCount += len(columns)
+	qb.outputs = append(qb.outputs, outputs...)
+}
+
+// addBypass adds a bypass part to the queryBuilder
+func (qb *queryBuilder) addBypass(b *bypass) error {
+	qb.sqlBuilder.write(b.chunk)
+	return nil
+}
+
+// checkAllArgsUsed goes through all the arguments contained in typeToValue and
+// checks that they were used somewhere during the building of the query.
+func (qb *queryBuilder) checkAllArgsUsed(typeToValue typeinfo.TypeToValue) error {
+	for argType := range typeToValue {
+		if !qb.argUsed[argType] {
+			return notReferencedInQueryError(argType)
+		}
+	}
+	return nil
+}
+
+// boundInsertColumn represents a column in an insert statement along with the values
+// to be inserted into it.
+type boundInsertColumn struct {
+	// vals contains the query parameters. There may be multiple for a bulk
+	// insert, or none for a literal.
+	vals []any
+	// inputNum is the number associated with the first named input for this
+	// column. The numbers inputNum to inputNum + len(vals) can be used by this
+	// boundInsertColumn.
+	inputNum int
+	// omit indicates if the column and values should be omitted.
+	omit bool
+	// bulk is true if the list of values should be inserted in a bulk insert
+	// expression.
+	bulk bool
+	// argType is the type of the argument that was used to generate the
+	// params.
+	argType reflect.Type
+	// inputName is the type name of the input parameter.
+	inputName string
+	// literal is set if the value to insert is a literal.
+	literal string
+	// column is the column name.
+	column string
+}
+
+// parameter returns the value to be inserted into the boundInsertColumn in the given
+// row. The inputCount it used to generate the parameter name.
+func (bc *boundInsertColumn) parameter(row int) (name string, v any, newParam bool, err error) {
+	switch {
+	case len(bc.vals) == 0:
+		return bc.literal, nil, false, nil
+	case len(bc.vals) == 1:
+		name = "sqlair_" + strconv.Itoa(bc.inputNum)
+		newParam = false
+		if row == 0 {
+			newParam = true
+		}
+		return "@" + name, sql.Named(name, bc.vals[0]), newParam, nil
+	case row < len(bc.vals):
+		name = "sqlair_" + strconv.Itoa(bc.inputNum+row)
+		return "@" + name, sql.Named(name, bc.vals[row]), true, nil
+	default:
+		return "", nil, false, fmt.Errorf("internal error: no bulk insert value for row %d, only have %d values", row, len(bc.vals))
+	}
+}
+
+// sqlBuilder is used to generate SQL string piece by piece using the struct
+// methods.
+type sqlBuilder struct {
+	buf bytes.Buffer
+}
+
+// writeInsert writes the SQL for INSERT statements to the sqlBuilder.
+func (b *sqlBuilder) writeInsert(columns []string, rows [][]string) {
+	// Write out the columns.
+	b.buf.WriteString("(")
+	b.writeCommaSeparatedList(columns, func(_ int, column string) string {
+		return column
+	})
+	b.buf.WriteString(") VALUES ")
+	// Write out the values.
+	for i, row := range rows {
+		if i != 0 {
+			b.buf.WriteString(", ")
+		}
+		b.buf.WriteString("(")
+		b.writeCommaSeparatedList(row, func(_ int, value string) string {
+			return value
+		})
+		b.buf.WriteString(")")
+	}
+}
+
+// writeInputs writes the SQL for input placeholders to the sqlBuilder.
+func (b *sqlBuilder) writeInputs(inputCount, num int) {
+	b.writeCommaSeparatedList(make([]string, num), func(i int, column string) string {
+		return "@sqlair_" + strconv.Itoa(inputCount+i)
+	})
+}
+
+// writeOutput writes the SQL for output columns to the sqlBuilder.
+func (b *sqlBuilder) writeOutput(outputCount int, columns []string) {
+	b.writeCommaSeparatedList(columns, func(i int, column string) string {
+		return column + " AS " + markerName(outputCount+i)
+	})
+}
+
+// writeCommaSeparatedList writes out the provided list using the writer to
+// write each element into the SQL.
+func (b *sqlBuilder) writeCommaSeparatedList(list []string, writer func(i int, s string) string) {
+	for i, s := range list {
+		if i != 0 {
+			b.buf.WriteString(", ")
+		}
+		b.buf.WriteString(writer(i, s))
+	}
+}
+
+// write writes the SQL to the sqlBuilder.
+func (b *sqlBuilder) write(sql string) {
+	b.buf.WriteString(sql)
+}
+
+// getSQL returns the generated SQL string
+func (b *sqlBuilder) getSQL() string {
+	return b.buf.String()
+}
+
+const markerPrefix = "_sqlair_"
+
+func markerName(n int) string {
+	return markerPrefix + strconv.Itoa(n)
+}
+
+// markerIndex returns the int X from the string "_sqlair_X".
+func markerIndex(s string) (int, bool) {
+	if strings.HasPrefix(s, markerPrefix) {
+		n, err := strconv.Atoi(s[len(markerPrefix):])
+		if err == nil {
+			return n, true
+		}
+	}
+	return 0, false
+}
+
+func notReferencedInQueryError(t reflect.Type) error {
+	return fmt.Errorf(`argument of type %q not used by query`, typeinfo.PrettyTypeName(t))
+}

--- a/internal/expr/querybuilder.go
+++ b/internal/expr/querybuilder.go
@@ -61,7 +61,7 @@ func (qb *queryBuilder) addInputs(inputVals []any) {
 	qb.sqlBuilder.writeInputs(firstInputNum, len(inputVals))
 }
 
-// addInput adds a typedInsertExpr to the queryBuilder
+// addInsert adds a typedInsertExpr to the queryBuilder
 func (qb *queryBuilder) addInsert(boundColumns []*boundInsertColumn, numRows int) error {
 	var rowsSQL [][]string
 	var columnNames []string
@@ -114,8 +114,11 @@ func (qb *queryBuilder) checkAllArgsUsed(typeToValue typeinfo.TypeToValue) error
 	return nil
 }
 
-// inputAssigner assigns input numbers to input expressions.
+// inputAssigner assigns input numbers to input expressions. SQLair query inputs
+// are assigned unique number to use in their name. The inputAssigner keeps
+// track of which inputs have already been used in the query.
 type inputAssigner struct {
+	// inputCount stores the next unused input number.
 	inputCount int
 }
 

--- a/internal/typeinfo/valuelocator_test.go
+++ b/internal/typeinfo/valuelocator_test.go
@@ -264,7 +264,7 @@ func (s *typeInfoSuite) TestLocateParams(c *C) {
 		c.Check(params.Bulk, Equals, t.expectedBulk)
 		c.Assert(params.Vals, HasLen, len(t.expectedVals))
 		for i, v := range t.expectedVals {
-			c.Check(params.Vals[i].Interface(), Equals, v)
+			c.Check(params.Vals[i], Equals, v)
 		}
 	}
 }

--- a/internal/typeinfo/valuelocator_test.go
+++ b/internal/typeinfo/valuelocator_test.go
@@ -323,7 +323,7 @@ func (s *typeInfoSuite) TestLocateParamsError(c *C) {
 		input: func(ai ArgInfo) (Input, error) {
 			return ai.InputMember("M", "foo")
 		},
-		err: `got nil map in slice of "M" at position 1`,
+		err: `got nil map in slice of "M" at index 1`,
 	}, {
 		summary:    "map bulk insert nil pointer to map in slice",
 		typeSample: M{},
@@ -331,7 +331,7 @@ func (s *typeInfoSuite) TestLocateParamsError(c *C) {
 		input: func(ai ArgInfo) (Input, error) {
 			return ai.InputMember("M", "foo")
 		},
-		err: `got nil pointer in slice of "M" at position 1`,
+		err: `got nil pointer in slice of "M" at index 1`,
 	}, {
 		summary:    "map bulk insert empty slice",
 		typeSample: M{},
@@ -355,7 +355,7 @@ func (s *typeInfoSuite) TestLocateParamsError(c *C) {
 		input: func(ai ArgInfo) (Input, error) {
 			return ai.InputMember("TS", "foo")
 		},
-		err: `got nil pointer in slice of "TS" at position 0`,
+		err: `got nil pointer in slice of "TS" at index 0`,
 	}, {
 		summary:    "struct bulk insert empty slice",
 		typeSample: TS{},


### PR DESCRIPTION
SQLair currently supports insert expressions, but not bulk inserts. To insert multiple rows into a database with SQLair, users currently have to execute the same statement multiple times using a for loop or write a query that inserts a fixed number of rows by explicitly writing out each row with separate input expressions for every column.

Additionally, users may want to bulk insert where network latency needs to be minimised such as in Juju where the distributed database requires multiple trips.

Bulk inserts are supported using the same syntax currently used for INSERTS. If one or more of the types passed to `Query` is a slice instead of a simple value, then it becomes a bulk insert with any other values in the INSERT remaining constant.

For example:
```
type S struct {
    v string `db:"col1"`
}

type T struct {
   v string `db:"col4"`
}

s := sqlair.MustPrepare(
    "INSERT INTO t (col1, col2, col3, col4) VALUES ($S.*, $M.col2, "v3", $T.col4)",
    S{},
    sqlair.M{},
    T{},
)

db.Query(
    s,
    []S{{v: "v1.1"}, {v: "v1.2"}, {v: "v1.3"}},
    sqlair.M{"col2": "v2"},
    []T{{v: "v4.1"}, {v: "v4.2"}, {v: "v4.3"}},
)
```
The query sent to the DB from the above example will be:
```
INSERT INTO  t (col1, col2, col3, col4) VALUES (@sqlair_0, @sqlair_3, "v3", @sqalir_4), (@sqlair_1, @sqlair_3, "v3", @sqalir_5), (@sqlair_2, @sqlair_3, "v3", @sqalir_6)
```
Where the placeholders are:
Name | Value
---|---
sqlair_0 | v1.1
sqlair_1 | v1.2
sqlair_2 | v1.3
sqlair_3 | v2
sqlair_4 | v4.1
sqlair_5 | v4.2
sqlair_6 | v4.3

Note that SQLair will check that all the slices passed to Query for bulk INSERTS are of the same cardinality, else throw out an error.
