### PR TITLE
fix: panic on no columns

### DIFF
--- a/package_test.go
+++ b/package_test.go
@@ -416,7 +416,7 @@ func (s *PackageSuite) TestIterGetErrors(c *C) {
 		types:   []any{Person{}},
 		inputs:  []any{},
 		outputs: []any{&Person{}},
-		err:     `cannot get result: query uses "&Person" outside of result context`,
+		err:     `cannot get result: column\(s\) for output "&Person" not found in query results`,
 	}}
 
 	db, tables := s.personAndAddressDB(c)
@@ -484,6 +484,16 @@ func (s *PackageSuite) TestValidGet(c *C) {
 		inputs:   []any{},
 		outputs:  []any{sqlair.M{}},
 		expected: []any{sqlair.M{"avg": float64(2625), "name": "Fred"}},
+	}, {
+		summary: "multiple semicolons at end",
+		query: `UPDATE person
+SET id = id + 1
+WHERE name = $Person.name
+RETURNING person.id AS &Person.*;;`,
+		types:    []any{Person{}},
+		inputs:   []any{Person{Name: "Fred"}},
+		outputs:  []any{&Person{}},
+		expected: []any{&Person{ID: 31}},
 	}}
 
 	db, tables := s.personAndAddressDB(c)


### PR DESCRIPTION
SQLair would panic when it expected to find at least one column in the results and found none. It would create a slice using the length of the found columns and then try and access it with the expected index of the column.

An error is now thrown in this case instead or panic, this error is also tested.

Part of the reason this panic occured is becuase the ScanArgs function is undertested. It had no unit tests, only the black box tests in package_test.go. Unit tests for errors have been added in expr_test, though it could still do with more explict happy path tests.

This fixes #176.