### PR TITLE
docs: remove "How to" from how-to headings

### DIFF
--- a/docs/howto/custom-types-in-structs.md
+++ b/docs/howto/custom-types-in-structs.md
@@ -1,5 +1,5 @@
 (custom-types)=
-# How to use custom types in structs
+# Use custom types in structs
 SQLair makes it very easy to serialise to and from structs. But one case that may cause issues, is when you have a user defined type in your struct. For example:
 ```go
 type MyModel struct {

--- a/docs/howto/db.md
+++ b/docs/howto/db.md
@@ -1,5 +1,5 @@
 (db)=
-# How to use a SQLair database
+# Use a SQLair database
 To create a SQLair database and run SQLair queries on it, you need to wrap a
 `sql.DB` database object from the `database/sql` package. SQLair is a
 convenience wrapper around the database, it does not create the DB itself.

--- a/docs/howto/query.md
+++ b/docs/howto/query.md
@@ -1,5 +1,5 @@
 (query)=
-# How to query the database
+# Query the database
 
 ## SQLair-proof your types
 The first step in building your query is to decide what you would like to put

--- a/docs/howto/tx.md
+++ b/docs/howto/tx.md
@@ -1,5 +1,5 @@
 (tx)=
-# How to manage SQLair transactions
+# Manage SQLair transactions
 SQLair transactions are created on a `sqlair.DB`.
 
 > See more: {ref}`db`.


### PR DESCRIPTION
Change the headings in the how to guides to be direct rather than repeating the words "How to"