### PR TITLE
fix: closing db on finalizer and memory leak

### DIFF
--- a/cache.go
+++ b/cache.go
@@ -103,8 +103,8 @@ func (sc *statementCache) newDB(sqldb *sql.DB) *DB {
 }
 
 // lookupStmt checks if a Statement has been prepared on the db driver with the
-// given primedSQL. If it has, the driver-prepared sql.Stmt is returned.
-func (sc *statementCache) lookupStmt(db *DB, s *Statement, primedSQL string) (stmt *sql.Stmt, ok bool) {
+// given primedSQL. If it has, the driverStmt is returned.
+func (sc *statementCache) lookupStmt(db *DB, s *Statement, primedSQL string) (dStmt *driverStmt, ok bool) {
 	// The Statement cache ID is only removed from stmtDBCache when the
 	// finalizer is run. The Statement's cache ID must be in the stmtDBCache
 	// since we hold a reference to the Statement. It is therefore safe to
@@ -116,27 +116,32 @@ func (sc *statementCache) lookupStmt(db *DB, s *Statement, primedSQL string) (st
 	if !ok || ds.sql != primedSQL {
 		return nil, false
 	}
-	return ds.stmt, ok
+	return ds, ok
 }
 
 // driverPrepareStatement prepares a statement on the database and then stores
 // the prepared *sql.Stmt in the cache.
-func (sc *statementCache) driverPrepareStmt(ctx context.Context, db *DB, s *Statement, primedSQL string) (*sql.Stmt, error) {
+func (sc *statementCache) driverPrepareStmt(ctx context.Context, db *DB, s *Statement, primedSQL string) (*driverStmt, error) {
 	sqlstmt, err := db.sqldb.PrepareContext(ctx, primedSQL)
 	if err != nil {
 		return nil, err
 	}
+
 	sc.mutex.Lock()
 	defer sc.mutex.Unlock()
-	// If there is already a statement in the cache, replace it with ours.
-	if driverStmt, ok := sc.stmtDBCache[s.cacheID][db.cacheID]; ok {
-		// Set a finalizer on the statement we evict from the cache to close it
-		// once current users have finished with it.
-		runtime.SetFinalizer(driverStmt.stmt, (*sql.Stmt).Close)
+
+	// If there is already a statement in the cache, set a finalizer on it to
+	// close it once concurrent users have finished with it and replace it with
+	// ours.
+	if ds, ok := sc.stmtDBCache[s.cacheID][db.cacheID]; ok {
+		runtime.SetFinalizer(ds, func(ds *driverStmt) {
+			ds.stmt.Close()
+		})
 	}
-	sc.stmtDBCache[s.cacheID][db.cacheID] = &driverStmt{sql: primedSQL, stmt: sqlstmt}
+	ds := &driverStmt{sql: primedSQL, stmt: sqlstmt}
+	sc.stmtDBCache[s.cacheID][db.cacheID] = ds
 	sc.dbStmtCache[db.cacheID][s.cacheID] = true
-	return sqlstmt, nil
+	return ds, nil
 }
 
 // removeAndCloseStmtFunc removes and closes all sql.Stmt objects associated

--- a/cache.go
+++ b/cache.go
@@ -120,7 +120,7 @@ func (sc *statementCache) lookupStmt(db *DB, s *Statement, primedSQL string) (dS
 }
 
 // driverPrepareStatement prepares a statement on the database and then stores
-// the prepared *sql.Stmt in the cache.
+// the prepared driverStmt in the cache.
 func (sc *statementCache) driverPrepareStmt(ctx context.Context, db *DB, s *Statement, primedSQL string) (*driverStmt, error) {
 	sqlstmt, err := db.sqldb.PrepareContext(ctx, primedSQL)
 	if err != nil {

--- a/cache.go
+++ b/cache.go
@@ -153,8 +153,7 @@ func (sc *statementCache) removeAndCloseStmtFunc(s *Statement) {
 }
 
 // removeAndCloseDBFunc closes and removes from the cache all sql.Stmt objects
-// prepared on the database, removes the database from then cache, then closes
-// the sql.DB.
+// prepared on the database, removes the database from then cache.
 func (sc *statementCache) removeAndCloseDBFunc(db *DB) {
 	sc.mutex.Lock()
 	defer sc.mutex.Unlock()
@@ -165,5 +164,4 @@ func (sc *statementCache) removeAndCloseDBFunc(db *DB) {
 		delete(dbCache, db.cacheID)
 	}
 	delete(sc.dbStmtCache, db.cacheID)
-	db.sqldb.Close()
 }


### PR DESCRIPTION
**fix: remove close DB on sqlair.DB going out of memory**

As part of the cache work, a finalizer was put on the sqlair.DB that
would close the underlying sql.DB when the sqlair.DB went out of memory.

This was a misfeature, if thread seperatly held the sql.DB or the same
thread tried to use it later on it would be inexplicably closed.

Remove the db.Close on the sqlair.DB finalizer.

**fix: memory leak**

When statements are eviceted from the cache, they are not always closed.
This change fixes that.

Some sqlair.Statements can have multiple sql queries generated from them
depending on the arguements (e.g. bulk inserts, or queries with slice
arguements). SQLair maintains a sqlair.Statement to driverStmt cache for
DB queries. When one of these queries is executed, and it is looked up
in the cache, if a driver statement is found, but has different SQL, it
will be removed from the cache and replaced with the newly generated SQL
from the version of the query with different arguments.

Before this change, a finalizer was set on the *sql.Stmt to close it
when it dropped from memory. The *sql.Stmt couldn't be closed straight
away because there is a possibility someone else is using it
concurrently, therefor the finalizer was set to clear it up after it had
been finished with.

This didn't work as intended. In fact, the sql.DB holds a reference to
this *sql.Stmt so the finalizer will only ever be run when this is
closed. The test designed to check that this statement was closed did
not pick it up because before the check, the DB was closed. In a recent
change, the DB stopped being closed at this point, and this caused the
test to start failing.

After this change, instead of putting a finalizer on the database/sql
controlled *sql.Stmt, we put a finalizer on the SQLair controlled
driverStmt. This means we can audit usages far more effectively and are
not dependent on third party code.

If the finalizer is run before all concurrent users of the *sql.Stmt
have finished with it, sql.Rows may return an error saying query closed.
This happens when the underlying statement is closed. To ensure that the
finalizer is only run when all concurrent users have finished with it,
the Iterator will now hold a reference to this driverStmt. That way,
it will only be once the Iterator goes out of memory that the driverStmt
is closed.