### PR TITLE
feat: add a cache for driver prepared statements

### DIFF
--- a/cache.go
+++ b/cache.go
@@ -13,9 +13,9 @@ import (
 	"github.com/canonical/sqlair/internal/expr"
 )
 
-// statementCache caches driver prepared sql.Stmt objects associated with
-// sqlair.Statement objects. The driver prepared sql.Stmt objects corresponding
-// to a single sqlair.Statement can be prepared on different database and have
+// statementCache caches driver-prepared sql.Stmt objects associated with
+// sqlair.Statement objects. The driver-prepared sql.Stmt objects corresponding
+// to a single sqlair.Statement can be prepared on different databases and have
 // different generated SQL (depending on query arguments).
 //
 // Entries in the cache are indexed by the sqlair.Statement cache ID and the
@@ -27,7 +27,7 @@ import (
 // set on sqlair.DB objects to close all sql.Stmt objects prepared on the DB,
 // close the DB, and remove the DB cache ID from the cache.
 //
-// Only a single driver prepared sql.Stmt is cached for each sqlair.DB/
+// Only a single driver-prepared sql.Stmt is cached for each sqlair.DB/
 // sqlair.Statement pair. If the sqlair.Statement is re-prepared with different
 // generated SQL then the previous sql.Stmt is evicted from the cache. A
 // finalizer is set on the evicted sql.Stmt to ensure it is closed once all
@@ -103,10 +103,10 @@ func (sc *statementCache) newDB(sqldb *sql.DB) *DB {
 }
 
 // lookupStmt checks if a Statement has been prepared on the db driver with the
-// given primedSQL. If it has, the driver prepared sql.Stmt is returned.
+// given primedSQL. If it has, the driver-prepared sql.Stmt is returned.
 func (sc *statementCache) lookupStmt(db *DB, s *Statement, primedSQL string) (stmt *sql.Stmt, ok bool) {
 	// The Statement cache ID is only removed from stmtDBCache when the
-	// finalizer is run. The Statements cache ID must be in the stmtDBCache
+	// finalizer is run. The Statement's cache ID must be in the stmtDBCache
 	// since we hold a reference to the Statement. It is therefore safe to
 	// access in it in the map without first checking it exists.
 	sc.mutex.RLock()

--- a/cache.go
+++ b/cache.go
@@ -1,0 +1,150 @@
+// Copyright 2024 Canonical Ltd.
+// Licensed under the AGPLv3, see LICENCE file for details.
+
+package sqlair
+
+import (
+	"context"
+	"database/sql"
+	"runtime"
+	"sync"
+	"sync/atomic"
+
+	"github.com/canonical/sqlair/internal/expr"
+)
+
+// statementCache caches the driver prepared sql.Stmt objects associated with
+// each sqlair.Statement. A sqlair.Statement can correspond to multiple sql.Stmt
+// objects prepared on different databases. Entries in the cache are therefore
+// indexed by the sqlair.Statement cache ID and the sqlair.DB cache ID.
+//
+// A finalizer is set on sqlair.Statement objects to close the associated
+// sql.Stmt objects. Similarly, a finalizer is set on sqlair.DB objects to close
+// all sql.Stmt objects prepared on the DB, close the DB, and remove the DB
+// cache ID from the cache.
+//
+// The mutex must be locked when accessing either the stmtDBCache or the
+// dbStmtCache.
+type statementCache struct {
+	// stmtDBCache stores sql.Stmt objects addressed via the cache ID of the
+	// sqlair.Statement they built from and the sqlair.DB they are prepared on.
+	stmtDBCache map[uint64]map[uint64]*sql.Stmt
+
+	// dbStmtCache indicates when a sqlair.Statement has been prepared on a particular sqlair.DB.
+	dbStmtCache map[uint64]map[uint64]bool
+
+	// stmtIDCount and dbIDCount are monotonically increasing counters used to
+	// generate unique new cache IDs.
+	stmtIDCount uint64
+	dbIDCount   uint64
+
+	mutex sync.RWMutex
+}
+
+var once sync.Once
+var singleStmtCache *statementCache
+
+// newStatementCache returns the single instance of the statement cache.
+func newStatementCache() *statementCache {
+	once.Do(func() {
+		singleStmtCache = &statementCache{
+			stmtDBCache: map[uint64]map[uint64]*sql.Stmt{},
+			dbStmtCache: map[uint64]map[uint64]bool{},
+		}
+	})
+	return singleStmtCache
+}
+
+// newStatement returns a new sqlair.Statement and adds it to the cache. A
+// finalizer is set on the sqlair.Statement to remove its ID from the cache and
+// close all associated sql.Stmt objects.
+func (sc *statementCache) newStatement(te *expr.TypeBoundExpr) *Statement {
+	cacheID := atomic.AddUint64(&sc.stmtIDCount, 1)
+	sc.mutex.Lock()
+	sc.stmtDBCache[cacheID] = map[uint64]*sql.Stmt{}
+	sc.mutex.Unlock()
+	s := &Statement{te: te, cacheID: cacheID}
+	// This finalizer is run after the Statement is garbage collected.
+	runtime.SetFinalizer(s, sc.removeAndCloseStmtFunc)
+	return s
+}
+
+// newDB returns a new sqlair.DB and allocates the necessary resources in the
+// statementCache. A finalizer is set on the sqlair.DB to remove references to
+// it from the cache, close all sql.Stmt objects on it, and close the sql.DB
+func (sc *statementCache) newDB(sqldb *sql.DB) *DB {
+	cacheID := atomic.AddUint64(&sc.dbIDCount, 1)
+	sc.mutex.Lock()
+	sc.dbStmtCache[cacheID] = map[uint64]bool{}
+	sc.mutex.Unlock()
+	db := &DB{sqldb: sqldb, cacheID: cacheID}
+	// This finalizer is run after the DB is garbage collected.
+	runtime.SetFinalizer(db, sc.removeAndCloseDBFunc)
+	return db
+}
+
+// lookupStmt checks if a *sql.Stmt corresponding to s has been prepared on db
+// and stored in the cache.
+func (sc *statementCache) lookupStmt(db *DB, s *Statement) (*sql.Stmt, bool) {
+	// The Statement cache ID is only removed from stmtDBCache when the
+	// finalizer is run. The Statements cache ID must be in the stmtDBCache
+	// since we hold a reference to the Statement. It is therefore safe to
+	// access in it in the map without first checking it exists.
+	sc.mutex.RLock()
+	sqlstmt, ok := sc.stmtDBCache[s.cacheID][db.cacheID]
+	sc.mutex.RUnlock()
+	return sqlstmt, ok
+}
+
+// driverPrepareStatement prepares a statement on the database and then stores
+// the prepared *sql.Stmt in the cache.
+func (sc *statementCache) driverPrepareStmt(ctx context.Context, db *DB, s *Statement, sql string) (*sql.Stmt, error) {
+	sqlstmt, err := db.sqldb.PrepareContext(ctx, sql)
+	if err != nil {
+		return nil, err
+	}
+	sc.mutex.Lock()
+	defer sc.mutex.Unlock()
+	// Check if sqlstmt has been inserted by another process else already.
+	sqlstmtAlt, ok := sc.stmtDBCache[s.cacheID][db.cacheID]
+	if ok {
+		err = sqlstmt.Close()
+		if err != nil {
+			return nil, err
+		}
+		sqlstmt = sqlstmtAlt
+	} else {
+		sc.stmtDBCache[s.cacheID][db.cacheID] = sqlstmt
+		sc.dbStmtCache[db.cacheID][s.cacheID] = true
+	}
+	return sqlstmt, nil
+}
+
+// removeAndCloseStmtFunc removes and closes all sql.Stmt objects associated
+// with the argument Statement from the statement caches of each DB.
+func (sc *statementCache) removeAndCloseStmtFunc(s *Statement) {
+	sc.mutex.Lock()
+	defer sc.mutex.Unlock()
+	dbCache := sc.stmtDBCache[s.cacheID]
+	for dbCacheID, sqlstmt := range dbCache {
+		sqlstmt.Close()
+		delete(sc.dbStmtCache[dbCacheID], s.cacheID)
+	}
+	delete(sc.stmtDBCache, s.cacheID)
+}
+
+// removeAndCloseDBFunc closes and removes from the cache all sql.Stmt objects
+// prepared on the database, removes the database from then cache, then closes
+// the sql.DB.
+func (sc *statementCache) removeAndCloseDBFunc(db *DB) {
+	sc.mutex.Lock()
+	defer sc.mutex.Unlock()
+	statementCache := sc.dbStmtCache[db.cacheID]
+	for statementCacheID := range statementCache {
+		dbCache := sc.stmtDBCache[statementCacheID]
+		dbCache[db.cacheID].Close()
+		delete(dbCache, db.cacheID)
+	}
+	delete(sc.dbStmtCache, db.cacheID)
+	db.sqldb.Close()
+}

--- a/cache_test.go
+++ b/cache_test.go
@@ -1,0 +1,331 @@
+// Copyright 2024 Canonical Ltd.
+// Licensed under the AGPLv3, see LICENCE file for details.
+
+package sqlair
+
+import (
+	"context"
+	"database/sql"
+	"runtime"
+	"testing"
+	"time"
+
+	_ "github.com/mattn/go-sqlite3"
+	. "gopkg.in/check.v1"
+)
+
+func TestCache(t *testing.T) { TestingT(t) }
+
+type CacheSuite struct{}
+
+var _ = Suite(&CacheSuite{})
+
+func (s *CacheSuite) TearDownTest(c *C) {
+	// Check every test finishes cleanly.
+	s.triggerFinalizers()
+	s.checkCacheEmpty(c)
+	s.checkDriverStmtsAllClosed(c)
+}
+
+func (s *CacheSuite) TearDownSuite(_ *C) {
+	stmtRegistryMutex.Lock()
+	defer stmtRegistryMutex.Unlock()
+
+	// Reset prepared statements trackers.
+	closedStmts = map[string]map[uintptr]bool{}
+	openedStmts = map[string]map[uintptr]string{}
+
+	// Reset prepared statements trackers.
+	dbQueriesRun = map[string]int{}
+	stmtQueriesRun = map[string]int{}
+}
+
+func (s *CacheSuite) TestPreparedStatementReuse(c *C) {
+	db := s.openDB(c)
+
+	var stmtID uint64
+	// For a Statement or DB to be removed from the cache it needs to go out of
+	// scope and be garbage collected. A function is used to "forget" the
+	// statement.
+	func() {
+		stmt, err := Prepare(`SELECT 'test'`)
+		c.Assert(err, IsNil)
+		stmtID = stmt.cacheID
+
+		// Start a query with stmt on db. This will prepare the stmt on the db.
+		err = db.Query(nil, stmt).Run()
+		c.Assert(err, IsNil)
+
+		// Check a statement is in the cache and a prepared statement has been
+		// opened on the DB.
+		s.checkStmtInCache(c, db.cacheID, stmt.cacheID)
+		s.checkNumDBStmts(c, db.cacheID, 1)
+		s.checkDriverStmtsOpened(c, 1)
+
+		// Run the query again.
+		err = db.Query(nil, stmt).Run()
+		c.Assert(err, IsNil)
+
+		// Check that running a second time does not prepare a second statement.
+		s.checkNumDBStmts(c, db.cacheID, 1)
+		s.checkDriverStmtsOpened(c, 1)
+	}()
+
+	s.triggerFinalizers()
+
+	// Check the prepared statement has been removed from the cache and closed.
+	s.checkStmtNotInCache(c, stmtID)
+	s.checkDriverStmtsAllClosed(c)
+}
+
+func (s *CacheSuite) TestClosingDB(c *C) {
+	stmt, err := Prepare(`SELECT 'test'`)
+	c.Assert(err, IsNil)
+
+	var dbID uint64
+	func() {
+		db := s.openDB(c)
+		dbID = db.cacheID
+
+		// Start a query with stmt on db. This will prepare the stmt on the db.
+		err = db.Query(nil, stmt).Run()
+		c.Assert(err, IsNil)
+
+		// Check a statement is in the cache and a prepared statement has been
+		// opened on the DB.
+		s.checkStmtInCache(c, db.cacheID, stmt.cacheID)
+		s.checkNumDBStmts(c, db.cacheID, 1)
+		s.checkDriverStmtsOpened(c, 1)
+	}()
+
+	s.triggerFinalizers()
+	s.checkDBNotInCache(c, dbID)
+	s.checkDriverStmtsAllClosed(c)
+
+	// Check that the statement runs fine on a new DB.
+	db := s.openDB(c)
+	err = db.Query(nil, stmt).Run()
+	c.Assert(err, IsNil)
+
+	// Check the statement has been added to the cache for the new DB.
+	s.checkStmtInCache(c, db.cacheID, stmt.cacheID)
+	s.checkNumDBStmts(c, db.cacheID, 1)
+	s.checkDriverStmtsOpened(c, 2)
+}
+
+func (s *CacheSuite) TestStatementPreparedAndClosed(c *C) {
+	db := s.openDB(c)
+
+	// For a Statement or DB to be removed from the cache it needs to go out of
+	// scope and be garbage collected. A function is used to "forget" the
+	// statement.
+	func() {
+		stmt, err := Prepare(`SELECT 'test'`)
+		c.Assert(err, IsNil)
+
+		// Start a query with stmt on db. This will prepare the stmt on the db.
+		err = db.Query(nil, stmt).Run()
+		c.Assert(err, IsNil)
+
+		// Check a prepared statement has been opened on the DB.
+		s.checkDriverStmtsOpened(c, 1)
+	}()
+	s.triggerFinalizers()
+	s.checkDriverStmtsAllClosed(c)
+}
+
+func (s *CacheSuite) TestPreparedStatementsClosedWithDB(c *C) {
+	stmt, err := Prepare(`SELECT 'test'`)
+	c.Assert(err, IsNil)
+
+	// For a Statement or DB to be removed from the cache it needs to go out of
+	// scope and be garbage collected. A function is used to "forget" the
+	// statement.
+	func() {
+		db := s.openDB(c)
+
+		// Start a query with stmt on db. This will prepare the stmt on the db.
+		err = db.Query(context.Background(), stmt).Run()
+		c.Assert(err, IsNil)
+
+		s.checkStmtInCache(c, db.cacheID, stmt.cacheID)
+	}()
+	s.triggerFinalizers()
+	s.checkStmtNotInCache(c, stmt.cacheID)
+}
+
+func (s *CacheSuite) TestPreparedStatementsInTX(c *C) {
+	db := s.openDB(c)
+
+	stmt, err := Prepare(`SELECT 'test'`)
+	c.Assert(err, IsNil)
+
+	// Start a new transaction.
+	tx, err := db.Begin(context.Background(), nil)
+	c.Assert(err, IsNil)
+
+	// A query executed on a transaction will reuse a prepared statement if it
+	// exists, but it will not create one if it does not. The query below should
+	// run directly on the DB, not use a prepared statement.
+	err = tx.Query(context.Background(), stmt).Run()
+	c.Assert(err, IsNil)
+	// Check no new statement has been added to the driver cache.
+	s.checkNumDBStmts(c, db.cacheID, 0)
+	s.checkQueriesRunOnDB(c, 1)
+	s.checkQueriesRunOnStmt(c, 0)
+
+	// Prepare the query on the database by running it.
+	err = db.Query(context.Background(), stmt).Run()
+	c.Assert(err, IsNil)
+	s.checkStmtInCache(c, db.cacheID, stmt.cacheID)
+	s.checkNumDBStmts(c, db.cacheID, 1)
+	s.checkQueriesRunOnDB(c, 1)
+	s.checkQueriesRunOnStmt(c, 1)
+
+	// Run the statement on the transaction. This should reuse the prepared
+	// statement.
+	err = tx.Query(context.Background(), stmt).Run()
+	c.Assert(err, IsNil)
+	// Check no new statement has been added to the driver cache.
+	s.checkQueriesRunOnDB(c, 1)
+	s.checkQueriesRunOnStmt(c, 2)
+
+	err = tx.Commit()
+	c.Assert(err, IsNil)
+}
+
+// TestLateQuery checks that a Query that outlives a Statement does not throw a
+// statement is closed error.
+func (s *CacheSuite) TestLateQuery(c *C) {
+	var q *Query
+	// Drop all the values except the query itself.
+	func() {
+		db := s.openDB(c)
+
+		selectStmt, err := Prepare(`SELECT 'hello'`)
+		c.Assert(err, IsNil)
+		q = db.Query(nil, selectStmt)
+	}()
+
+	s.triggerFinalizers()
+
+	// Assert that sql.Stmt was not closed early.
+	c.Assert(q.Run(), IsNil)
+}
+
+// TestLateQueryTX checks that a Query on a transaction that outlives a
+// Statement does not throw a statement is closed error.
+func (s *CacheSuite) TestLateQueryTX(c *C) {
+	var q *Query
+	// Drop all the values except the query itself.
+	func() {
+		db := s.openDB(c)
+
+		selectStmt, err := Prepare(`SELECT 'hello'`)
+		c.Assert(err, IsNil)
+		tx, err := db.Begin(nil, nil)
+		c.Assert(err, IsNil)
+		q = tx.Query(nil, selectStmt)
+	}()
+
+	s.triggerFinalizers()
+
+	// Assert that sql.Stmt was not closed early.
+	c.Assert(q.Run(), IsNil)
+}
+
+func (s *CacheSuite) openDB(c *C) *DB {
+	db, err := sql.Open("sqlite3_stmtChecked", "file:test.db?cache=shared&mode=memory&testName="+c.TestName())
+	c.Assert(err, IsNil)
+	return NewDB(db)
+}
+
+func (s *CacheSuite) triggerFinalizers() {
+	// Try to run finalizers by calling GC several times.
+	for i := 0; i <= 10; i++ {
+		runtime.GC()
+		time.Sleep(0)
+	}
+}
+
+func (s *CacheSuite) checkStmtInCache(c *C, dbID, stmtID uint64) {
+	stmtCache.mutex.RLock()
+	defer stmtCache.mutex.RUnlock()
+	_, ok := stmtCache.stmtDBCache[stmtID][dbID]
+	c.Check(ok, Equals, true)
+	_, ok = stmtCache.dbStmtCache[dbID][stmtID]
+	c.Check(ok, Equals, true)
+}
+
+func (s *CacheSuite) checkStmtNotInCache(c *C, stmtID uint64) {
+	stmtCache.mutex.RLock()
+	defer stmtCache.mutex.RUnlock()
+	dbc, ok := stmtCache.stmtDBCache[stmtID]
+	if ok {
+		c.Check(dbc, HasLen, 0)
+	}
+
+	for _, dbc := range stmtCache.dbStmtCache {
+		_, ok := dbc[stmtID]
+		c.Check(ok, Equals, false)
+	}
+}
+
+func (s *CacheSuite) checkDBNotInCache(c *C, dbID uint64) {
+	stmtCache.mutex.RLock()
+	defer stmtCache.mutex.RUnlock()
+	_, ok := stmtCache.dbStmtCache[dbID]
+	c.Check(ok, Equals, false)
+
+	for _, sc := range stmtCache.stmtDBCache {
+		_, ok := sc[dbID]
+		c.Check(ok, Equals, false)
+	}
+}
+
+func (s *CacheSuite) checkNumDBStmts(c *C, dbID uint64, n int) {
+	stmtCache.mutex.RLock()
+	defer stmtCache.mutex.RUnlock()
+	sc, ok := stmtCache.dbStmtCache[dbID]
+	c.Check(ok, Equals, true)
+	c.Check(sc, HasLen, n)
+
+	numDBStmts := 0
+	for _, dbc := range stmtCache.stmtDBCache {
+		if _, ok := dbc[dbID]; ok {
+			numDBStmts += 1
+		}
+	}
+	c.Check(numDBStmts, Equals, n)
+}
+
+func (s *CacheSuite) checkCacheEmpty(c *C) {
+	stmtCache.mutex.RLock()
+	defer stmtCache.mutex.RUnlock()
+	c.Check(stmtCache.stmtDBCache, HasLen, 0)
+	c.Check(stmtCache.dbStmtCache, HasLen, 0)
+}
+
+func (s *CacheSuite) checkDriverStmtsAllClosed(c *C) {
+	stmtRegistryMutex.RLock()
+	defer stmtRegistryMutex.RUnlock()
+	c.Check(len(openedStmts[c.TestName()]), Equals, len(closedStmts[c.TestName()]))
+}
+
+func (s *CacheSuite) checkDriverStmtsOpened(c *C, n int) {
+	stmtRegistryMutex.RLock()
+	defer stmtRegistryMutex.RUnlock()
+	c.Check(openedStmts[c.TestName()], HasLen, n)
+}
+
+func (s *CacheSuite) checkQueriesRunOnDB(c *C, n int) {
+	queriesRunMutex.RLock()
+	defer queriesRunMutex.RUnlock()
+	c.Check(dbQueriesRun[c.TestName()], Equals, n)
+}
+
+func (s *CacheSuite) checkQueriesRunOnStmt(c *C, n int) {
+	queriesRunMutex.RLock()
+	defer queriesRunMutex.RUnlock()
+	c.Check(stmtQueriesRun[c.TestName()], Equals, n)
+}

--- a/driver_test.go
+++ b/driver_test.go
@@ -1,0 +1,231 @@
+// Copyright 2024 Canonical Ltd.
+// Licensed under the AGPLv3, see LICENCE file for details.
+package sqlair
+
+import (
+	"context"
+	"database/sql"
+	"database/sql/driver"
+	"fmt"
+	"strings"
+	"sync"
+	"unsafe"
+
+	"github.com/mattn/go-sqlite3"
+)
+
+// This file contains a wrapper sql.Driver over the SQLite driver which
+// monitors the creation and closing of prepared statements and stores the
+// references to said statements. We can later use that information to check
+// for statement leaks.
+
+// openedStmts and closedStmts store the pointers to the created/closed
+// statements indexed by test case. We use unsafe pointers instead of references
+// to the objects because if we stored a reference the runtime.Finalizer would
+// not be able to run.
+var openedStmts = map[string]map[uintptr]string{}
+var closedStmts = map[string]map[uintptr]bool{}
+var stmtRegistryMutex sync.RWMutex
+
+// dbQueriesRun and stmtQueriesRun count the number of queries run directly
+// against the database and queries that are run through a prepared statement.
+// The maps are indexed by the test name. The queriesRunMutex must be used when
+// accessing the counts.
+var dbQueriesRun = map[string]int{}
+var stmtQueriesRun = map[string]int{}
+var queriesRunMutex sync.RWMutex
+
+type Driver struct {
+	driver.Driver
+}
+
+type Conn struct {
+	testName string
+	*sqlite3.SQLiteConn
+}
+
+type Stmt struct {
+	testName string
+	*sqlite3.SQLiteStmt
+}
+
+func (s *Stmt) Close() error {
+	stmtRegistryMutex.Lock()
+	defer stmtRegistryMutex.Unlock()
+	_, ok := closedStmts[s.testName]
+	if !ok {
+		closedStmts[s.testName] = map[uintptr]bool{}
+	}
+	closedStmts[s.testName][uintptr(unsafe.Pointer(s))] = true
+
+	return s.SQLiteStmt.Close()
+}
+
+func (c *Conn) PrepareContext(ctx context.Context, query string) (driver.Stmt, error) {
+	s, err := c.SQLiteConn.PrepareContext(ctx, query)
+	if sm, ok := s.(*sqlite3.SQLiteStmt); ok {
+		sPtr := &Stmt{SQLiteStmt: sm, testName: c.testName}
+
+		stmtRegistryMutex.Lock()
+		defer stmtRegistryMutex.Unlock()
+		_, ok := openedStmts[c.testName]
+		if !ok {
+			openedStmts[c.testName] = map[uintptr]string{}
+		}
+		openedStmts[c.testName][uintptr(unsafe.Pointer(sPtr))] = query
+
+		return sPtr, err
+	} else {
+		panic(fmt.Sprintf("internal error: base driver is not SQLite, got %T", s))
+	}
+}
+
+func (c *Conn) Prepare(query string) (driver.Stmt, error) {
+	return c.PrepareContext(context.Background(), query)
+}
+
+func (c *Conn) Query(query string, args []driver.Value) (driver.Rows, error) {
+	rows, err := c.SQLiteConn.Query(query, args)
+	if err == nil {
+		queriesRunMutex.Lock()
+		defer queriesRunMutex.Unlock()
+		if _, ok := dbQueriesRun[c.testName]; ok {
+			dbQueriesRun[c.testName] += 1
+		} else {
+			dbQueriesRun[c.testName] = 1
+		}
+	}
+	return rows, err
+}
+
+func (c *Conn) QueryContext(ctx context.Context, query string, args []driver.NamedValue) (driver.Rows, error) {
+	rows, err := c.SQLiteConn.QueryContext(ctx, query, args)
+	if err == nil {
+		queriesRunMutex.Lock()
+		defer queriesRunMutex.Unlock()
+		if _, ok := dbQueriesRun[c.testName]; ok {
+			dbQueriesRun[c.testName] += 1
+		} else {
+			dbQueriesRun[c.testName] = 1
+		}
+	}
+	return rows, err
+}
+
+func (c *Conn) Exec(query string, args []driver.Value) (driver.Result, error) {
+	res, err := c.SQLiteConn.Exec(query, args)
+	if err == nil {
+		queriesRunMutex.Lock()
+		defer queriesRunMutex.Unlock()
+		if _, ok := dbQueriesRun[c.testName]; ok {
+			dbQueriesRun[c.testName] += 1
+		} else {
+			dbQueriesRun[c.testName] = 1
+		}
+	}
+	return res, err
+}
+
+func (c *Conn) ExecContext(ctx context.Context, query string, args []driver.NamedValue) (driver.Result, error) {
+	res, err := c.SQLiteConn.ExecContext(ctx, query, args)
+	if err == nil {
+		queriesRunMutex.Lock()
+		defer queriesRunMutex.Unlock()
+		if _, ok := dbQueriesRun[c.testName]; ok {
+			dbQueriesRun[c.testName] += 1
+		} else {
+			dbQueriesRun[c.testName] = 1
+		}
+	}
+	return res, err
+}
+
+func (s *Stmt) Query(args []driver.Value) (driver.Rows, error) {
+	rows, err := s.SQLiteStmt.Query(args)
+	if err == nil {
+		queriesRunMutex.Lock()
+		defer queriesRunMutex.Unlock()
+		if _, ok := stmtQueriesRun[s.testName]; ok {
+			stmtQueriesRun[s.testName] += 1
+		} else {
+			stmtQueriesRun[s.testName] = 1
+		}
+	}
+	return rows, err
+}
+
+func (s *Stmt) QueryContext(ctx context.Context, args []driver.NamedValue) (driver.Rows, error) {
+	rows, err := s.SQLiteStmt.QueryContext(ctx, args)
+	if err == nil {
+		queriesRunMutex.Lock()
+		defer queriesRunMutex.Unlock()
+		if _, ok := stmtQueriesRun[s.testName]; ok {
+			stmtQueriesRun[s.testName] += 1
+		} else {
+			stmtQueriesRun[s.testName] = 1
+		}
+	}
+	return rows, err
+}
+
+func (s *Stmt) Exec(args []driver.Value) (driver.Result, error) {
+	res, err := s.SQLiteStmt.Exec(args)
+	if err == nil {
+		queriesRunMutex.Lock()
+		defer queriesRunMutex.Unlock()
+		if _, ok := stmtQueriesRun[s.testName]; ok {
+			stmtQueriesRun[s.testName] += 1
+		} else {
+			stmtQueriesRun[s.testName] = 1
+		}
+	}
+	return res, err
+}
+
+func (s *Stmt) ExecContext(ctx context.Context, args []driver.NamedValue) (driver.Result, error) {
+	fmt.Println(s.SQLiteStmt)
+	res, err := s.SQLiteStmt.ExecContext(ctx, args)
+	if err == nil {
+		queriesRunMutex.Lock()
+		defer queriesRunMutex.Unlock()
+		if _, ok := stmtQueriesRun[s.testName]; ok {
+			stmtQueriesRun[s.testName] += 1
+		} else {
+			stmtQueriesRun[s.testName] = 1
+		}
+	}
+	return res, err
+}
+
+const TestNameTag = "testName"
+
+// Open expects the DSN to contain the test name using the testNameTag
+// attribute.
+func (d *Driver) Open(name string) (driver.Conn, error) {
+	var testName string
+	parameters := strings.Split(name, "?")[1]
+	for _, p := range strings.Split(parameters, "&") {
+		if strings.HasPrefix(p, TestNameTag) {
+			testName = strings.Split(p, "=")[1]
+		}
+	}
+	if testName == "" {
+		panic("internal error: testName is not found in the db DSN")
+	}
+
+	baseConn, err := d.Driver.Open(name)
+	if err != nil {
+		return nil, err
+	}
+	if baseConn, ok := baseConn.(*sqlite3.SQLiteConn); ok {
+		return &Conn{SQLiteConn: baseConn, testName: testName}, err
+	} else {
+		panic("internal error: base driver is not SQLite")
+	}
+}
+
+func init() {
+	sql.Register("sqlite3_stmtChecked", &Driver{
+		&sqlite3.SQLiteDriver{},
+	})
+}

--- a/driver_test.go
+++ b/driver_test.go
@@ -63,6 +63,9 @@ func (s *Stmt) Close() error {
 
 func (c *Conn) PrepareContext(ctx context.Context, query string) (driver.Stmt, error) {
 	s, err := c.SQLiteConn.PrepareContext(ctx, query)
+	if err != nil {
+		return nil, err
+	}
 	if sm, ok := s.(*sqlite3.SQLiteStmt); ok {
 		sPtr := &Stmt{SQLiteStmt: sm, testName: c.testName}
 
@@ -76,7 +79,7 @@ func (c *Conn) PrepareContext(ctx context.Context, query string) (driver.Stmt, e
 
 		return sPtr, err
 	} else {
-		panic(fmt.Sprintf("internal error: base driver is not SQLite, got %T", s))
+		return nil, fmt.Errorf("internal error: base driver is not SQLite, got %T", s)
 	}
 }
 
@@ -183,7 +186,6 @@ func (s *Stmt) Exec(args []driver.Value) (driver.Result, error) {
 }
 
 func (s *Stmt) ExecContext(ctx context.Context, args []driver.NamedValue) (driver.Result, error) {
-	fmt.Println(s.SQLiteStmt)
 	res, err := s.SQLiteStmt.ExecContext(ctx, args)
 	if err == nil {
 		queriesRunMutex.Lock()

--- a/package_test.go
+++ b/package_test.go
@@ -10,16 +10,12 @@ import (
 	"errors"
 	"fmt"
 	"strconv"
-	"testing"
 
 	_ "github.com/mattn/go-sqlite3"
 	. "gopkg.in/check.v1"
 
 	"github.com/canonical/sqlair"
 )
-
-// Hook up gocheck into the "go test" runner.
-func TestPackage(t *testing.T) { TestingT(t) }
 
 type PackageSuite struct {
 	db *sql.DB


### PR DESCRIPTION
When the same SQLair query is executed multiple times against the database it is recompiled by the database every time. This is inefficient. 

It is possible to instead prepare a SQL query against the database driver and cache it in SQLair to allow for reuse of the query.

With this change, when a SQLair statement is executed directly against a database it is first prepared and then executed, the prepared statement is put in the cache for reuse. If the statement is executed in a transaction, the SQLair statement is looked up in the cache but if it is not found it is not prepared on the driver. This is due to the issues in #117.