### PR TITLE
fix: format in read the docs yaml

### DIFF
--- a/docs/.readthedocs.yaml
+++ b/docs/.readthedocs.yaml
@@ -14,7 +14,8 @@ build:
     pre_install:
       - python3 .sphinx/build_requirements.py
       - git fetch --unshallow || true
-    post_checkout: cd docs && python3 .sphinx/build_requirements.py
+    post_checkout: 
+      - cd docs && python3 .sphinx/build_requirements.py
 
 # Build documentation in the docs/ directory with Sphinx
 sphinx:


### PR DESCRIPTION
There was an issue the the read the docs yaml that was only made apparent once the build process started. This fixes it.

The option under post_checkout had to be a list not a string.