### PR TITLE
Fix spelling in docs

### DIFF
--- a/docs/.custom_wordlist.txt
+++ b/docs/.custom_wordlist.txt
@@ -7,3 +7,8 @@ Golang
 dev
 DSL
 ORM
+untagged
+variadic
+Alastair
+prepends
+deserialise

--- a/docs/.custom_wordlist.txt
+++ b/docs/.custom_wordlist.txt
@@ -1,0 +1,9 @@
+SQLair
+struct
+structs
+TODO
+BNF
+Golang
+dev
+DSL
+ORM

--- a/docs/howto/custom-types-in-structs.md
+++ b/docs/howto/custom-types-in-structs.md
@@ -11,7 +11,7 @@ type MyKey [32]int
 ```
 For this example, `MyKey` could be any use defined type that can be serialised to a database row type. The problem is, that SQLair and its underlying libraries do not know how to serialise the `MyKey` type.
 
-Luckily, there are two very useful interfaces you can use to get around this problem. The [Valuer](https://pkg.go.dev/database/sql/driver#Valuer) and [Scanner](https://pkg.go.dev/database/sql#Scanner). The `Valuer` interface tells the driver how to serialise the type for putting in the database and the Scanner tells it how to de-serialise it.
+Luckily, there are two very useful interfaces you can use to get around this problem. The [Valuer](https://pkg.go.dev/database/sql/driver#Valuer) and [Scanner](https://pkg.go.dev/database/sql#Scanner). The `Valuer` interface tells the driver how to serialise the type for putting in the database and the Scanner tells it how to deserialise it.
 
 For example:
 ```go

--- a/docs/howto/input-expressions.md
+++ b/docs/howto/input-expressions.md
@@ -1,6 +1,6 @@
 (input-expressions)=
 # How to input 
-SQLair input expressions can be used anywhere in a SQL query you would normally use an input placeholder (such as `?`, or `$1`). They always start with a doller sign (`$`). For example:
+SQLair input expressions can be used anywhere in a SQL query you would normally use an input placeholder (such as `?`, or `$1`). They always start with a dollar sign (`$`). For example:
 ```
 INSERT INTO Person (name, age) 
 VALUES ($Person.*)
@@ -36,9 +36,9 @@ WHERE  name IN ($Names[:])
 ```
 
 ## Insert all columns of objects
-The syntax `INSERT INTO table (*) VALUES ($Type1.*, $Type2.col_name2, ...)` can be used to insert columns from structs into the database. SQLair will expand the asterisk on the left hand side into all the column names specified on the right. If a struct on the left is followed by an asterisk it will insert all tagged fields on the struct. Types with a single field/key specifed will only have just that member inserted.
+The syntax `INSERT INTO table (*) VALUES ($Type1.*, $Type2.col_name2, ...)` can be used to insert columns from structs into the database. SQLair will expand the asterisk on the left hand side into all the column names specified on the right. If a struct on the left is followed by an asterisk it will insert all tagged fields on the struct. Types with a single field/key specified will only have just that member inserted.
 
-It will also insert the corrent number of parameter palceholders on the right. The values specified on the right will then be passed to the database as query arguments and be inserted into the database.
+It will also insert the current number of parameter placeholders on the right. The values specified on the right will then be passed to the database as query arguments and be inserted into the database.
 
 Example:
 ```
@@ -47,7 +47,7 @@ VALUES ($Struct1.*, $Struct2.col_name1, $Struct2.col_name2, $Map.key)
 ```
 
 ## Insert particular columns from objects
-The syntax `(col_name1, col_name2, ...) VALUES ($Type1.*, $Type2.col_name2, ...)` can be used to insert specified columns from the collection of objects on the right. It works the same way as inserting all the columns of objects (above) excepet it will only insert those specified on the left.
+The syntax `(col_name1, col_name2, ...) VALUES ($Type1.*, $Type2.col_name2, ...)` can be used to insert specified columns from the collection of objects on the right. It works the same way as inserting all the columns of objects (above) except it will only insert those specified on the left.
 
 Example:
 ```

--- a/docs/howto/output-expressions.md
+++ b/docs/howto/output-expressions.md
@@ -9,7 +9,7 @@ The `Person` object here should be tagged with the column names. SQLair will the
 
 There are several different forms of output expression. Their forms and functions are described below.
 
-See {ref}`output-expression-syntax` for the exact valid sytnax.
+See {ref}`output-expression-syntax` for the exact valid syntax.
 
 ## Get a single column in an object
 The syntax `&Struct.col_name` with fetch and set the field of the type `Struct` tagged with `col_name`. This can also be done with maps, `&Map.key` will fetch the column key from the database and insert it into the map with the key `"key"`.
@@ -22,7 +22,7 @@ FROM   table
 ```
 
 ## Get all the columns in a struct
-The syntax `&Struct.*` fetches and sets all the tagged fields of `Struct`. SQLair will expand the type into all of the tagged column names and insert the results into the struct when it gets the results.
+The syntax `&Struct.*` fetches and sets all the tagged fields of `Struct`. SQLair will expand the type into all the tagged column names and insert the results into the struct when it gets the results.
 
 Example:
 ```

--- a/docs/index.md
+++ b/docs/index.md
@@ -19,7 +19,7 @@ the tables to Go structs without the overhead of an Object-Relational Mapping
 library (ORM). SQLair concerns itself only with the mapping from the Go objects
 to the database tables. It allows you to run any SQL you wish.
 
-The library is perfect for anyone who is looking for the convinence of
+The library is perfect for anyone who is looking for the convenience of
 automatic mapping between database tables to Go types and who just wants to
 write SQL instead of dealing with an ORM.
 
@@ -68,7 +68,7 @@ explanation/index
 
 ## Project and community
 
-SQLair is an an open source project that warmly welcomes community projects,
+SQLair is an open source project that warmly welcomes community projects,
 contributions, suggestions, fixes and constructive feedback. We welcome any
 improvements to the documentation or SQLair itself. Please see our contributing
 guide if you would like to get involved!
@@ -76,9 +76,12 @@ guide if you would like to get involved!
 - [SQLair GitHub page](https://github.com/canonical/sqlair)
 - [SQLair contributing guide](https://github.com/canonical/sqlair/blob/main/CONTRIBUTING.md)
 
-The SQLair project is currently under the care of the Juju team at Canonical. If you have any questions or would just like to say hi you can find us on the Charmhub Discorse Forum. Just mention SQLair in the subject of your post and we will see it.
+The SQLair project is currently under the care of the Juju team at Canonical. If
+you have any questions or would just like to say hi you can find us on the
+Charmhub Discourse Forum. Just mention SQLair in the subject of your post, and we
+will see it.
 
-- [Charmhub Discorse Forum](https://discourse.charmhub.io/)
+- [Charmhub Discourse Forum](https://discourse.charmhub.io/)
 
 If you have any issues or bugs to raise, please see our GitHub issues page.
 

--- a/docs/tutorial/tutorial.md
+++ b/docs/tutorial/tutorial.md
@@ -22,9 +22,7 @@ WHERE team_id = $Location.team_id
 
 SQLair adds special *expressions* to your SQL statements. These expressions allow you to use Go types directly in the query to reference the source of the parameters and the destination of the results. The purpose of a query in the context of your program can be worked out from a single glance.
 
-SQLair uses the [`database/sql`](https://pkg.go.dev/database/sql) package to interact with the raw database and provides a convenience layer on top. This convinience layer provides a very different API to `database/sql`.
-
-The full API docs can be found at [pkg.go.dev/github.com/canonical/sqlair](https://pkg.go.dev/github.com/canonical/sqlair).
+SQLair uses the [`database/sql`](https://pkg.go.dev/database/sql) package to interact with the raw database and provides a convenience layer on top. This convenience layer provides a very different API to `database/sql`.
 
 In this introduction we will use the example of a company's database containing employees and the teams they belong to. A full example code listing is given at the end of this post.
 
@@ -43,7 +41,7 @@ type Employee struct {
 }
 ```
 
-All struct fields that correspond to a column and are used with SQLair should be tagged with the `db` tag. If a field of the struct does not correspond to a database column it can be left untagged and it will be ignored by SQLair.
+All struct fields that correspond to a column and are used with SQLair should be tagged with the `db` tag. If a field of the struct does not correspond to a database column it can be left untagged, and it will be ignored by SQLair.
 
 It is important to note that SQLair *needs* the struct fields to be public in to order read from them and write to them.
 
@@ -63,7 +61,7 @@ stmt, err := sqlair.Prepare(`
 )
 ```
 
-The `Prepare` function needs a sample of every struct mentioned in the query. It uses the struct's reflection information to generate the columns and check that the expressions make sense. These type samples are only used for reflection information, their content is disregarded.
+The `Prepare` function needs a sample of every struct mentioned in the query. It uses reflection information from the struct to generate the columns and check that the expressions make sense. These type samples are only used for reflection information, their content is disregarded.
 
 There is also a function `sqlair.MustPrepare` that does not return an error and panics if it encounters one.
 
@@ -124,13 +122,13 @@ stmt, err := sqlair.Prepare(`
 )
 ```
 
-As with input expressions, it is important to note that the we always use the column names found in the `db` tags of the struct in the output expression rather than the field name.
+As with input expressions, it is important to note that we always use the column names found in the `db` tags of the struct in the output expression rather than the field name.
 
 See {ref}`output-expressions` for more.
 
 ##### Insert statements
 
-Input expressions can also be used inside insert statements with sytax similar to output expressions. Below is a simple example of using an insert statement to insert a struct into a database:
+Input expressions can also be used inside insert statements with syntax similar to output expressions. Below is a simple example of using an insert statement to insert a struct into a database:
 ```go
 type Person struct {
 	ID       int    `db:"id"`


### PR DESCRIPTION
This PR fixes the documentation CI job. The fixes container in here are:
- Add words to the `custom_wordlist.txt`
- Fix spelling