### PR TITLE
build: update to go version 1.24

### DIFF
--- a/.github/workflows/go-test.yml
+++ b/.github/workflows/go-test.yml
@@ -4,7 +4,7 @@ jobs:
   build:
     strategy:
       matrix:
-        go-version: [1.18.x, 1.x]
+        go-version: [1.24.x, 1.x]
     runs-on: ubuntu-latest
     steps:
       - name: Checkout code

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -63,8 +63,8 @@ passed to SQLair. For more info, see
 
 ### Environment setup
 
-SQLair is written in Go version 1.18. Make sure you have this, or a higher
-version installed. The choice to use 1.18 was made to maximize compatibility.
+SQLair is written in Go version 1.24. Make sure you have this, or a higher
+version installed.
 
 ### Building and testing
 

--- a/docs/tutorial/tutorial.md
+++ b/docs/tutorial/tutorial.md
@@ -9,7 +9,7 @@ Let's get started!
 
 
 ## Set things up
-For this tutorial you will need Go version 1.18. To use SQLair you will need a
+For this tutorial you will need Go version 1.24. To use SQLair you will need a
 Go project that sets up a database. 
 
 To create the project run:

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/canonical/sqlair
 
-go 1.18
+go 1.24
 
 require (
 	github.com/mattn/go-sqlite3 v1.14.16


### PR DESCRIPTION
Update to the latest supported go version, 1.24. Go 1.18 is unmaintained and thus a security risk.

According to pkg.go.dev, SQLair is imported by the open source projects github.com/juju/juju and github.com/canonical/notary. Both of these are on go version 1.24 so this should not cause them any issues when updating to the latest version of SQLair.

Updating to the latest Go version also fixes the possible security issue addressed in the closed PR #180.

All tests pass with: 
```
go test ./...
```