### PR TITLE
fix: add error for unused types in prepare and refactor bindtypes/arginfo 

### DIFF
--- a/internal/expr/bindtypes.go
+++ b/internal/expr/bindtypes.go
@@ -48,26 +48,18 @@ func (pe *ParsedExpr) BindTypes(args ...any) (tbe *TypeBoundExpr, err error) {
 	}
 
 	// Bind types to each expression.
-	var typedExprs []typedExpr
-	outputUsed := map[string]bool{}
+	teb := newTypedExprBuilder(argInfo)
 	for _, expr := range pe.exprs {
-		typedExpr, err := expr.bindTypes(argInfo)
-		if err != nil {
+		if err := expr.bindTypes(teb); err != nil {
 			return nil, err
 		}
-
-		if toe, ok := typedExpr.(*typedOutputExpr); ok {
-			for _, oc := range toe.outputColumns {
-				if ok := outputUsed[oc.output.Identifier()]; ok {
-					return nil, fmt.Errorf("%s appears more than once in output expressions", oc.output.Desc())
-				}
-				outputUsed[oc.output.Identifier()] = true
-			}
-		}
-		typedExprs = append(typedExprs, typedExpr)
 	}
 
-	return &TypeBoundExpr{typedExprs: typedExprs}, nil
+	if err := teb.checkAllArgsUsed(argInfo); err != nil {
+		return nil, err
+	}
+
+	return &TypeBoundExpr{typedExprs: teb.typedExprs}, nil
 }
 
 // expression represents a parsed node of the SQLair query's AST.
@@ -75,9 +67,8 @@ type expression interface {
 	// String returns a text representation for debugging and testing purposes.
 	String() string
 
-	// bindTypes binds the types to the expression to generate either a
-	// *typedInputExpr or *typedOutputExpr.
-	bindTypes(typeinfo.ArgInfo) (typedExpr, error)
+	// bindTypes binds the types to the expression to generate a typedExpr.
+	bindTypes(*typedExprBuilder) error
 }
 
 // bypass represents part of the expression that we want to pass to the backend
@@ -93,8 +84,9 @@ func (b *bypass) String() string {
 
 // bindTypes returns the bypass part itself since it contains no references to
 // types.
-func (b *bypass) bindTypes(typeinfo.ArgInfo) (typedExpr, error) {
-	return b, nil
+func (b *bypass) bindTypes(teb *typedExprBuilder) error {
+	teb.AddBypass(b)
+	return nil
 }
 
 // addToQuery adds the bypass part to the query builder.
@@ -116,12 +108,13 @@ func (e *memberInputExpr) String() string {
 
 // bindTypes generates a *typedInputExpr containing type information about the
 // Go object and its member.
-func (e *memberInputExpr) bindTypes(argInfo typeinfo.ArgInfo) (typedExpr, error) {
-	input, err := argInfo.InputMember(e.ma.typeName, e.ma.memberName)
+func (e *memberInputExpr) bindTypes(teb *typedExprBuilder) error {
+	input, err := teb.InputMember(e.ma.typeName, e.ma.memberName)
 	if err != nil {
-		return nil, fmt.Errorf("input expression: %s: %s", err, e.raw)
+		return fmt.Errorf("input expression: %s: %s", err, e.raw)
 	}
-	return &typedInputExpr{input: input}, nil
+	teb.AddTypedInputExpr(input)
+	return nil
 }
 
 // asteriskInsertExpr is an input expression occurring within an INSERT
@@ -140,7 +133,7 @@ func (e *asteriskInsertExpr) String() string {
 
 // bindTypes generates a *typedInsertExpr containing type information about the
 // asteriskInsertExpr.
-func (e *asteriskInsertExpr) bindTypes(argInfo typeinfo.ArgInfo) (tie typedExpr, err error) {
+func (e *asteriskInsertExpr) bindTypes(teb *typedExprBuilder) (err error) {
 	defer func() {
 		if err != nil {
 			err = fmt.Errorf("input expression: %s: %s", err, e.raw)
@@ -150,24 +143,25 @@ func (e *asteriskInsertExpr) bindTypes(argInfo typeinfo.ArgInfo) (tie typedExpr,
 	var cols []typedColumn
 	for _, source := range e.sources {
 		if source.memberName == "*" {
-			inputs, tags, err := argInfo.AllStructInputs(source.typeName)
+			inputs, tags, err := teb.AllStructInputs(source.typeName)
 			if err != nil {
-				return nil, err
+				return err
 			}
 			for i, input := range inputs {
 				c := newInsertColumn(input, tags[i], false)
 				cols = append(cols, c)
 			}
 		} else {
-			input, err := argInfo.InputMember(source.typeName, source.memberName)
+			input, err := teb.InputMember(source.typeName, source.memberName)
 			if err != nil {
-				return nil, err
+				return err
 			}
 			c := newInsertColumn(input, source.memberName, true)
 			cols = append(cols, c)
 		}
 	}
-	return &typedInsertExpr{insertColumns: cols}, nil
+	teb.AddTypedInsertExpr(cols)
+	return nil
 }
 
 // columnsInsertExpr is an input expression occurring within an INSERT statement
@@ -188,7 +182,7 @@ func (e *columnsInsertExpr) String() string {
 // columnsInsertExpr. It checks that all the listed columns are provided by the
 // supplied types. If a map with an asterisk is passed, the spare columns are
 // taken from that map.
-func (e *columnsInsertExpr) bindTypes(argInfo typeinfo.ArgInfo) (tie typedExpr, err error) {
+func (e *columnsInsertExpr) bindTypes(teb *typedExprBuilder) (err error) {
 	defer func() {
 		if err != nil {
 			err = fmt.Errorf("input expression: %s: %s", err, e.raw)
@@ -207,29 +201,29 @@ func (e *columnsInsertExpr) bindTypes(argInfo typeinfo.ArgInfo) (tie typedExpr, 
 	var remainingMap *string
 	for _, source := range e.sources {
 		if source.memberName == "*" {
-			kind, err := argInfo.Kind(source.typeName)
+			kind, err := teb.Kind(source.typeName)
 			if err != nil {
-				return nil, err
+				return err
 			}
 			// If we find a map save it for later to match the spare columns.
 			if kind == reflect.Map {
 				if remainingMap != nil {
-					return nil, fmt.Errorf("cannot use more than one map with asterisk")
+					return fmt.Errorf("cannot use more than one map with asterisk")
 				}
 				remainingMap = &source.typeName
 				continue
 			}
-			inps, tags, err := argInfo.AllStructInputs(source.typeName)
+			inps, tags, err := teb.AllStructInputs(source.typeName)
 			if err != nil {
-				return nil, err
+				return err
 			}
 			for i := range tags {
 				colToInput[tags[i]] = append(colToInput[tags[i]], inps[i])
 			}
 		} else {
-			inp, err := argInfo.InputMember(source.typeName, source.memberName)
+			inp, err := teb.InputMember(source.typeName, source.memberName)
 			if err != nil {
-				return nil, err
+				return err
 			}
 			colToInput[source.memberName] = []typeinfo.Input{inp}
 		}
@@ -245,23 +239,24 @@ func (e *columnsInsertExpr) bindTypes(argInfo typeinfo.ArgInfo) (tie typedExpr, 
 		input, ok := colToInput[columnStr]
 		if !ok && remainingMap != nil {
 			// The spare columns must belong to the map.
-			inp, err := argInfo.InputMember(*remainingMap, columnStr)
+			inp, err := teb.InputMember(*remainingMap, columnStr)
 			if err != nil {
 				// unreachable
-				return nil, err
+				return err
 			}
 			input = []typeinfo.Input{inp}
 		} else if !ok {
-			return nil, fmt.Errorf("missing type that provides column %q", columnStr)
+			return fmt.Errorf("missing type that provides column %q", columnStr)
 		}
 		if len(input) > 1 {
-			return nil, fmt.Errorf("more than one type provides column %q", columnStr)
+			return fmt.Errorf("more than one type provides column %q", columnStr)
 		}
 
 		c := newInsertColumn(input[0], columnStr, true)
 		cols = append(cols, c)
 	}
-	return &typedInsertExpr{insertColumns: cols}, nil
+	teb.AddTypedInsertExpr(cols)
+	return nil
 }
 
 // basicInsertExpr is an input expression occurring within an INSERT statement
@@ -282,24 +277,25 @@ func (e *basicInsertExpr) String() string {
 
 // bindTypes generates a *typedInsertExpr containing type information about the
 // values to be inserted in the basicInsertExpr.
-func (e *basicInsertExpr) bindTypes(argInfo typeinfo.ArgInfo) (tie typedExpr, err error) {
+func (e *basicInsertExpr) bindTypes(teb *typedExprBuilder) (err error) {
 	defer func() {
 		if err != nil {
 			err = fmt.Errorf("input expression: %s: %s", err, e.raw)
 		}
 	}()
 	if len(e.columns) != len(e.sources) {
-		return nil, fmt.Errorf("mismatched number of columns and values: %d != %d", len(e.columns), len(e.sources))
+		return fmt.Errorf("mismatched number of columns and values: %d != %d", len(e.columns), len(e.sources))
 	}
 	var cols []typedColumn
 	for i, source := range e.sources {
-		col, err := source.typedColumn(argInfo, e.columns[i].columnName())
+		col, err := source.typedColumn(teb, e.columns[i].columnName())
 		if err != nil {
-			return nil, err
+			return err
 		}
 		cols = append(cols, col)
 	}
-	return &typedInsertExpr{insertColumns: cols}, nil
+	teb.AddTypedInsertExpr(cols)
+	return nil
 }
 
 // sliceInputExpr is an input expression of the form "$S[:]" that represents a
@@ -316,12 +312,13 @@ func (e *sliceInputExpr) String() string {
 
 // bindTypes generates a *typedInputExpr containing type information about the
 // slice.
-func (e *sliceInputExpr) bindTypes(argInfo typeinfo.ArgInfo) (typedExpr, error) {
-	input, err := argInfo.InputSlice(e.sliceTypeName)
+func (e *sliceInputExpr) bindTypes(teb *typedExprBuilder) error {
+	input, err := teb.InputSlice(e.sliceTypeName)
 	if err != nil {
-		return nil, fmt.Errorf("input expression: %s: %s", err, e.raw)
+		return fmt.Errorf("input expression: %s: %s", err, e.raw)
 	}
-	return &typedInputExpr{input}, nil
+	teb.AddTypedInputExpr(input)
+	return nil
 }
 
 // outputExpr represents columns to be read from the database and Go values to
@@ -340,7 +337,7 @@ func (e *outputExpr) String() string {
 // bindTypes binds the output expression to concrete types. It then checks the
 // expression is valid with respect to its bound types and returns a
 // *typedOutputExpr.
-func (e *outputExpr) bindTypes(argInfo typeinfo.ArgInfo) (te typedExpr, err error) {
+func (e *outputExpr) bindTypes(teb *typedExprBuilder) (err error) {
 	defer func() {
 		if err != nil {
 			err = fmt.Errorf("output expression: %s: %s", err, e.raw)
@@ -352,7 +349,7 @@ func (e *outputExpr) bindTypes(argInfo typeinfo.ArgInfo) (te typedExpr, err erro
 	starTypes := starCountTypes(e.targetTypes)
 	starColumns := starCountColumns(e.sourceColumns)
 
-	toe := &typedOutputExpr{}
+	var outputColumns []outputColumn
 
 	// Case 1: Generated columns e.g. "* AS (&P.*, &A.id)" or "&P.*".
 	if numColumns == 0 || (numColumns == 1 && starColumns == 1) {
@@ -365,60 +362,63 @@ func (e *outputExpr) bindTypes(argInfo typeinfo.ArgInfo) (te typedExpr, err erro
 		for _, t := range e.targetTypes {
 			if t.memberName == "*" {
 				// Generate asterisk columns.
-				outputs, memberNames, err := argInfo.AllStructOutputs(t.typeName)
+				outputs, memberNames, err := teb.AllStructOutputs(t.typeName)
 				if err != nil {
-					return nil, err
+					return err
 				}
 				for i, output := range outputs {
 					oc := newOutputColumn(pref, memberNames[i], output)
-					toe.outputColumns = append(toe.outputColumns, oc)
+					outputColumns = append(outputColumns, oc)
 				}
 			} else {
 				// Generate explicit columns.
-				output, err := argInfo.OutputMember(t.typeName, t.memberName)
+				output, err := teb.OutputMember(t.typeName, t.memberName)
 				if err != nil {
-					return nil, err
+					return err
 				}
 				oc := newOutputColumn(pref, t.memberName, output)
-				toe.outputColumns = append(toe.outputColumns, oc)
+				outputColumns = append(outputColumns, oc)
 			}
 		}
-		return toe, nil
+		teb.AddTypedOutputExpr(outputColumns)
+		return nil
 	} else if numColumns > 1 && starColumns > 0 {
-		return nil, fmt.Errorf("invalid asterisk in columns")
+		return fmt.Errorf("invalid asterisk in columns")
 	}
 
 	// Case 2: Explicit columns, single asterisk type e.g. "(col1, t.col2) AS &P.*".
 	if starTypes == 1 && numTypes == 1 {
 		for _, c := range e.sourceColumns {
-			output, err := argInfo.OutputMember(e.targetTypes[0].typeName, c.columnName())
+			output, err := teb.OutputMember(e.targetTypes[0].typeName, c.columnName())
 			if err != nil {
-				return nil, err
+				return err
 			}
 			oc := newOutputColumn(c.tableName(), c.columnName(), output)
-			toe.outputColumns = append(toe.outputColumns, oc)
+			outputColumns = append(outputColumns, oc)
 		}
-		return toe, nil
+		teb.AddTypedOutputExpr(outputColumns)
+		return nil
 	} else if starTypes > 0 && numTypes > 1 {
-		return nil, fmt.Errorf("invalid asterisk in types")
+		return fmt.Errorf("invalid asterisk in types")
 	}
 
 	// Case 3: Explicit columns and types e.g. "(col1, col2) AS (&P.name, &P.id)".
 	if numColumns == numTypes {
 		for i, c := range e.sourceColumns {
 			t := e.targetTypes[i]
-			output, err := argInfo.OutputMember(t.typeName, t.memberName)
+			output, err := teb.OutputMember(t.typeName, t.memberName)
 			if err != nil {
-				return nil, err
+				return err
 			}
 			oc := newOutputColumn(c.tableName(), c.columnName(), output)
-			toe.outputColumns = append(toe.outputColumns, oc)
+			outputColumns = append(outputColumns, oc)
 		}
 	} else {
-		return nil, fmt.Errorf("mismatched number of columns and target types")
+		return fmt.Errorf("mismatched number of columns and target types")
 	}
 
-	return toe, nil
+	teb.AddTypedOutputExpr(outputColumns)
+	return nil
 }
 
 // valueAccessor defines an accessor that can be used to generate a typedColumn
@@ -426,7 +426,7 @@ func (e *outputExpr) bindTypes(argInfo typeinfo.ArgInfo) (te typedExpr, err erro
 type valueAccessor interface {
 	// typedColumn generates a typedColumn that associates the given colum name
 	// with the value specified by the valueAccessor.
-	typedColumn(argInfo typeinfo.ArgInfo, columnName string) (typedColumn, error)
+	typedColumn(teb *typedExprBuilder, columnName string) (typedColumn, error)
 }
 
 // memberAccessor stores information for accessing a keyed Go value. It consists
@@ -447,7 +447,7 @@ func (l literal) String() string {
 }
 
 // typedColumn generates a typedColumn with the given name from a literal.
-func (l literal) typedColumn(_ typeinfo.ArgInfo, columnName string) (typedColumn, error) {
+func (l literal) typedColumn(_ *typedExprBuilder, columnName string) (typedColumn, error) {
 	lc := newLiteralColumn(columnName, l.value)
 	return lc, nil
 }
@@ -458,8 +458,8 @@ func (ma memberAccessor) String() string {
 
 // typedColumn generates a typedColumn with the input specified by the member
 // accessor and the given column name.
-func (ma memberAccessor) typedColumn(argInfo typeinfo.ArgInfo, columnName string) (typedColumn, error) {
-	input, err := argInfo.InputMember(ma.typeName, ma.memberName)
+func (ma memberAccessor) typedColumn(teb *typedExprBuilder, columnName string) (typedColumn, error) {
+	input, err := teb.InputMember(ma.typeName, ma.memberName)
 	if err != nil {
 		return nil, err
 	}

--- a/internal/expr/typedexprbuilder.go
+++ b/internal/expr/typedexprbuilder.go
@@ -1,0 +1,205 @@
+// Copyright 2024 Canonical Ltd.
+// Licensed under the AGPLv3, see LICENCE file for details.
+
+package expr
+
+import (
+	"fmt"
+	"reflect"
+	"sort"
+
+	"github.com/canonical/sqlair/internal/typeinfo"
+)
+
+// typedExprBuild is used to build up typed expressions.
+type typedExprBuilder struct {
+	argInfo    map[string]typeinfo.ArgInfo
+	argUsed    map[typeinfo.ArgInfo]bool
+	outputUsed map[string]bool
+	typedExprs []typedExpr
+}
+
+func newTypedExprBuilder(argInfo map[string]typeinfo.ArgInfo) *typedExprBuilder {
+	return &typedExprBuilder{
+		argInfo:    argInfo,
+		argUsed:    map[typeinfo.ArgInfo]bool{},
+		outputUsed: map[string]bool{},
+	}
+}
+
+// InputMember returns an input locator for a member of a struct or map.
+func (teb *typedExprBuilder) InputMember(typeName string, memberName string) (typeinfo.Input, error) {
+	arg, err := teb.getArg(typeName)
+	if err != nil {
+		return nil, err
+	}
+	vl, err := arg.GetMember(memberName)
+	if err != nil {
+		return nil, err
+	}
+	input, ok := vl.(typeinfo.Input)
+	if !ok {
+		return nil, fmt.Errorf("%s cannot be used as input", vl.ArgType().Kind())
+	}
+	return input, nil
+}
+
+// OutputMember returns an output locator for a member of a struct or map.
+func (teb *typedExprBuilder) OutputMember(typeName string, memberName string) (typeinfo.Output, error) {
+	arg, err := teb.getArg(typeName)
+	if err != nil {
+		return nil, err
+	}
+	vl, err := arg.GetMember(memberName)
+	if err != nil {
+		return nil, err
+	}
+	output, ok := vl.(typeinfo.Output)
+	if !ok {
+		return nil, fmt.Errorf("%s cannot be used as output", vl.ArgType().Kind())
+	}
+	if _, ok := teb.outputUsed[output.Identifier()]; ok {
+		return nil, usedInMultipleOutputsError(output.Desc())
+	}
+	teb.outputUsed[output.Identifier()] = true
+	return output, nil
+}
+
+// AllStructInputs returns a list of inputs locators that locate every member
+// of the named type along with the names of the members. If the type is not a
+// struct an error is returned.
+func (teb *typedExprBuilder) AllStructInputs(typeName string) ([]typeinfo.Input, []string, error) {
+	arg, err := teb.getArg(typeName)
+	if err != nil {
+		return nil, nil, err
+	}
+	members, names, err := arg.GetAllStructMembers()
+	if err != nil {
+		return nil, nil, err
+	}
+
+	var inputs []typeinfo.Input
+	for _, member := range members {
+		input, ok := member.(typeinfo.Input)
+		if !ok {
+			return nil, nil, fmt.Errorf("%s cannot be used as input", member.ArgType().Kind())
+		}
+		inputs = append(inputs, input)
+	}
+	return inputs, names, nil
+}
+
+// AllStructOutputs returns a list of output locators that locate every member
+// of the named type along with the names of the members. If the type is not a
+// struct an error is returned.
+func (teb *typedExprBuilder) AllStructOutputs(typeName string) ([]typeinfo.Output, []string, error) {
+	arg, err := teb.getArg(typeName)
+	if err != nil {
+		return nil, nil, err
+	}
+	members, names, err := arg.GetAllStructMembers()
+	if err != nil {
+		return nil, nil, err
+	}
+
+	var outputs []typeinfo.Output
+	for _, member := range members {
+		output, ok := member.(typeinfo.Output)
+		if !ok {
+			return nil, nil, fmt.Errorf("%s cannot be used as output", member.ArgType().Kind())
+		}
+		if _, ok := teb.outputUsed[output.Identifier()]; ok {
+			return nil, nil, usedInMultipleOutputsError(output.Desc())
+		}
+		teb.outputUsed[output.Identifier()] = true
+		outputs = append(outputs, output)
+	}
+
+	return outputs, names, nil
+}
+
+// InputSlice returns an input locator for a slice.
+func (teb *typedExprBuilder) InputSlice(typeName string) (typeinfo.Input, error) {
+	arg, err := teb.getArg(typeName)
+	if err != nil {
+		return nil, err
+	}
+	sliceLocator, err := arg.GetSlice()
+	if err != nil {
+		return nil, err
+	}
+	input, ok := sliceLocator.(typeinfo.Input)
+	if !ok {
+		return nil, fmt.Errorf("%s cannot be used as input", sliceLocator.ArgType().Kind())
+	}
+	return input, nil
+}
+
+func (teb *typedExprBuilder) getArg(typeName string) (typeinfo.ArgInfo, error) {
+	arg, ok := teb.argInfo[typeName]
+	if !ok {
+		return nil, nameNotFoundError(teb.argInfo, typeName)
+	}
+	teb.argUsed[arg] = true
+	return arg, nil
+}
+
+// Kind looks up the type name and returns its kind.
+func (teb *typedExprBuilder) Kind(typeName string) (reflect.Kind, error) {
+	arg, ok := teb.argInfo[typeName]
+	if !ok {
+		return 0, nameNotFoundError(teb.argInfo, typeName)
+	}
+	return arg.Typ().Kind(), nil
+}
+
+// checkAllArgsUsed goes through all the arguments contained in typeToValue and
+// checks that they were used when building the typed expression.
+func (teb *typedExprBuilder) checkAllArgsUsed(typeToValue map[string]typeinfo.ArgInfo) error {
+	for _, argInfo := range typeToValue {
+		if !teb.argUsed[argInfo] {
+			return fmt.Errorf("type %q not found in statement", argInfo.Typ().Name())
+		}
+	}
+	return nil
+}
+
+// AddTypedInsertExpr wraps and adds the columns of an insert expression to the
+// typed expressions.
+func (teb *typedExprBuilder) AddTypedInsertExpr(insertColumns []typedColumn) {
+	teb.typedExprs = append(teb.typedExprs, &typedInsertExpr{insertColumns: insertColumns})
+}
+
+// AddTypedInputExpr wrap and adds an input to the typed expressions.
+func (teb *typedExprBuilder) AddTypedInputExpr(input typeinfo.Input) {
+	teb.typedExprs = append(teb.typedExprs, &typedInputExpr{input})
+}
+
+// AddTypedOutputExpr wraps and adds output columns to the typed expressions.
+func (teb *typedExprBuilder) AddTypedOutputExpr(outputColumns []outputColumn) {
+	teb.typedExprs = append(teb.typedExprs, &typedOutputExpr{outputColumns: outputColumns})
+}
+
+// AddBypass adds a bypass part to the typed expressions
+func (teb *typedExprBuilder) AddBypass(b *bypass) {
+	teb.typedExprs = append(teb.typedExprs, b)
+}
+
+// nameNotFoundError generates the arguments present and returns a missing type
+// error.
+func nameNotFoundError(argInfo map[string]typeinfo.ArgInfo, missingTypeName string) error {
+	// Get names of the arguments we have from the ArgInfo keys.
+	var argNames []string
+	for argName := range argInfo {
+		argNames = append(argNames, argName)
+	}
+	// Sort for consistent error messages.
+	sort.Strings(argNames)
+	return typeinfo.TypeMissingError(missingTypeName, argNames)
+}
+
+func usedInMultipleOutputsError(desc string) error {
+	// This error message is appended the expression the second usage was
+	// found in.
+	return fmt.Errorf("%s is used in multiple output expressions including", desc)
+}

--- a/internal/typeinfo/arginfo.go
+++ b/internal/typeinfo/arginfo.go
@@ -13,8 +13,22 @@ import (
 	"unicode/utf8"
 )
 
+// ArgInfo exposes useful information about SQLair input/output argument types.
+type ArgInfo interface {
+	Typ() reflect.Type
+	// GetMember finds a type and a member of it and returns a locator for the
+	// member. If the type does not have members it returns an error.
+	GetMember(memberName string) (ValueLocator, error)
+	// GetAllStructMembers returns information about every struct member of the
+	// arg along with their names. If the arg is not a struct an error is
+	// returned.
+	GetAllStructMembers() ([]ValueLocator, []string, error)
+	GetSlice() (ValueLocator, error)
+}
+
 // GenerateArgInfo takes sample instantiations of argument types and uses
-// reflection to generate an ArgInfo containing the types.
+// reflection to generate an ArgInfo for each. These ArgInfo objects are
+// returned in a map keyed by the type names.
 func GenerateArgInfo(typeSamples []any) (map[string]ArgInfo, error) {
 	argInfo := map[string]ArgInfo{}
 	for _, typeSample := range typeSamples {
@@ -45,19 +59,6 @@ func GenerateArgInfo(typeSamples []any) (map[string]ArgInfo, error) {
 		}
 	}
 	return argInfo, nil
-}
-
-// ArgInfo exposes useful information about SQLair input/output argument types.
-type ArgInfo interface {
-	Typ() reflect.Type
-	// GetMember finds a type and a member of it and returns a locator for the
-	// member. If the type does not have members it returns an error.
-	GetMember(memberName string) (ValueLocator, error)
-	// GetAllStructMembers returns information about every struct member of the
-	// arg along with their names. If the arg is not a struct an error is
-	// returned.
-	GetAllStructMembers() ([]ValueLocator, []string, error)
-	GetSlice() (ValueLocator, error)
 }
 
 // structInfo stores information useful for SQLair about struct types.

--- a/internal/typeinfo/arginfo.go
+++ b/internal/typeinfo/arginfo.go
@@ -177,7 +177,7 @@ func getArgInfo(t reflect.Type) (ArgInfo, error) {
 			tagToField: make(map[string]*structField),
 			structType: t,
 		}
-		tags := []string{}
+		var tags []string
 
 		fields, err := getStructFields(t)
 		if err != nil {
@@ -280,10 +280,10 @@ func getStructFields(structType reflect.Type) ([]*structField, error) {
 
 		// If Anonymous is true, the field is embedded.
 		if field.Anonymous && tag == "" {
-			// If the embedded struct is tagged then we do not look inside it and
-			// we pass it straight to the driver. This means it must implement the
-			// Valuer or Scanner interface (for inputs/outputs respectively) or the
-			// driver will reject it with a panic.
+			// If the embedded struct is tagged then we do not look inside it,
+			// and we pass it straight to the driver. This means it must
+			// implement the Valuer or Scanner interface (for inputs/outputs
+			// respectively) or the driver will reject it with a panic.
 			if !field.IsExported() {
 				continue
 			}

--- a/internal/typeinfo/validate.go
+++ b/internal/typeinfo/validate.go
@@ -64,27 +64,6 @@ func ValidateInputs(args []any) (TypeToValue, error) {
 	return typeToValue, nil
 }
 
-func checkDuplicate(tv TypeToValue, t reflect.Type) error {
-	switch t.Kind() {
-	case reflect.Slice:
-		// If the slice has no name and its element type is map, struct or
-		// pointer then we assume it is for a bulk insert.
-		switch t.Elem().Kind() {
-		case reflect.Map, reflect.Struct:
-			if _, ok := tv[t.Elem()]; t.Name() == "" && ok {
-				return typeAndSliceProvidedError(t, t.Elem())
-			}
-		case reflect.Pointer:
-			if _, ok := tv[t.Elem().Elem()]; t.Name() == "" && ok {
-				return typeAndSliceProvidedError(t, t.Elem().Elem())
-			}
-		}
-	case reflect.Map, reflect.Struct:
-
-	}
-	return nil
-}
-
 // ValidateOutputs takes the raw SQLair output arguments from the user and uses
 // reflection to check that they are valid. It returns a TypeToValue containing
 // the reflect.Value of the output arguments.

--- a/internal/typeinfo/valuelocator.go
+++ b/internal/typeinfo/valuelocator.go
@@ -326,7 +326,7 @@ func PrettyTypeName(t reflect.Type) string {
 	return t.Name()
 }
 
-// valueNotFoundError generates the arguments present and returns a typeMissingError
+// valueNotFoundError generates the arguments present and returns a TypeMissingError
 func valueNotFoundError(typeToValue TypeToValue, missingType reflect.Type) error {
 	// Get the argument names from typeToValue map.
 	argNames := []string{}
@@ -338,5 +338,5 @@ func valueNotFoundError(typeToValue TypeToValue, missingType reflect.Type) error
 	}
 	// Sort for consistent error messages.
 	sort.Strings(argNames)
-	return typeMissingError(PrettyTypeName(missingType), argNames)
+	return TypeMissingError(PrettyTypeName(missingType), argNames)
 }

--- a/package_test.go
+++ b/package_test.go
@@ -525,7 +525,7 @@ func (s *PackageSuite) TestGetErrors(c *C) {
 	}, {
 		summary: "no outputs",
 		query:   "UPDATE person SET id=300 WHERE id=30",
-		types:   []any{Person{}},
+		types:   []any{},
 		inputs:  []any{},
 		outputs: []any{&Person{}},
 		err:     "cannot get results: output variables provided but not referenced in query",
@@ -1255,12 +1255,12 @@ func (s *PackageSuite) TestInsert(c *C) {
 	insertAddressIDStmt, err := sqlair.Prepare("INSERT INTO address (id) VALUES ($Person.address_id)", Person{})
 	c.Assert(err, IsNil)
 
-	insertAddressStmt, err := sqlair.Prepare("INSERT INTO address (*) VALUES ($Address.id, $Address.street, $Address.district)", Person{}, Address{})
+	insertAddressStmt, err := sqlair.Prepare("INSERT INTO address (*) VALUES ($Address.id, $Address.street, $Address.district)", Address{})
 	c.Assert(err, IsNil)
 
 	// RETURNING clauses are supported by SQLite with syntax taken from
 	// postgresql. The inserted values are returned as query results.
-	returningStmt, err := sqlair.Prepare("INSERT INTO address(*) VALUES($Address.*) RETURNING &Address.*", Person{}, Address{})
+	returningStmt, err := sqlair.Prepare("INSERT INTO address(*) VALUES($Address.*) RETURNING &Address.*", Address{})
 	c.Assert(err, IsNil)
 
 	// SELECT statements to check the inserts have worked correctly.

--- a/package_test.go
+++ b/package_test.go
@@ -1055,7 +1055,7 @@ func (s *PackageSuite) TestTransactions(c *C) {
 	err = tx.Rollback()
 	c.Assert(err, IsNil)
 
-	// Check Derek isnt in db.
+	// Check Derek isn't in db.
 	tx, err = db.Begin(ctx, nil)
 	c.Assert(err, IsNil)
 	var derekCheck = Person{}


### PR DESCRIPTION
When doing `sqlair.Prepare`, SQLair will not throw an error if you pass extra types that are not used in the query. This refactor is motivated by the need to add this error.

The `BindTypes` function used `ArgInfo` from the `typeinfo` package to get information about the arguments. The `ArgInfo` object has methods that allow `BindTypes` to pass simply the name of the type needed and they will return all the relevent information about the type or an error message if it is not found. The `typeinfo` package is only concerned with getting information about types, and does not do any storing of state.

A simple (but wrong) way to track which types have been used during prepare would be to add state to this `ArgInfo` object, and when `BindTypes` was finished, it could be queried to see if all types had been used. However, this would add state to `ArgInfo`

Another way to do this would be to keep track of the arguments used in `BindTypes` directly, however, the level of abstraction here is wrong, several layers have to be unwrapped to get the type information.

The solution I have landed upon is adding an extra layer in-between `ArgInfo` and the `bindTypes` functions on the typed expressions. This follows a similar pattern to the query builder in the `BindInputs` stage. The `ArgInfo` object arguably had too much responsibility considering that it was designed only to be concerned with types. Therefore, it was natural to transfer some of this to the new `typedExprBulider` layer which is now responsible for finding the arguments in the map returned from `GenerateArgInfo` and also with the keeping track of outputs and arguments used.