### PR TITLE
docs: fix issues with formatting

### DIFF
--- a/docs/howto/input-expressions.md
+++ b/docs/howto/input-expressions.md
@@ -6,13 +6,13 @@ INSERT INTO Person (name, age)
 VALUES ($Person.*)
 ```
 
-The `Person` object here should be tagged with the column names (see {doc}`preparing-go-objects` for more). SQLair will then expand it into a series of input placeholders corresponding to the number of columns being inserted and send the generated SQL to the database, along with the argument values extracted from the struct.
+The `Person` object here should be tagged with the column names. SQLair will then expand it into a series of input placeholders corresponding to the number of columns being inserted and send the generated SQL to the database, along with the argument values extracted from the struct.
 
 This is not the only form of input expression. There are several ways you can input values with SQLair. This how-to guide takes you through the different forms.
 
 See {ref}`output-expression-syntax` for the exact valid syntax.
 
-##### Input a single parameter
+## Input a single parameter
 The syntax `$Struct.col_name` can be used to input the field of the struct tagged with `col_name` in the query. This also works with key of maps. 
 
 Example:
@@ -25,7 +25,7 @@ AND    col_name2 = $Map.col_name2
 
 
 
-##### Input a slice
+## Input a slice
 The syntax `$Slice[:]` can be used to pass all the values of a slice as a parameter. The `Slice` object here must be a named slice type.
 
 Example:
@@ -35,7 +35,7 @@ FROM   table
 WHERE  name IN ($Names[:])
 ```
 
-##### Insert all columns of objects
+## Insert all columns of objects
 The syntax `INSERT INTO table (*) VALUES ($Type1.*, $Type2.col_name2, ...)` can be used to insert columns from structs into the database. SQLair will expand the asterisk on the left hand side into all the column names specified on the right. If a struct on the left is followed by an asterisk it will insert all tagged fields on the struct. Types with a single field/key specifed will only have just that member inserted.
 
 It will also insert the corrent number of parameter palceholders on the right. The values specified on the right will then be passed to the database as query arguments and be inserted into the database.
@@ -46,7 +46,7 @@ INSERT INTO table (*)
 VALUES ($Struct1.*, $Struct2.col_name1, $Struct2.col_name2, $Map.key)
 ```
 
-##### Insert particular columns from objects
+## Insert particular columns from objects
 The syntax `(col_name1, col_name2, ...) VALUES ($Type1.*, $Type2.col_name2, ...)` can be used to insert specified columns from the collection of objects on the right. It works the same way as inserting all the columns of objects (above) excepet it will only insert those specified on the left.
 
 Example:

--- a/docs/howto/output-expressions.md
+++ b/docs/howto/output-expressions.md
@@ -5,13 +5,13 @@ SQLair output expressions are designed to replace the column selection part of a
 SELECT &Person.*
 FROM   person
 ```
-The `Person` object here should be tagged with the column names (see {doc}`preparing-go-objects` for more). SQLair will then expand the struct into the names of the columns it is tagged with and send the generated SQL to the database. When you get the results, it will automatically scan the columns into the correct fields of the person struct.
+The `Person` object here should be tagged with the column names. SQLair will then expand the struct into the names of the columns it is tagged with and send the generated SQL to the database. When you get the results, it will automatically scan the columns into the correct fields of the person struct.
 
 There are several different forms of output expression. Their forms and functions are described below.
 
 See {ref}`output-expression-syntax` for the exact valid sytnax.
 
-##### Get a single column in an object
+## Get a single column in an object
 The syntax `&Struct.col_name` with fetch and set the field of the type `Struct` tagged with `col_name`. This can also be done with maps, `&Map.key` will fetch the column key from the database and insert it into the map with the key `"key"`.
 
 Example:
@@ -21,7 +21,7 @@ SELECT &Struct.col_name,
 FROM   table
 ```
 
-##### Get all the columns in a struct
+## Get all the columns in a struct
 The syntax `&Struct.*` fetches and sets all the tagged fields of `Struct`. SQLair will expand the type into all of the tagged column names and insert the results into the struct when it gets the results.
 
 Example:
@@ -30,7 +30,7 @@ SELECT &Struct.*
 FROM   table
 ```
 
-##### Get all the columns in a struct from a particular table
+## Get all the columns in a struct from a particular table
 The syntax `table.* AS &Struct.*` does the same as getting all the fields of a struct (above) but prepends all columns with the table name. The tags on the struct should not include the table name.
 
 Example:
@@ -41,7 +41,7 @@ FROM       t
 INNER JOIN s
 ```
 
-##### Get a subset of an objects columns
+## Get a subset of an objects columns
 The syntax `(table1.col_name1, table2.col_name2) AS &Struct.*` fetches and sets only the specified columns (the table names are optional). This syntax can also be used with maps. If a table name is included the map key or the struct tag do not include the table name, it is only mentioned in the query.
 
 Example:
@@ -52,7 +52,7 @@ FROM       t
 INNER JOIN s
 ```
 
-##### Put particular columns in particular places in an object
+## Put particular columns in particular places in an object
 The syntax `(col_name1, col_name2) AS (&Type.other_col1, &Type.other_col2)` will fetch the specified columns and put them in the type locations specified. If `Type` is a struct this will be the fields tagged with `other_col1` and `other_col2`, if it was a map it would be the fields with that name.
 
 This form should only really be used if you are selecting from a table you would not usually select from. The tags on the fields of the struct should match the columns in the database.

--- a/docs/tutorial/tutorial.md
+++ b/docs/tutorial/tutorial.md
@@ -75,7 +75,7 @@ In the SQLair expressions, the characters `$` and `&` are used to specify input 
 
 SQLair Input expressions replace the question mark placeholders in the SQL statement. An input expression is made up of the struct type name and a column name taken from the `db` tag of a struct field. For example:
 
-```plaintext
+```
 UPDATE employee 
 SET name = $Empolyee.name
 WHERE id = $Employee.id


### PR DESCRIPTION
There were a few issues with formatting that are stopping the docs being built, including one or two broken links and mismatched headings sizes.