### PR TITLE
docs: add how-to on SQL functions and tidy up

### DIFF
--- a/docs/howto/custom-types-in-structs.md
+++ b/docs/howto/custom-types-in-structs.md
@@ -1,6 +1,8 @@
 (custom-types)=
 # Use custom types in structs
-SQLair makes it very easy to serialise to and from structs. But one case that may cause issues, is when you have a user defined type in your struct. For example:
+SQLair makes it very easy to serialise to and from structs. But one case that
+may cause issue, is when you have a user-defined type in your struct. For
+example:
 ```go
 type MyModel struct {
   ID  int    `db:"uuid"`
@@ -9,9 +11,15 @@ type MyModel struct {
 
 type MyKey [32]int
 ```
-For this example, `MyKey` could be any use defined type that can be serialised to a database row type. The problem is, that SQLair and its underlying libraries do not know how to serialise the `MyKey` type.
+For this example, `MyKey` could be any user-defined type that can be serialised
+to a database row type. The problem is that SQLair and its underlying libraries
+do not know how to serialise the `MyKey` type.
 
-Luckily, there are two very useful interfaces you can use to get around this problem. The [Valuer](https://pkg.go.dev/database/sql/driver#Valuer) and [Scanner](https://pkg.go.dev/database/sql#Scanner). The `Valuer` interface tells the driver how to serialise the type for putting in the database and the Scanner tells it how to deserialise it.
+Luckily, there are two very useful interfaces you can use to get around this
+problem: the [Valuer](https://pkg.go.dev/database/sql/driver#Valuer) and
+[Scanner](https://pkg.go.dev/database/sql#Scanner). The `Valuer` interface tells
+the driver how to serialise the type for putting in the database and the Scanner
+tells it how to deserialise it.
 
 For example:
 ```go
@@ -32,5 +40,7 @@ func (k *MyKey) Scan(src any) error {
 }
 ```
 
-See the [Valuer](https://pkg.go.dev/database/sql/driver#Valuer) and [Scanner](https://pkg.go.dev/database/sql#Scanner) interface documentation for more details.
-
+```{admonition} See more
+:class: tip
+[Go | Valuer](https://pkg.go.dev/database/sql/driver#Valuer), [Go | Scanner](https://pkg.go.dev/database/sql#Scanner) 
+```

--- a/docs/howto/custom-types-in-structs.md
+++ b/docs/howto/custom-types-in-structs.md
@@ -16,8 +16,8 @@ to a database row type. The problem is that SQLair and its underlying libraries
 do not know how to serialise the `MyKey` type.
 
 Luckily, there are two very useful interfaces you can use to get around this
-problem: the [Valuer](https://pkg.go.dev/database/sql/driver#Valuer) and
-[Scanner](https://pkg.go.dev/database/sql#Scanner). The `Valuer` interface tells
+problem: the [`Valuer`](https://pkg.go.dev/database/sql/driver#Valuer) and
+[`Scanner`](https://pkg.go.dev/database/sql#Scanner). The `Valuer` interface tells
 the driver how to serialise the type for putting in the database and the Scanner
 tells it how to deserialise it.
 

--- a/docs/howto/custom-types-in-structs.md
+++ b/docs/howto/custom-types-in-structs.md
@@ -1,7 +1,7 @@
 (custom-types)=
 # Use custom types in structs
 SQLair makes it very easy to serialise to and from structs. But one case that
-may cause issue, is when you have a user-defined type in your struct. For
+may cause issues is when you have a user-defined type in your struct. For
 example:
 ```go
 type MyModel struct {

--- a/docs/howto/db.md
+++ b/docs/howto/db.md
@@ -10,7 +10,8 @@ through `database/sql`.
 To wrap a `sql.DB` with SQLair, use the `sqlair.NewDB` method. This will return
 a `sqlair.DB`.
 
-```{seealso}
+```{admonition} See more
+:class: tip
 [`sqlair.NewDB`](https://pkg.go.dev/github.com/canonical/sqlair#NewDB),
 [`sqlair.DB`](https://pkg.go.dev/github.com/canonical/sqlair#DB),
 [`database/sql.DB`](https://pkg.go.dev/database/sql#DB)
@@ -26,6 +27,7 @@ To unwrap a SQLair database and get out the `sql.DB`, use `DB.PlainDB`. SQLair
 does not handle closing the database -- this should be done through the
 `database/sql` package.
 
-```{seealso}
+```{admonition} See more
+:class: tip
 [`DB.PlainDB`](https://pkg.go.dev/github.com/canonical/sqlair#DB.PlainDB)
 ```

--- a/docs/howto/db.md
+++ b/docs/howto/db.md
@@ -10,10 +10,11 @@ through `database/sql`.
 To wrap a `sql.DB` with SQLair, use the `sqlair.NewDB` method. This will return
 a `sqlair.DB`.
 
-> See more:
+```{seealso}
 [`sqlair.NewDB`](https://pkg.go.dev/github.com/canonical/sqlair#NewDB),
 [`sqlair.DB`](https://pkg.go.dev/github.com/canonical/sqlair#DB),
 [`database/sql.DB`](https://pkg.go.dev/database/sql#DB)
+```
 
 ## Query a SQLair database
 
@@ -25,5 +26,6 @@ To unwrap a SQLair database and get out the `sql.DB`, use `DB.PlainDB`. SQLair
 does not handle closing the database -- this should be done through the
 `database/sql` package.
 
-> See more:
+```{seealso}
 [`DB.PlainDB`](https://pkg.go.dev/github.com/canonical/sqlair#DB.PlainDB)
+```

--- a/docs/howto/functions.md
+++ b/docs/howto/functions.md
@@ -1,0 +1,34 @@
+(functions)=
+# Get SQL function results
+funcs
+To output the result of a SQL function such as `COUNT`, `MAX` or `SUM`, use the
+`AS` keyword to select the function result into an output variable, then run
+the query.
+
+For example:
+
+```go
+type Count struct {
+    Num int `db:"num"`
+}
+
+stmt, err := sqlair.Prepare(
+    "SELECT COUNT(*) AS &Count.num FROM employees", 
+    Count{},
+)
+if err != nil {
+    return err
+}
+
+var count Count
+err := db.Query(ctx, stmt).Get(&count)
+if err != nil {
+    return err
+}
+
+fmt.Printf("Number of employees: %d", count.Num)
+```
+
+```{seealso}
+{ref}`output-expression-syntax`
+```

--- a/docs/howto/functions.md
+++ b/docs/howto/functions.md
@@ -1,6 +1,6 @@
 (functions)=
 # Get SQL function results
-funcs
+
 To output the result of a SQL function such as `COUNT`, `MAX` or `SUM`, use the
 `AS` keyword to select the function result into an output variable, then run
 the query.
@@ -29,6 +29,7 @@ if err != nil {
 fmt.Printf("Number of employees: %d", count.Num)
 ```
 
-```{seealso}
+```{admonition} See more
+:class: tip
 {ref}`output-expression-syntax`
 ```

--- a/docs/howto/index.md
+++ b/docs/howto/index.md
@@ -1,7 +1,12 @@
 (howto)=
 # How-to guides
 
-These how-to guides cover key operations and processes in SQLair.
+These how-to guides cover how to use SQLair to interact with the database and
+get the most out of its functionality.
+
+## Interacting with the database
+SQLair supports different ways of running your queries on the database. They can
+be done through transactions, or straight on the database itself.
 
 ```{toctree}
 :titlesonly:
@@ -9,5 +14,15 @@ These how-to guides cover key operations and processes in SQLair.
 db
 tx
 query
+```
+
+## Mapping types to the database
+These guides cover specific use cases of SQLair when it comes to mapping types
+to the database rows.
+
+```{toctree}
+:titlesonly:
+
 custom-types-in-structs
+functions
 ```

--- a/docs/howto/query.md
+++ b/docs/howto/query.md
@@ -19,7 +19,8 @@ type Location struct {
     City string `db:"city"`
 }
 ```
-```{seealso}```
+```{admonition} See more
+:class: tip```
 {ref}`types` 
 ```
 ## Write your query string using the types
@@ -39,7 +40,8 @@ query := `
 `
 ```
 
-```{seealso}
+```{admonition} See more
+:class: tip
 {ref}`input-expression-syntax`, {ref}`output-expression-syntax`.
 ```
 ## Prepare your query string to get a statement
@@ -66,7 +68,8 @@ if err != nil {
 }
 ```
 
-```{seealso}
+```{admonition} See more
+:class: tip
 [`sqlair.Prepare`](https://pkg.go.dev/github.com/canonical/sqlair#Prepare),
 [`sqlair.MustPrepare`](https://pkg.go.dev/github.com/canonical/sqlair#MustPrepare)
 ```
@@ -84,7 +87,8 @@ reused. One of the methods on `Query` should immediately be called. It should
 not be saved as variable.
 ```
 
-```{seealso}
+```{admonition} See more
+:class: tip
 [`DB.Query`](https://pkg.go.dev/github.com/canonical/sqlair#DB.Query),
 [`TX.Query`](https://pkg.go.dev/github.com/canonical/sqlair#TX.Query),
 [`sqlair.Query`](https://pkg.go.dev/github.com/canonical/sqlair#Query)
@@ -107,7 +111,8 @@ if err != nil {
 // employee now contains the first employee returned from the database.
 ```
 
-```{seealso}
+```{admonition} See more
+:class: tip
 [`Query.Get`](https://pkg.go.dev/github.com/canonical/sqlair#Query.Get)
 ```
 
@@ -128,7 +133,8 @@ if err != nil {
 // employees now contains all the employees returned from the database.
 ```
 
-```{seealso}
+```{admonition} See more
+:class: tip
 [`Query.GetAll`](https://pkg.go.dev/github.com/canonical/sqlair#Query.GetAll)
 ```
 
@@ -169,7 +175,8 @@ for iter.Next() {
 }
 ```
 
-```{seealso}
+```{admonition} See more
+:class: tip
 [`Query.Iter`](https://pkg.go.dev/github.com/canonical/sqlair#Query.Iter),
 [`sqlair.Iterator`](https://pkg.go.dev/github.com/canonical/sqlair#Iterator),
 [`Iterator.Next`](https://pkg.go.dev/github.com/canonical/sqlair#Iterator.Next),
@@ -199,7 +206,8 @@ if err != nil {
 // employee has been inserted into the database.
 ```
 
-```{seealso}
+```{admonition} See more
+:class: tip
 [`Query.Run`](https://pkg.go.dev/github.com/canonical/sqlair#Query.Run)
 ```
 
@@ -237,7 +245,8 @@ if err != nil {
 }
 ```
 
-```{seealso}
+```{admonition} See more
+:class: tip
 [`sqlair.Outcome`](https://pkg.go.dev/github.com/canonical/sqlair#Outcome),
 [`sql.Result`](https://pkg.go.dev/database/sql#Result)
 ```

--- a/docs/howto/query.md
+++ b/docs/howto/query.md
@@ -19,9 +19,9 @@ type Location struct {
     City string `db:"city"`
 }
 ```
-
-> See more: {ref}`types` 
-
+```{seealso}```
+{ref}`types` 
+```
 ## Write your query string using the types
 
 SQLair queries are regular SQL queries with special input and output expressions
@@ -31,7 +31,7 @@ Write your SQL query with SQLair input expressions instead of query parameters
 and SQLair output expressions instead of columns to select.
 
 For example:
-```
+```go
 query := `
     SELECT &Employee.*
     FROM employee
@@ -39,8 +39,9 @@ query := `
 `
 ```
 
-> See more {ref}`input-expression-syntax`, {ref}`output-expression-syntax`.
-
+```{seealso}
+{ref}`input-expression-syntax`, {ref}`output-expression-syntax`.
+```
 ## Prepare your query string to get a statement
 
 Now you have your query string, you need to pass it to `sqlair.Prepare` along
@@ -65,9 +66,10 @@ if err != nil {
 }
 ```
 
-> See more:
+```{seealso}
 [`sqlair.Prepare`](https://pkg.go.dev/github.com/canonical/sqlair#Prepare),
 [`sqlair.MustPrepare`](https://pkg.go.dev/github.com/canonical/sqlair#MustPrepare)
+```
 
 ## Execute the statement on the database
 
@@ -82,10 +84,11 @@ reused. One of the methods on `Query` should immediately be called. It should
 not be saved as variable.
 ```
 
-> See more:
+```{seealso}
 [`DB.Query`](https://pkg.go.dev/github.com/canonical/sqlair#DB.Query),
 [`TX.Query`](https://pkg.go.dev/github.com/canonical/sqlair#TX.Query),
 [`sqlair.Query`](https://pkg.go.dev/github.com/canonical/sqlair#Query)
+```
 
 ### Get one row
 To get only the first row returned from the database use `Query.Get`, passing
@@ -104,7 +107,9 @@ if err != nil {
 // employee now contains the first employee returned from the database.
 ```
 
-> See more: [`Query.Get`](https://pkg.go.dev/github.com/canonical/sqlair#Query.Get)
+```{seealso}
+[`Query.Get`](https://pkg.go.dev/github.com/canonical/sqlair#Query.Get)
+```
 
 ### Get all the rows
 To get all the rows returned from the database use `Query.GetAll`, passing
@@ -123,8 +128,9 @@ if err != nil {
 // employees now contains all the employees returned from the database.
 ```
 
-> See more:
+```{seealso}
 [`Query.GetAll`](https://pkg.go.dev/github.com/canonical/sqlair#Query.GetAll)
+```
 
 ### Iterate over the rows
 To iterate over the rows returned from the query, get an `Iterator` with
@@ -163,12 +169,13 @@ for iter.Next() {
 }
 ```
 
-> See more:
+```{seealso}
 [`Query.Iter`](https://pkg.go.dev/github.com/canonical/sqlair#Query.Iter),
 [`sqlair.Iterator`](https://pkg.go.dev/github.com/canonical/sqlair#Iterator),
 [`Iterator.Next`](https://pkg.go.dev/github.com/canonical/sqlair#Iterator.Next),
 [`Iterator.Get`](https://pkg.go.dev/github.com/canonical/sqlair#Iterator.Get),
 [`Iterator.Close`](https://pkg.go.dev/github.com/canonical/sqlair#Iterator.Close)
+```
 ### Just run 
 To run a query that does not return any rows, use `Query.Run`. This is useful
 when doing operations that are not expected to return anything.
@@ -192,8 +199,9 @@ if err != nil {
 // employee has been inserted into the database.
 ```
 
-> See more:
+```{seealso}
 [`Query.Run`](https://pkg.go.dev/github.com/canonical/sqlair#Query.Run)
+```
 
 
 ## (Optional) Get the query outcome
@@ -229,6 +237,7 @@ if err != nil {
 }
 ```
 
-> See more:
+```{seealso}
 [`sqlair.Outcome`](https://pkg.go.dev/github.com/canonical/sqlair#Outcome),
 [`sql.Result`](https://pkg.go.dev/database/sql#Result)
+```

--- a/docs/howto/tx.md
+++ b/docs/howto/tx.md
@@ -2,7 +2,8 @@
 # Manage SQLair transactions
 SQLair transactions are created on a `sqlair.DB`.
 
-```{seealso}
+```{admonition} See more
+:class: tip
 {ref}`db`.
 ```
 ## Begin a SQLair transaction
@@ -26,7 +27,8 @@ if err != nil {
 }
 ```
 
-```{seealso}
+```{admonition} See more
+:class: tip
 [DB.Begin](https://pkg.go.dev/github.com/canonical/sqlair#DB.Begin),
 [sqlair.TXOptions](https://pkg.go.dev/github.com/canonical/sqlair#TXOptions)
 ```
@@ -48,7 +50,8 @@ if err != nil {
 }
 ```
 
-```{seealso}
+```{admonition} See more
+:class: tip
 [TX.Commit](https://pkg.go.dev/github.com/canonical/sqlair#TX.Commit),
 [TX.Rollback](https://pkg.go.dev/github.com/canonical/sqlair#TX.Rollback),
 [sqlair.ErrTXDone](https://pkg.go.dev/github.com/canonical/sqlair#ErrTXDone)

--- a/docs/howto/tx.md
+++ b/docs/howto/tx.md
@@ -2,7 +2,9 @@
 # Manage SQLair transactions
 SQLair transactions are created on a `sqlair.DB`.
 
-> See more: {ref}`db`.
+```{seealso}
+{ref}`db`.
+```
 ## Begin a SQLair transaction
 
 To begin a transaction, on your database, call `DB.Begin`, passing a context and
@@ -24,8 +26,10 @@ if err != nil {
 }
 ```
 
-> See more: [DB.Begin](https://pkg.go.dev/github.com/canonical/sqlair#DB.Begin),
+```{seealso}
+[DB.Begin](https://pkg.go.dev/github.com/canonical/sqlair#DB.Begin),
 [sqlair.TXOptions](https://pkg.go.dev/github.com/canonical/sqlair#TXOptions)
+```
 
 ## Query a SQLair transaction
 See {ref}`query`.
@@ -44,7 +48,8 @@ if err != nil {
 }
 ```
 
-> See more:
+```{seealso}
 [TX.Commit](https://pkg.go.dev/github.com/canonical/sqlair#TX.Commit),
 [TX.Rollback](https://pkg.go.dev/github.com/canonical/sqlair#TX.Rollback),
 [sqlair.ErrTXDone](https://pkg.go.dev/github.com/canonical/sqlair#ErrTXDone)
+```

--- a/docs/index.md
+++ b/docs/index.md
@@ -68,6 +68,7 @@ guide if you would like to get involved!
 
 - [SQLair GitHub page](https://github.com/canonical/sqlair)
 - [SQLair contributing guide](https://github.com/canonical/sqlair/blob/main/CONTRIBUTING.md)
+- [Ubuntu code of conduct](https://ubuntu.com/community/ethos/code-of-conduct)
 
 The SQLair project is currently under the care of the Juju team at Canonical. If
 you have any questions or would just like to say hi you can find us on the

--- a/docs/reference/types.md
+++ b/docs/reference/types.md
@@ -55,7 +55,8 @@ type Address struct {
 }
 ```
 
-```{seealso}
+```{admonition} See more
+:class: tip
 {ref}`insert-statements`
 ```
 ### Maps

--- a/docs/reference/types.md
+++ b/docs/reference/types.md
@@ -55,8 +55,9 @@ type Address struct {
 }
 ```
 
-> See more: {ref}`insert-statements`
-
+```{seealso}
+{ref}`insert-statements`
+```
 ### Maps
 
 Named maps can be used with SQLair and must have a key with a base type of

--- a/docs/tutorial/tutorial.md
+++ b/docs/tutorial/tutorial.md
@@ -157,7 +157,8 @@ type Order struct {
 }
 ```
 
-```{seealso}
+```{admonition} See more
+:class: tip
 {ref}`types`, [Go | Struct Tags](https://go.dev/wiki/Well-known-struct-tags)
 ```
 
@@ -201,7 +202,8 @@ func populateDB(db *sqlair.DB) error {
 }
 ```
 
-```{seealso}
+```{admonition} See more
+:class: tip
 {ref}`input-expression-syntax`, {ref}`query`
 ```
 
@@ -440,7 +442,8 @@ Customer record of Joe: main.Customer{ID:1, Name:"Joe", Address:"15 Westmeade Ro
 Finished without errors!
 ```
 
-```{seealso}
+```{admonition} See more
+:class: tip
 {ref}`output-expression-syntax`, {ref}`input-expression-syntax`, [`Query.Get`](https://pkg.go.dev/github.com/canonical/sqlair#Query.Get)
 ```
 
@@ -489,7 +492,8 @@ Finished without errors!
 ```
 You have all the orders. Congratulations! You have learnt the basics of SQLair!
 
-```{seealso}
+```{admonition} See more
+:class: tip
 [`Query.GetAll`](https://pkg.go.dev/github.com/canonical/sqlair#Query.GetAll)
 ```
 
@@ -503,7 +507,8 @@ rm -r tutorial
 ## Next steps
 This tutorial has introduced you to the basics, but there is a lot more to
 explore!
-```{seealso}
+```{admonition} See more
+:class: tip
 {ref}`howto`, {ref}`reference`,
 [pkg.go.dev](https://pkg.go.dev/github.com/canonical/sqlair)
 ```

--- a/docs/tutorial/tutorial.md
+++ b/docs/tutorial/tutorial.md
@@ -157,7 +157,9 @@ type Order struct {
 }
 ```
 
-> See more {ref}`types`, [Go | Struct Tags](https://go.dev/wiki/Well-known-struct-tags)
+```{seealso}
+{ref}`types`, [Go | Struct Tags](https://go.dev/wiki/Well-known-struct-tags)
+```
 
 ## Put your struct in the database
 
@@ -199,7 +201,9 @@ func populateDB(db *sqlair.DB) error {
 }
 ```
 
-> See more {ref}`input-expression-syntax`, {ref}`query`
+```{seealso}
+{ref}`input-expression-syntax`, {ref}`query`
+```
 
 To insert the data into the database, create a `Query` on the database using the
 [`DB.Query`](https://pkg.go.dev/github.com/canonical/sqlair#Query) method and
@@ -436,7 +440,9 @@ Customer record of Joe: main.Customer{ID:1, Name:"Joe", Address:"15 Westmeade Ro
 Finished without errors!
 ```
 
-> See more: {ref}`output-expression-syntax`, {ref}`input-expression-syntax`, [`Query.Get`](https://pkg.go.dev/github.com/canonical/sqlair#Query.Get)
+```{seealso}
+{ref}`output-expression-syntax`, {ref}`input-expression-syntax`, [`Query.Get`](https://pkg.go.dev/github.com/canonical/sqlair#Query.Get)
+```
 
 ### Get all the orders
 
@@ -483,7 +489,9 @@ Finished without errors!
 ```
 You have all the orders. Congratulations! You have learnt the basics of SQLair!
 
-> See more: [`Query.GetAll`](https://pkg.go.dev/github.com/canonical/sqlair#Query.GetAll)
+```{seealso}
+[`Query.GetAll`](https://pkg.go.dev/github.com/canonical/sqlair#Query.GetAll)
+```
 
 ## Tear things down
 Getting rid of the tutorial is as simple as deleting the directory! No further
@@ -495,5 +503,7 @@ rm -r tutorial
 ## Next steps
 This tutorial has introduced you to the basics, but there is a lot more to
 explore!
-> See more {ref}`howto`, {ref}`reference`,
+```{seealso}
+{ref}`howto`, {ref}`reference`,
 [pkg.go.dev](https://pkg.go.dev/github.com/canonical/sqlair)
+```

--- a/docs/tutorial/tutorial.md
+++ b/docs/tutorial/tutorial.md
@@ -498,8 +498,8 @@ You have all the orders. Congratulations! You have learnt the basics of SQLair!
 ```
 
 ## Tear things down
-Getting rid of the tutorial is as simple as deleting the directory! No further
-steps required.
+To restore your machine to the state it had before you started this tutorial,
+simply delete the directory. No further steps required.
 ```bash
 cd ..
 rm -r tutorial


### PR DESCRIPTION
Add a how-to guide on how to get the results out of SQL functions.
Use the `seealso` directive instead of `> See more:` .
Add content to the how-to index page.
Link to the Ubuntu code of conduct on the main page.

## QA
View the new docs by checking out this branch and doing:
```
cd docs
make run
```