### PR TITLE
fix: potential memory aliasing issue

### DIFF
--- a/internal/expr/bindtypes.go
+++ b/internal/expr/bindtypes.go
@@ -209,7 +209,8 @@ func (e *columnsInsertExpr) bindTypes(teb *typedExprBuilder) (err error) {
 				if remainingMap != nil {
 					return fmt.Errorf("cannot use more than one map with asterisk")
 				}
-				remainingMap = &source.typeName
+				remainingMapTypeName := source.typeName
+				remainingMap = &remainingMapTypeName
 				continue
 			}
 			inps, tags, err := teb.AllStructInputs(source.typeName)


### PR DESCRIPTION
Running gosec on the SQLair codebase uncovered a potential issue with the memory location of a loop variable being aliased mid loop. This can be an issue in go versions <1.22 as the memory location of the loop variable is reused in subsequent iterations, meaning the value may change unexpectedly.

Original issue:
```
$ gosec ./...
[/home/aflynn/Canonical/SQLair/sqlair/internal/expr/bindtypes.go:212] - G601 (CWE-118): Implicit memory aliasing in for loop. (Confidence: MEDIUM, Severity: MEDIUM)
    211: 				}
  > 212: 				remainingMap = &source.typeName
    213: 				continue

```