### PR TITLE
fix: prepend locations in .readthedocs.yaml with with docs directory

### DIFF
--- a/docs/.readthedocs.yaml
+++ b/docs/.readthedocs.yaml
@@ -12,7 +12,7 @@ build:
     python: "3.11"
   jobs:
     pre_install:
-      - python3 .sphinx/build_requirements.py
+      - cd docs && python3 .sphinx/build_requirements.py && cd ..
       - git fetch --unshallow || true
     post_checkout: 
       - cd docs && python3 .sphinx/build_requirements.py


### PR DESCRIPTION
One of the locations in the RTD yaml was incorrect since we are using a docs directory.